### PR TITLE
Fix/sdio art crash

### DIFF
--- a/FLOWS.md
+++ b/FLOWS.md
@@ -1,0 +1,353 @@
+# SonosESP: Art + Polling Flow Reference
+
+## What This Document Is
+
+A precise reference for two critical user flows and all the subsystems they touch.
+Created to understand why **CMD_NEXT works** but **CMD_PLAY_QUEUE_ITEM gets stuck** with art and DMA issues.
+
+---
+
+## Current State (as of 2026-03-15)
+
+### What Works
+- CMD_NEXT: art loads reliably
+- Art LRU cache: cache hits work at any DMA level (no TCP)
+- Lyrics: fragmentation guard (`largest_free_block`) correctly prevents TLS during art downloads
+
+### What Is Broken
+- **DMA depletes to ~19-26KB and gets stuck** — art enters DMA wait loop and can't exit
+- **Root cause (CONFIRMED)**: Every TCP connection (SOAP + art download) uses FIN-close → TIME_WAIT PCB → each PCB holds **~6-8.7KB DMA** for 120 seconds
+- **Math**: boot DMA ~115KB. 16 max sockets (CONFIG_LWIP_MAX_SOCKETS=16). At steady state: 16 PCBs × ~6KB = 96KB consumed → only 19KB free
+- **SO_LINGER fix FAILED**: `lwip_setsockopt(fd, SO_LINGER)` returns -1 — not compiled into the pioarduino pre-built framework. Silently does nothing.
+- **Result**: art stuck in DMA wait loop at outer=25+ (75+ seconds) waiting for DMA to recover to 40KB threshold it can never reach
+- **Lyrics instability**: `largest_free_block` guard aborts lyrics when art is downloading (correct) BUT when DMA is permanently depleted, lyrics also never runs
+
+---
+
+## Architecture Overview
+
+### Tasks
+
+| Task Name | Priority | Core | Stack | Purpose |
+|-----------|----------|------|-------|---------|
+| `mainAppTask` | 1 | 1 | 8KB (SRAM) | LVGL render, UI updates, watchdog |
+| `loopTask` | 1 | 1 | 8KB (SRAM) | Idle (just vTaskDelay) |
+| `albumArtTask` | 0 | 0 | 20KB (PSRAM) | Download + decode art |
+| `SonosNet` | 2 | 0 | 6KB | Process command queue (Next/Pause/Seek/etc.) |
+| `SonosPoll` | 3 | 0 | 6KB | Polling GetPositionInfo every 300ms |
+| `lyricsTask` | 1 | 0 | 8KB | Fetch HTTPS lyrics from lrclib.net |
+| `clockBgTask` | 1 | 0 | 8KB | Clock screensaver background + weather |
+
+### Mutexes
+
+| Mutex | Taken By | Purpose |
+|-------|----------|---------|
+| `network_mutex` | art task, lyrics task, all sendSOAP calls | Serialize ALL WiFi TCP operations |
+| `deviceMutex` | SonosNet, SonosPoll | Protect SonosDevice struct |
+| `art_mutex` | art task, main UI, requestAlbumArt() | Protect pending_art_url / art_ready / last_art_url |
+
+### Key Global Variables (`ui_globals.cpp` / `ui_common.h`)
+
+```
+volatile bool          art_download_in_progress  // MAIN GATE: suppresses pollingTask
+volatile unsigned long last_art_download_end_ms   // Set after ALL art/clock downloads
+volatile unsigned long last_transient_500_ms       // Set when Sonos returns HTTP 500
+volatile unsigned long last_track_change_ms        // Set in requestAlbumArt() (disabled: SDIO_TRACK_CHANGE_SETTLE_MS=0)
+volatile unsigned long last_network_end_ms         // Set after every network op
+volatile unsigned long last_https_end_ms           // Set after every HTTPS op
+volatile unsigned long last_queue_fetch_time       // Set after updateQueue() completes
+
+String  pending_art_url    // URL that art task should download next
+String  last_art_url       // URL of the art currently displayed
+bool    art_ready          // true when scaled art is in art_buffer and ready to display
+bool    art_show_placeholder // true when placeholder should show (no art, or error)
+bool    art_abort_download   // Signal art task to abort mid-download (track changed)
+bool    art_suppress_source_change // Used by CMD_PLAY_QUEUE_ITEM settle window
+```
+
+---
+
+## Flow 1: CMD_NEXT (Press "Next" Button)
+
+### Step-by-Step
+
+```
+[mainAppTask]  ev_next() callback fires
+               → sonos.next()
+               → 400ms debounce check
+               → xQueueSend(commandQueue, CMD_NEXT)
+
+[SonosNet]     dequeue CMD_NEXT
+               art_download_in_progress = TRUE   ← suppress polling NOW
+               sendSOAP("AVTransport", "Next")   ← acquires network_mutex
+                  last_network_end_ms = millis()
+               vTaskDelay(200ms)                  ← allow Sonos device to settle
+               updateTrackInfo()                  ← GetPositionInfo SOAP
+                  → onSonosUpdate() callback fires
+                  → pending_art_url = new_track_art_url
+                  last_network_end_ms = millis()
+
+[mainAppTask]  updateUI() → requestAlbumArt(pending_art_url)
+               → pending_art_url stored in art_mutex block
+               → last_track_change_ms = millis()
+
+[albumArtTask] loop: pending_art_url != last_art_url → download path
+               → art_download_in_progress = FALSE  ← allow polling during sdioPreWait
+               → sdioPreWait() (queue-poll cooldown only, ~0-3000ms)
+               → art_download_in_progress = TRUE   ← DMA wait starts
+               → DMA wait loop (up to 165s)
+               → acquire network_mutex
+               → HTTP download
+               → decode + scale
+               → http.end() + drain
+               → last_art_download_end_ms = millis()
+               → release network_mutex
+               → art_ready = true (main UI renders on next cycle)
+```
+
+### TCP Connections Created (TIME_WAIT PCBs)
+
+| SOAP/Request | TCP teardown | TIME_WAIT? |
+|---|---|---|
+| Next SOAP | FIN-close (SO_LINGER fails silently) | YES, ~6KB DMA, 120s |
+| GetPositionInfo SOAP | FIN-close | YES, ~6KB DMA, 120s |
+| Art HTTP download | FIN-close (art stays open during decode now) | Passive close → NO (server does TIME_WAIT) |
+
+**CMD_NEXT creates 2 new TIME_WAIT PCBs ≈ 12KB DMA consumed.**
+
+---
+
+## Flow 2: CMD_PLAY_QUEUE_ITEM (Tap Queue Track)
+
+### Step-by-Step
+
+```
+[mainAppTask]  ev_queue_item(trackNum) callback fires
+               → sonos.playQueueItem(trackNum)
+               → xQueueSend(commandQueue, CMD_PLAY_QUEUE_ITEM + trackNum)
+               → lv_screen_load(scr_main)
+
+[SonosNet]     dequeue CMD_PLAY_QUEUE_ITEM
+               art_download_in_progress = TRUE   ← suppress polling NOW
+               sendSOAP("AVTransport", "Seek", "<Target>N</Target>")  ← TIME_WAIT PCB #1
+                  last_network_end_ms = millis()
+               vTaskDelay(100ms)
+               sendSOAP("AVTransport", "Play")   ← TIME_WAIT PCB #2
+                  last_network_end_ms = millis()
+               deviceMutex: dev->isPlaying = true
+               vTaskDelay(200ms)
+               updateTrackInfo()                 ← GetPositionInfo SOAP, TIME_WAIT PCB #3
+                  → onSonosUpdate() → pending_art_url = new_track_art_url
+                  last_network_end_ms = millis()
+
+[mainAppTask]  updateUI() → requestAlbumArt(pending_art_url)
+               → same as CMD_NEXT from here
+
+[albumArtTask] same as CMD_NEXT from here
+```
+
+### TCP Connections Created (TIME_WAIT PCBs)
+
+| SOAP/Request | TCP teardown | TIME_WAIT? |
+|---|---|---|
+| Seek SOAP | FIN-close | YES, ~6KB DMA, 120s |
+| Play SOAP | FIN-close | YES, ~6KB DMA, 120s |
+| GetPositionInfo SOAP | FIN-close | YES, ~6KB DMA, 120s |
+| Art HTTP download | Passive close (new) | NO (server's TIME_WAIT) |
+
+**CMD_PLAY_QUEUE_ITEM creates 3 new TIME_WAIT PCBs ≈ 18KB DMA consumed.**
+
+If DMA was already at 20KB before CMD_PLAY_QUEUE_ITEM fires, adding 18KB = -DMA. This is the stuck state.
+
+---
+
+## Why CMD_NEXT Works But CMD_PLAY_QUEUE_ITEM Gets Stuck
+
+**CMD_NEXT typically fires when DMA is still healthy** (user presses Next at the start of a session, DMA ~90KB). 2 new PCBs = 12KB consumed, leaving 78KB → well above ART_MIN_FREE_DMA=40KB → art downloads fine.
+
+**CMD_PLAY_QUEUE_ITEM typically fires AFTER the user has been using the app** for a while:
+- Many SOAPs have accumulated: 16 TIME_WAIT PCBs × 6KB = 96KB consumed
+- DMA is already at 19-24KB before CMD fires
+- 3 more SOAPs from CMD = +18KB needed but DMA is already low
+- Art enters DMA wait loop at 15-19KB
+- DMA stuck at ~24KB (16 PCBs permanently cycling through socket pool via tcp_kill_timewait)
+- **ART_MIN_FREE_DMA=40KB is unreachable at steady state when all 16 sockets are TIME_WAIT**
+
+**The steady-state DMA floor = boot_DMA - (max_sockets × avg_pcb_dma_cost)**
+= 115KB - 16 × ~6KB = **~19KB**
+
+This is a structural problem. The system can never maintain 40KB free DMA at steady state because the SOAP polling alone fills all 16 socket slots with Time_Wait PCBs.
+
+---
+
+## Polling Task Guards (SonosPoll Task)
+
+All guards are checked every loop cycle before firing any SOAP:
+
+```
+pollingTaskFunction() loop:
+│
+├─ [EARLY EXIT GUARD] ──────────────────────────────────────────────────────
+│   if (art_download_in_progress) → skip all SOAPs, sleep 300ms, continue
+│   if (last_art_download_end_ms < 1000ms ago) → skip, sleep 300ms, continue
+│   if (last_track_change_ms < SDIO_TRACK_CHANGE_SETTLE_MS ago) → skip, sleep 1000ms (disabled: =0)
+│   if (last_transient_500_ms < 3000ms ago) → skip, sleep 1000ms
+│
+├─ updateTrackInfo() ── ALWAYS (GetPositionInfo SOAP) ─────────────────────
+│   → onSonosUpdate() may set pending_art_url
+│
+├─ [POST-SOAP-1 GUARD] ─────────────────────────────────────────────────────
+│   if (pending_art_url != last_art_url) → tick++, sleep 300ms, continue
+│   if (last_transient_500_ms < 3000ms ago) → tick++, sleep 300ms, continue
+│
+├─ updatePlaybackState() ── MANDATORY (GetTransportInfo SOAP) ─────────────
+│
+├─ [MID-CYCLE GUARD] ───────────────────────────────────────────────────────
+│   if (art_download_in_progress || !pending_art_url.isEmpty()) → tick++, continue
+│
+├─ OPTIONAL SOAPs (all gated by mid-cycle guard passing):
+│   ├─ updateVolume() every 5 cycles
+│   ├─ updateTransportSettings() every 10 cycles
+│   ├─ updateMediaInfo() every 50 cycles (radio only)
+│   └─ updateQueue() every 100 cycles (non-radio only)
+│       └─ if (last_art_download_end_ms < 3000ms) → SKIP
+│       └─ after success: vTaskDelay(1000ms) drain
+│
+└─ vTaskDelay(300ms) ─── base interval
+```
+
+---
+
+## Art Task Main Loop (albumArtTask)
+
+```
+albumArtTask() infinite loop:
+│
+├─ Check WiFi connected → if not: vTaskDelay(1000ms), continue
+│
+├─ [NO-URL PATH] ───────────────────────────────────────────────────────────
+│   Read pending_art_url under art_mutex
+│   if url == "":
+│       if millis() - last_art_download_end_ms >= 1000ms (or ==0):
+│           art_download_in_progress = FALSE  ← ONLY place flag is cleared
+│       vTaskDelay(100ms); continue
+│
+├─ [URL PRESENT PATH] ──────────────────────────────────────────────────────
+│   Check LRU cache → if hit: display cached art, continue
+│   Check art_abort_download → if set: clear, continue
+│   art_download_in_progress = FALSE  ← allow polling during sdioPreWait
+│   sdioPreWait("ART", SDIO_WAIT_QUEUE_POLL, &abort_flag, &shutdown_flag)
+│   → waits up to 3000ms if last_queue_fetch_time < 3s ago
+│   → returns false if abort/shutdown fired → continue
+│
+├─ [DMA WAIT LOOP] ─────────────────────────────────────────────────────────
+│   art_download_in_progress = TRUE  ← suppress polling NOW
+│   for outer in 0..50:  (max 165s total)
+│       for inner in 0..30:  (3s per outer)
+│           fdma = heap_caps_get_free_size(DMA)
+│           if fdma >= ART_MIN_FREE_DMA (40KB): dma_ok=true; break
+│           vTaskDelay(100ms)
+│       if !dma_ok:
+│           art_download_in_progress = FALSE; vTaskDelay(300ms)  ← SDIO warm
+│           art_download_in_progress = TRUE
+│   if !dma_ok after 50 loops:
+│       if fdma < 35000: Serial.printf("DMA critically low — skipping"); continue
+│       else: proceed cautiously (DMA 35-40KB range)
+│
+├─ [ACQUIRE MUTEX + DOWNLOAD] ──────────────────────────────────────────────
+│   xSemaphoreTake(network_mutex, 10s)
+│   check abort → if set: release mutex, continue
+│   inside-mutex cooldown rechecks (short TCP drain times, NOT full sdioPreWait times)
+│   artPreConnectHTTP() → raw socket → SO_RCVBUF=8192 → connect → wrap in WiFiClient
+│   http.begin(preClient, url)
+│   http.GET()
+│   if code==200: chunked read into jpgBuf (PSRAM), 5ms between chunks
+│   [SUCCESS PATH]:
+│       artLogMem("post-close")  ← TCP still open (passive close design)
+│       decode JPEG/PNG → 420×420 scale → extract dominant color → update LVGL
+│       http.end()  ← passive close: server FIN already arrived during decode
+│       vTaskDelay(SDIO_TCP_CLOSE_MS = 200ms)
+│       last_network_end_ms = last_art_download_end_ms = millis()
+│       xSemaphoreGive(network_mutex)
+│   [FAILURE PATH]:
+│       http.end() + cleanup
+│       last_network_end_ms = last_art_download_end_ms = millis()
+│       xSemaphoreGive(network_mutex)
+│
+└─ vTaskDelay(100ms) ─── check interval
+```
+
+---
+
+## The DMA Problem: Root Cause Analysis
+
+### Confirmed Facts
+
+1. Each TCP connection (SOAP or HTTP) creates a TIME_WAIT PCB holding **~6-8.7KB DMA** for 120 seconds
+2. `SO_LINGER{1,0}` to force RST-close: **not compiled into pioarduino pre-built framework** — `lwip_setsockopt` returns -1 silently
+3. `CONFIG_LWIP_TCP_MSL=60000ms` (60s), so TIME_WAIT = 2×60s = 120s — cannot be changed (pre-built)
+4. `CONFIG_LWIP_MAX_SOCKETS=16` — at any time, max 16 PCBs exist
+5. `tcp_kill_timewait()` auto-recycles oldest TIME_WAIT slot when pool is full
+
+### Steady-State DMA Consumption
+
+At polling rate 300ms per cycle, 2 SOAPs per cycle:
+- 16 socket slots filled with TIME_WAIT within ~2.4 seconds of startup
+- Each PCB holds ~6KB DMA (lwIP TCP receive buffer + PCB struct)
+- **Steady state: 16 × 6KB = 96KB permanently consumed**
+- **Boot DMA: ~115KB**
+- **Available for downloads: 115 - 96 = ~19KB**
+
+### Why ART_MIN_FREE_DMA=40KB Is Unreachable
+
+The threshold was set at 40KB = 17KB TCP pre-connect + 23KB dl-start headroom. Correct calculation, but unreachable at steady state because the 16 TIME_WAIT PCBs are always consuming the headroom.
+
+### What Needs to Change
+
+**Option A: Reduce per-PCB DMA cost**
+- Reduce `CONFIG_TCP_WND` (TCP receive window) → smaller PCB → less DMA per PCB
+- Cannot change (pre-built framework)
+
+**Option B: Force RST-close on SOAP connections**
+- `SO_LINGER` not compiled in
+- Alternative: `lwip_abort()` raw API or `shutdown(SHUT_RDWR)` then `close()`
+- Risky: may not work reliably without SO_LINGER support
+
+**Option C: HTTP keep-alive for SOAPs**
+- Sonos device does NOT support HTTP/1.1 keep-alive
+- Already confirmed: "Fresh HTTPClient per request — Sonos's embedded HTTP server does not support HTTP/1.1 keep-alive"
+
+**Option D: Lower ART_MIN_FREE_DMA to 20KB**
+- Risk: TCP pre-connect (17KB) + dl-start server burst (~14KB) = 31KB needed minimum
+- At 19KB free: TCP pre-connect would leave 2KB → server burst fails → pkt_rxbuff overflow → crash
+- Not viable
+
+**Option E: Brief wait after http.getString() before http.end() in sendSOAP**
+- If Sonos server sends FIN immediately after response body, a 1-5ms wait lets FIN arrive
+- http.end() called in CLOSE_WAIT state → passive close → no TIME_WAIT on P4 side
+- Server enters TIME_WAIT (server's RAM, not our DMA)
+- **Most promising fix. Needs testing.**
+
+**Option F: Reboot after extended DMA wait**
+- If DMA stays below threshold for >30s, soft-reboot
+- Extreme but guaranteed to restore DMA to boot level
+- Bad UX but prevents permanent art failure
+
+---
+
+## Summary: What's Happening When Queue Play Gets Stuck
+
+1. User has been using the app for ~2 minutes
+2. SOAPs have depleted DMA to ~19-26KB (steady state)
+3. User taps queue item
+4. CMD_PLAY_QUEUE_ITEM fires 3 SOAPs: Seek + Play + GetPositionInfo
+5. Each SOAP gets its tcp_kill_timewait() slot — DMA stays at ~19KB (recycled)
+6. Art task enters DMA wait loop: 19KB < 40KB threshold
+7. DMA wait loop: 3s inner wait + 300ms warm window, repeat up to 50×
+8. During warm window: 2 SOAPs fire (warm cycle), which GET killed by tcp_kill_timewait() = DMA stays flat
+9. DMA NEVER reaches 40KB — loop runs for the full 165 seconds
+10. After 165s: fdma=24KB. NEW HARD-SKIP at 35KB fires → skip download → continue loop
+11. Next iteration: DMA still 24KB → DMA wait loop again immediately
+12. Art NEVER loads
+
+**This is why it appears "stuck" — it IS stuck, legitimately, waiting for DMA that can never recover.**

--- a/include/config.h
+++ b/include/config.h
@@ -80,7 +80,14 @@
 // =============================================================================
 #define SONOS_MAX_DEVICES       32      // Maximum discoverable devices (keep in sync with MAX_SONOS_DEVICES)
 #define SONOS_QUEUE_SIZE_MAX    500     // Maximum queue items to fetch
-#define SONOS_QUEUE_BATCH_SIZE  50      // Items per queue fetch request
+#define SONOS_QUEUE_BATCH_SIZE  10      // Items per queue fetch request (was 50).
+                                        // 50-item response (~20KB, 14 TCP segs) forced WiFi driver to allocate
+                                        // all 32 dynamic RX buffers (~51KB) in one event → permanent 71KB DMA
+                                        // floor drop after first periodic queue poll → Song 2 crash-zone.
+                                        // 10-item response (~4KB, 3 TCP segs) allocates only 3 WiFi buffers.
+                                        // Art download (16KB burst) adds ~11 more buffers. Pool stabilises at
+                                        // ~14 total (22KB) instead of 32 (51KB). DMA floor = ~85KB vs ~35KB.
+                                        // 10 items is sufficient for the "Next Up" queue display.
 #define SONOS_CMD_QUEUE_SIZE    10      // Command queue depth
 #define SONOS_UI_QUEUE_SIZE     20      // UI update queue depth
 
@@ -225,6 +232,59 @@
 // QUEUE / PLAYLIST
 // =============================================================================
 #define QUEUE_ADD_AT_END        4294967295  // Add to end of queue constant
+
+// =============================================================================
+// SDIO CRASH DEFENCE (ESP32-P4 + ESP32-C6 SDIO architecture)
+// =============================================================================
+// The C6 WiFi chip connects to the P4 host via SDIO. C6 has a fixed-size
+// pkt_rxbuff. Concurrent TCP traffic (HTTP response residue + SOAP responses
+// + UPnP NOTIFY events) overflows it → C6 asserts sdio_push_data_to_queue:928
+// → SDIO host spins in tight register-poll loop → Interrupt WDT on CPU0.
+// All values below are calibrated for this hardware. Do NOT reduce without testing.
+#define SDIO_GENERAL_COOLDOWN_MS      200   // Min gap between any two network operations
+#define SDIO_HTTPS_COOLDOWN_MS       3000   // TLS teardown residue — 2000ms insufficient (DMA AES alloc failure)
+#define SDIO_STORM_COOLDOWN_MS       3000   // HTTP-500 storm settle (HLS source transition)
+#define SDIO_STORM_SAFETY_CAP_MS     5000   // Max wait inside 500-storm loop (safety cap)
+#define SDIO_TRACK_CHANGE_SETTLE_MS     0   // Disabled: Sonos lib is pure SOAP-polling (no UPnP subscriptions,
+                                            // no WiFiServer, no NOTIFY events). Long idle → C6 power-save → crash.
+#define SDIO_POST_STORM_SETTLE_MS       0   // Disabled: storm gate (3000ms) + any settle = too much idle → C6 SDIO
+                                            // DMA clock-gates → pkt_rxbuff fills on wake burst. Even 1000ms settle
+                                            // (total 4000ms idle) crashes. Keepalive: see SDIO_STORM_KEEPALIVE_MS.
+#define SDIO_TCP_CLOSE_MS             200   // TCP FIN-ACK drain after http.end() (non-TLS)
+#define SDIO_HTTPS_TCP_CLOSE_MS       500   // TCP FIN-ACK drain after http.end() (TLS)
+#define SDIO_INTER_DOWNLOAD_MS       1000   // Min gap between consecutive art/BG downloads
+#define ART_TCP_RCVBUF               4096   // TCP SO_RCVBUF for art HTTP socket. Controls app-layer recv
+                                            // buffer size (conn->recv_bufsize). Does NOT directly control
+                                            // TCP window advertisement (pcb->rcv_wnd). The TCP window
+                                            // (65534) is baked into the pre-compiled liblwip.a and cannot
+                                            // be changed at runtime. SO_RCVBUF gradually constrains the
+                                            // advertised window as the app buffer fills, preventing runaway
+                                            // server bursts during multi-segment downloads.
+#define ART_TCP_RCVBUF_DL_SAFETY    16000   // Abort if DMA < this AT dl-start (AFTER http.GET() burst absorbed).
+                                            // CONFIRMED CRASH: dl-start=22364 → WiFi alloc ~15KB during read → :928.
+                                            // Belt-and-suspenders: ART_DMA_MID_READ_MIN catches further drops during
+                                            // the read loop itself. 16KB catches catastrophically-low dl-start values
+                                            // (burst >> expected) without blocking healthy Song 2+ downloads.
+                                            // Song 2+ DMA floor 38-42KB: burst 16KB → dl-start 22-26KB >> 16KB ✓
+                                            // Crash scenario: dl-start 22KB > 16KB passes → mid-read check at 8KB
+                                            // catches the WiFi-alloc drop → aborts before :928.
+#define ART_MIN_FREE_DMA             8000   // Min DMA before art pre-connect (DMA wait loop gate — vestigial).
+#define ART_MIN_DMA_PRE_BURST       20000   // Min DMA before http.GET() (BEFORE burst arrives).
+                                            // Immediate burst drain (pre-alloc jpgBuf + drain loop right after GET)
+                                            // frees TCP pbufs before :928 crash window closes, so we no longer need
+                                            // 34KB headroom. Steady-state DMA floor = 28-32KB > 20KB → always passes.
+                                            // Crash floor = ~6-7KB; 20KB = crash_floor + ~13KB safety margin.
+                                            // Was 34KB: above 28-32KB floor → all art downloads aborted (art never loaded).
+#define ART_DMA_MID_READ_MIN         8000   // Abort if DMA < this DURING the chunk read loop. Belt-and-suspenders:
+                                            // if WiFi dynamic RX buffers allocate ~15KB after dl-start passes, this
+                                            // catches the resulting DMA drop before it hits the crash floor (~6-7KB).
+                                            // Confirmed crash floor: 6744 bytes. 8KB = 6744 + ~1.3KB safety margin.
+#define SDIO_QUEUE_POLL_COOLDOWN_MS  3000   // After updateQueue() 20KB Browse response residue (was 2000, too short)
+#define SDIO_POST_QUEUE_DRAIN_MS     1000   // Polling task: drain Browse response before next cycle
+
+// Lyrics-specific
+#define LYRICS_ART_WAIT_TIMEOUT_MS  15000   // Max wait for art_download_in_progress to clear (storm cooldown 3000ms + download ~2000ms + margin)
+#define LYRICS_RETRY_DELAY_MS        2000   // Between lyrics HTTPS fetch retry attempts
 
 // =============================================================================
 // WATCHDOG & RELIABILITY

--- a/include/config.h
+++ b/include/config.h
@@ -118,7 +118,7 @@
 // Polling tick modulos (base interval = 300ms, so N ticks = N * 300ms)
 #define POLL_VOLUME_MODULO      5       // Volume every 1.5s (5 * 300ms)
 #define POLL_TRANSPORT_MODULO   10      // Transport settings every 3s
-#define POLL_QUEUE_MODULO       100     // Queue every 30s (optimized: was 50/15s)
+#define POLL_QUEUE_MODULO       200     // Queue every 60s (was 100/30s — halved to reduce DMA pressure)
 #define POLL_MEDIA_INFO_MODULO  50      // Radio station info every 15s
 #define POLL_BASE_INTERVAL_MS   300     // Base polling interval
 
@@ -270,11 +270,12 @@
                                             // catches the WiFi-alloc drop → aborts before :928.
 #define ART_MIN_FREE_DMA             8000   // Min DMA before art pre-connect (DMA wait loop gate — vestigial).
 #define ART_MIN_DMA_PRE_BURST       20000   // Min DMA before http.GET() (BEFORE burst arrives).
-                                            // Immediate burst drain (pre-alloc jpgBuf + drain loop right after GET)
-                                            // frees TCP pbufs before :928 crash window closes, so we no longer need
-                                            // 34KB headroom. Steady-state DMA floor = 28-32KB > 20KB → always passes.
-                                            // Crash floor = ~6-7KB; 20KB = crash_floor + ~13KB safety margin.
-                                            // Was 34KB: above 28-32KB floor → all art downloads aborted (art never loaded).
+                                            // Session DMA depletion: ~10KB permanent loss per art download
+                                            // (WiFi dynamic RX buffer accumulation — platform-level, unfixable in app).
+                                            // At DMA=20-38KB: burst (14-21KB) → dl-start ~0-18KB → mid-read WiFi
+                                            // alloc ~15KB → :928. ART_DMA_MID_READ_MIN=8KB catches the drop.
+                                            // At DMA<20KB: abort cleanly → 3 aborts → esp_restart() → ~120KB DMA.
+                                            // Was 45000: caused early abort at 38KB → 6s wait before restart vs instant.
 #define ART_DMA_MID_READ_MIN         8000   // Abort if DMA < this DURING the chunk read loop. Belt-and-suspenders:
                                             // if WiFi dynamic RX buffers allocate ~15KB after dl-start passes, this
                                             // catches the resulting DMA drop before it hits the crash floor (~6-7KB).

--- a/include/lyrics.h
+++ b/include/lyrics.h
@@ -25,8 +25,10 @@ extern int current_lyric_index;
 // Initialize lyrics system (allocates PSRAM buffer)
 void initLyrics();
 
-// Request lyrics for a track (spawns background fetch task)
-void requestLyrics(const String& artist, const String& title, int durationSec);
+// Request lyrics for a track (spawns background fetch task).
+// Returns true if a new task was spawned, false if the previous task is still
+// running (caller should NOT update lyrics_last_track — retry next frame).
+bool requestLyrics(const String& artist, const String& title, int durationSec);
 
 // Clear lyrics and hide overlay
 void clearLyrics();

--- a/include/sonos_controller.h
+++ b/include/sonos_controller.h
@@ -125,8 +125,12 @@ private:
     SemaphoreHandle_t deviceMutex;
     QueueHandle_t commandQueue;
     QueueHandle_t uiUpdateQueue;
-    TaskHandle_t networkTaskHandle;
-    TaskHandle_t pollingTaskHandle;
+    TaskHandle_t  networkTaskHandle;
+    TaskHandle_t  pollingTaskHandle;
+    StaticTask_t  networkTaskTCB;           // TCB in internal SRAM (~88 bytes)
+    StaticTask_t  pollingTaskTCB;           // TCB in internal SRAM (~88 bytes)
+    StackType_t*  networkTaskStack = nullptr;  // Stack in PSRAM — allocated once in startTasks()
+    StackType_t*  pollingTaskStack = nullptr;  // Stack in PSRAM — allocated once in startTasks()
     
     // Internal methods
     String sendSOAP(const char* service, const char* action, const char* args);

--- a/include/sonos_controller.h
+++ b/include/sonos_controller.h
@@ -199,7 +199,7 @@ public:
     bool updateMediaInfo();          // Get station name for radio from GetMediaInfo
     bool updatePlaybackState();
     bool updateVolume();
-    bool updateQueue();
+    bool updateQueue(int startIndex = 0);  // startIndex: 0-based SOAP StartingIndex for windowed fetch
     bool updateTransportSettings();
     
     // Queue access

--- a/include/ui_common.h
+++ b/include/ui_common.h
@@ -86,7 +86,7 @@ extern lv_obj_t *btn_wifi_scan, *btn_wifi_connect, *lbl_scan_text;
 extern lv_obj_t *btn_sonos_scan, *spinner_scan;
 extern lv_obj_t *btn_groups_scan, *spinner_groups_scan;
 
-// Album art
+// Album art — rendering state
 extern lv_img_dsc_t art_dsc;
 extern uint16_t *art_buffer;
 extern uint16_t *art_temp_buffer;
@@ -98,11 +98,17 @@ extern uint32_t dominant_color;
 extern volatile bool color_ready;
 extern int art_offset_x, art_offset_y;
 extern bool is_sonos_radio_art;
-extern bool pending_is_station_logo;  // True when requesting radio station logo (PNG allowed)
-extern volatile unsigned long last_queue_fetch_time;  // Last updateQueue() completion (large HTTP — art waits 2000ms, sendSOAP unaffected)
-extern SemaphoreHandle_t network_mutex;  // Serializes all WiFi/HTTPS operations (SOAP, album art, OTA)
-extern volatile unsigned long last_network_end_ms;  // Last network operation end time (for SDIO cooldown)
-extern volatile unsigned long last_https_end_ms;   // Last HTTPS operation end time (TLS needs longer cooldown)
+extern bool pending_is_station_logo;
+
+// SDIO crash defence — network timing globals
+extern SemaphoreHandle_t network_mutex;
+extern volatile unsigned long last_network_end_ms;
+extern volatile unsigned long last_https_end_ms;
+extern volatile unsigned long last_queue_fetch_time;
+extern volatile bool          art_download_in_progress;
+extern volatile unsigned long last_art_download_end_ms;
+extern volatile unsigned long last_track_change_ms;
+extern volatile unsigned long last_transient_500_ms;
 
 // UI state
 extern String ui_title, ui_artist, ui_repeat;
@@ -197,6 +203,7 @@ void setBrightness(int level);
 void resetScreenTimeout();
 void checkAutoDim();
 void requestAlbumArt(const String &url);
+void clearAlbumArtCache();  // Invalidate LRU cache on track change
 void updateUI();
 void processUpdates();
 void triggerPendingOTA();  // Called from loop() when ota_auto_pending is set
@@ -215,7 +222,8 @@ inline String decodeHTMLEntities(const String& str) {
     return result;
 }
 
-// Album art task — stack lives in PSRAM to free internal SRAM for SDIO/WiFi DMA buffers
+// Network tasks — FreeRTOS handles and shutdown signals
+// Art and lyrics stacks live in PSRAM to free internal SRAM for SDIO/WiFi DMA buffers
 extern TaskHandle_t albumArtTaskHandle;
 extern StaticTask_t albumArtTaskTCB;
 extern StackType_t* art_task_stack;
@@ -224,13 +232,11 @@ extern volatile bool art_abort_download;
 void albumArtTask(void *param);
 void createArtTask();   // PSRAM-stack wrapper — use instead of xTaskCreatePinnedToCore directly
 
-// Lyrics task — stack lives in PSRAM for same reason
 extern TaskHandle_t lyricsTaskHandle;
 extern StaticTask_t lyricsTaskTCB;
 extern StackType_t* lyrics_task_stack;
 extern volatile bool lyrics_shutdown_requested;
 
-// Sonos task shutdown (for OTA)
 extern volatile bool sonos_tasks_shutdown_requested;
 
 // Clock / screensaver

--- a/include/ui_common.h
+++ b/include/ui_common.h
@@ -19,7 +19,7 @@
 #define DEFAULT_WIFI_PASSWORD ""
 
 // Firmware version
-#define FIRMWARE_VERSION "1.5.0"
+#define FIRMWARE_VERSION "1.5.0-nightly.12e5b76"
 #define GITHUB_REPO "OpenSurface/SonosESP"
 #define GITHUB_API_URL "https://api.github.com/repos/" GITHUB_REPO "/releases/latest"
 

--- a/include/ui_common.h
+++ b/include/ui_common.h
@@ -19,7 +19,7 @@
 #define DEFAULT_WIFI_PASSWORD ""
 
 // Firmware version
-#define FIRMWARE_VERSION "1.5.0-nightly.12e5b76"
+#define FIRMWARE_VERSION "1.6.0"
 #define GITHUB_REPO "OpenSurface/SonosESP"
 #define GITHUB_API_URL "https://api.github.com/repos/" GITHUB_REPO "/releases/latest"
 
@@ -109,6 +109,10 @@ extern volatile bool          art_download_in_progress;
 extern volatile unsigned long last_art_download_end_ms;
 extern volatile unsigned long last_track_change_ms;
 extern volatile unsigned long last_transient_500_ms;
+
+// On-demand queue window fetch
+extern volatile bool queue_fetch_requested;
+extern volatile int  queue_fetch_start_index;
 
 // UI state
 extern String ui_title, ui_artist, ui_repeat;

--- a/include/ui_common.h
+++ b/include/ui_common.h
@@ -19,7 +19,7 @@
 #define DEFAULT_WIFI_PASSWORD ""
 
 // Firmware version
-#define FIRMWARE_VERSION "1.3.0-nightly.b75ca67"
+#define FIRMWARE_VERSION "1.5.0"
 #define GITHUB_REPO "OpenSurface/SonosESP"
 #define GITHUB_API_URL "https://api.github.com/repos/" GITHUB_REPO "/releases/latest"
 

--- a/include/ui_common.h
+++ b/include/ui_common.h
@@ -19,7 +19,7 @@
 #define DEFAULT_WIFI_PASSWORD ""
 
 // Firmware version
-#define FIRMWARE_VERSION "1.3.0-nightly.85f511a"
+#define FIRMWARE_VERSION "1.3.0-nightly.b75ca67"
 #define GITHUB_REPO "OpenSurface/SonosESP"
 #define GITHUB_API_URL "https://api.github.com/repos/" GITHUB_REPO "/releases/latest"
 

--- a/include/ui_network_guard.h
+++ b/include/ui_network_guard.h
@@ -1,0 +1,49 @@
+#pragma once
+/**
+ * ui_network_guard.h — Centralised SDIO crash-defence pre-download guard.
+ *
+ * sdioPreWait() consolidates all SDIO cooldown boilerplate that previously
+ * lived duplicated across ui_album_art.cpp, lyrics.cpp, sonos_controller.cpp,
+ * and ui_clock_screen.cpp.
+ *
+ * Call OUTSIDE the network mutex, BEFORE acquiring it.
+ * Inside-mutex re-checks remain inline in each caller (one-shot, correct).
+ *
+ * Always enforces:
+ *   1. SDIO_GENERAL_COOLDOWN_MS  — min gap since last network op (any protocol)
+ *
+ * Optional checks (select via flags):
+ *   SDIO_WAIT_TRACK_CHANGE   — track-change settle (SDIO_TRACK_CHANGE_SETTLE_MS, currently 0)
+ *   SDIO_WAIT_STORM_GATE     — HTTP-500 storm while-loop (SDIO_STORM_COOLDOWN_MS)
+ *   SDIO_WAIT_QUEUE_POLL     — updateQueue() residue (SDIO_QUEUE_POLL_COOLDOWN_MS)
+ *   SDIO_WAIT_HTTPS_COOLDOWN — TLS teardown residue after last HTTPS session
+ *                              (SDIO_HTTPS_COOLDOWN_MS = 3s).
+ *                              Use only when the caller itself does HTTPS (lyrics, HTTPS art,
+ *                              clock weather). Do NOT use for plain HTTP callers (sendSOAP,
+ *                              local Sonos art) — it created 3s SDIO idle → pkt_rxbuff :928.
+ *
+ * Returns: false if abort_flag1 or abort_flag2 became true during any wait.
+ *          true  if all cooldowns passed without abort.
+ *
+ * Callers with no abort flags can ignore the return value —
+ * with nullptr flags it always returns true.
+ */
+
+#include <stdint.h>
+
+// Flags for optional check groups
+#define SDIO_WAIT_TRACK_CHANGE   0x01u   // Gate on last_track_change_ms
+#define SDIO_WAIT_STORM_GATE     0x02u   // Gate on last_transient_500_ms (while-loop)
+#define SDIO_WAIT_QUEUE_POLL     0x04u   // Gate on last_queue_fetch_time
+#define SDIO_WAIT_HTTPS_COOLDOWN 0x08u   // Gate on last_https_end_ms (3s TLS teardown wait)
+
+// Art task: all four guards. Storm gate waits for HLS transition to clear — Sonos
+// WiFi broadcast traffic during transitions + simultaneous large HTTP download
+// exhausts C6 pkt_rxbuff. WiFi.setSleep(false) makes the 3s wait safe (no power-save).
+#define SDIO_WAIT_ART  (SDIO_WAIT_TRACK_CHANGE | SDIO_WAIT_STORM_GATE | \
+                        SDIO_WAIT_QUEUE_POLL | SDIO_WAIT_HTTPS_COOLDOWN)
+
+bool sdioPreWait(const char*    tag,
+                 uint32_t       flags       = 0,
+                 volatile bool* abort_flag1 = nullptr,
+                 volatile bool* abort_flag2 = nullptr);

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,5 +66,4 @@ lib_deps =
     bblanchon/ArduinoJson@^7.3.0
     bitbank2/PNGdec@^1.0.3
     bitbank2/JPEGDEC@^1.8.0
-    ESP32Async/ESPAsyncWebServer
     ricmoo/QRCode@^0.0.1

--- a/src/lyrics.cpp
+++ b/src/lyrics.cpp
@@ -6,8 +6,9 @@
 #include "lyrics.h"
 #include "ui_common.h"
 #include "config.h"
-#include <WiFiClientSecure.h>
+#include "ui_network_guard.h"
 #include <HTTPClient.h>
+#include <WiFiClientSecure.h>
 #include <ArduinoJson.h>
 #include <esp_heap_caps.h>
 
@@ -169,22 +170,37 @@ static void lyricsTaskFunc(void* param) {
     // No self-spawn: loops internally so the single PSRAM stack is reused safely.
     while (true) {
         // PRE-WAIT cooldowns outside mutex so SOAP commands aren't blocked
+
+        // Wait for art download to finish before HTTP fetch (concurrent art + lyrics overflows pkt_rxbuff)
         {
-            unsigned long now = millis();
-            unsigned long elapsed = now - last_network_end_ms;
-            if (last_network_end_ms > 0 && elapsed < 200)
-                vTaskDelay(pdMS_TO_TICKS(200 - elapsed));
-            now = millis();
-            elapsed = now - last_https_end_ms;
-            if (last_https_end_ms > 0 && elapsed < 2000) {
-                unsigned long wait_ms = 2000 - elapsed;
-                Serial.printf("[LYRICS] HTTPS cooldown: waiting %lums\n", wait_ms);
-                vTaskDelay(pdMS_TO_TICKS(wait_ms));
+            unsigned long _now = millis();
+            Serial.printf("[LYRICS] PRE: art_dl=%d 500=%ldms net=%ldms art_end=%ldms heap=%u dma=%u stk=%u\n",
+                (int)art_download_in_progress,
+                last_transient_500_ms    ? (long)(_now - last_transient_500_ms)    : -1L,
+                last_network_end_ms      ? (long)(_now - last_network_end_ms)      : -1L,
+                last_art_download_end_ms ? (long)(_now - last_art_download_end_ms) : -1L,
+                heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
+                heap_caps_get_free_size(MALLOC_CAP_DMA),
+                uxTaskGetStackHighWaterMark(NULL));
+        }
+        {
+            unsigned long wait_start = millis();
+            while (art_download_in_progress) {
+                if (lyrics_abort_requested || lyrics_shutdown_requested) break;
+                if (millis() - wait_start > LYRICS_ART_WAIT_TIMEOUT_MS) break;  // safety timeout
+                vTaskDelay(pdMS_TO_TICKS(100));
             }
+            unsigned long art_waited = millis() - wait_start;
+            if (art_waited > 50)
+                Serial.printf("[LYRICS] Art-wait done: %lums (art_dl=%d)\n", art_waited, (int)art_download_in_progress);
         }
 
-        // Abort/shutdown after cooldown
-        if (lyrics_abort_requested || lyrics_shutdown_requested) {
+        // SDIO crash-defence: HTTPS cooldown + general cooldown.
+        // First HTTPS session triggers ~77KB one-time mbedTLS global init (cipher tables,
+        // entropy, RNG state). Subsequent sessions reuse this state and need only ~5KB DMA.
+        // DMA floor after first lyrics fetch: ~20KB (97KB post-WiFi − 77KB mbedTLS).
+        // SDIO_WAIT_HTTPS_COOLDOWN ensures 3s gap after any previous HTTPS session.
+        if (!sdioPreWait("LYRICS", SDIO_WAIT_HTTPS_COOLDOWN, &lyrics_abort_requested, &lyrics_shutdown_requested)) {
             lyrics_fetching = false;
             lyrics_abort_requested = false;
             lyrics_retry_count = 0;
@@ -193,7 +209,18 @@ static void lyricsTaskFunc(void* param) {
             return;
         }
 
+        // Re-check art_download_in_progress after sdioPreWait:
+        // (1) requestLyrics() is called BEFORE requestAlbumArt() sets the flag in the same
+        //     updateUI() call — lyrics task may start and pass the while loop above before
+        //     the flag is set. (2) Track may change and set the flag mid-sdioPreWait.
+        // Either way: loop back and wait for art to finish before attempting HTTPS.
+        if (art_download_in_progress) {
+            Serial.println("[LYRICS] Art download in progress after pre-wait — retrying after art");
+            continue;
+        }
+
         // Acquire mutex (3s timeout — short so SOAP commands aren't blocked for long)
+        uint32_t t_lyr_mutex = millis();
         if (!xSemaphoreTake(network_mutex, pdMS_TO_TICKS(3000))) {
             Serial.println("[LYRICS] Network busy, skipping fetch");
             lyrics_fetching = false;
@@ -202,20 +229,54 @@ static void lyricsTaskFunc(void* param) {
             return;
         }
 
-        // Re-check cooldowns under mutex (another task may have run while we waited)
-        {
-            unsigned long now = millis();
-            unsigned long elapsed = now - last_network_end_ms;
-            if (last_network_end_ms > 0 && elapsed < 200)
-                vTaskDelay(pdMS_TO_TICKS(200 - elapsed));
-            now = millis();
-            elapsed = now - last_https_end_ms;
-            if (last_https_end_ms > 0 && elapsed < 2000)
-                vTaskDelay(pdMS_TO_TICKS(2000 - elapsed));
+        Serial.printf("[LYRICS] Mutex acquired after %lums | heap=%u dma=%u\n",
+            millis() - t_lyr_mutex,
+            heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
+            heap_caps_get_free_size(MALLOC_CAP_DMA));
+        // Inside-mutex check: final race guard. Track change may have set art_download_in_progress
+        // between the recheck above and mutex acquisition (tiny window). Release and loop back.
+        if (art_download_in_progress) {
+            Serial.println("[LYRICS] Art download started while acquiring mutex — retrying after art");
+            xSemaphoreGive(network_mutex);
+            continue;
         }
 
-        // HTTPS fetch — scoped so WiFiClientSecure destructor frees TLS memory immediately
+        // Inside-mutex rechecks: TCP drain time only (full cooldown already ran in sdioPreWait).
         {
+            unsigned long now = millis();
+            unsigned long elapsed_net  = now - last_network_end_ms;
+            unsigned long elapsed_https = now - last_https_end_ms;
+            if (last_network_end_ms > 0 && elapsed_net < SDIO_GENERAL_COOLDOWN_MS)
+                vTaskDelay(pdMS_TO_TICKS(SDIO_GENERAL_COOLDOWN_MS - elapsed_net));
+            if (last_https_end_ms > 0 && elapsed_https < SDIO_HTTPS_TCP_CLOSE_MS)
+                vTaskDelay(pdMS_TO_TICKS(SDIO_HTTPS_TCP_CLOSE_MS - elapsed_https));
+        }
+
+        // DMA guard: esp-aes needs at least ~5KB DMA for HTTPS session.
+        // Confirmed failure: dma=10,980 total → "Failed to allocate DMA descriptors".
+        // NOTE: heap_caps_get_largest_free_block(MALLOC_CAP_DMA) returns wrong values
+        // on ESP32-P4 (4-16 bytes even at 96KB free) — use get_free_size only.
+        // Art auto-restart fires at 20s DMA floor, so this guard is belt-and-suspenders.
+        {
+            size_t dma_total = heap_caps_get_free_size(MALLOC_CAP_DMA);
+            if (dma_total < 30000) {
+                Serial.printf("[LYRICS] DMA too low (%u) — skipping fetch\n", (unsigned)dma_total);
+                xSemaphoreGive(network_mutex);
+                lyrics_fetching = false;
+                lyricsTaskHandle = NULL;
+                vTaskDelete(NULL);
+                return;
+            }
+        }
+
+        // HTTPS fetch — local WiFiClientSecure per song: TLS buffers (~32KB DMA) allocated for
+        // handshake and freed by destructor at scope exit. Permanent loss ~6.8KB (fragmentation)
+        // vs ~32KB if kept static. Critical: with static + setReuse the TLS record buffers are
+        // never released → session DMA floor drops ~32KB extra → Song 2+ pre-GET too low → crash.
+        {
+            Serial.printf("[LYRICS] HTTPS open → lrclib.net | heap=%u dma=%u\n",
+                heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
+                heap_caps_get_free_size(MALLOC_CAP_DMA));
             WiFiClientSecure client;
             client.setInsecure();
             HTTPClient http;
@@ -223,9 +284,12 @@ static void lyricsTaskFunc(void* param) {
             http.setTimeout(10000);
             http.addHeader("User-Agent", "SonosESP/1.0");
 
+            uint32_t t_lyr_get = millis();
             int code = http.GET();
+            Serial.printf("[LYRICS] HTTPS ← code=%d in %lums\n", code, millis() - t_lyr_get);
             if (code == 200) {
                 payload = http.getString();
+                Serial.printf("[LYRICS] Payload: %u bytes\n", (unsigned)payload.length());
                 lyrics_retry_count = 0;
             } else {
                 const char* error_msg;
@@ -247,7 +311,7 @@ static void lyricsTaskFunc(void* param) {
                 Serial.flush();
 
                 if (code == -1 || code == 404) {
-                    // No retry: -1 = SDIO stressed, 404 = no lyrics exist
+                    // No retry: -1 = connection failed, 404 = no lyrics exist
                     Serial.printf("[LYRICS] No retry for HTTP %d — marking song as failed\n", code);
                     strncpy(lyrics_failed_artist, pending_artist, sizeof(lyrics_failed_artist) - 1);
                     lyrics_failed_artist[sizeof(lyrics_failed_artist) - 1] = '\0';
@@ -269,14 +333,27 @@ static void lyricsTaskFunc(void* param) {
                 }
             }
 
+            // Wait up to 200ms for server FIN (passive close → server gets TIME_WAIT, not us).
+            if (WiFiClient* s = http.getStreamPtr()) {
+                for (int i = 0; i < 200 && s->connected(); i++)
+                    vTaskDelay(pdMS_TO_TICKS(1));
+            }
             http.end();
-            client.stop();
-        }  // WiFiClientSecure + HTTPClient destroyed here
+            client.stop();  // Explicitly free mbedTLS record buffers (~32KB DMA) before destructor.
+                            // Without this, TLS in/out record buffers linger until scope exit but
+                            // destructor ordering is non-deterministic vs. HTTPClient destruction.
+            Serial.printf("[LYRICS] HTTPS closed | heap=%u dma=%u\n",
+                heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
+                heap_caps_get_free_size(MALLOC_CAP_DMA));
+        }  // WiFiClientSecure and HTTPClient destroyed here; TLS buffers already freed by stop()
 
-        // TLS cleanup wait + timestamp update before releasing mutex
-        vTaskDelay(pdMS_TO_TICKS(200));
+        // Cleanup wait + timestamp update before releasing mutex
+        vTaskDelay(pdMS_TO_TICKS(SDIO_HTTPS_TCP_CLOSE_MS));  // drain TLS FIN-ACK
         last_network_end_ms = millis();
         last_https_end_ms   = millis();
+        Serial.printf("[LYRICS] Mutex releasing | heap=%u dma=%u\n",
+            heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
+            heap_caps_get_free_size(MALLOC_CAP_DMA));
         xSemaphoreGive(network_mutex);
 
         // Abort check after mutex release
@@ -294,7 +371,7 @@ static void lyricsTaskFunc(void* param) {
         if (lyrics_retry_count == 0) break;  // gave up (marked as failed or -1/404)
 
         // Transient error: wait before retry
-        vTaskDelay(pdMS_TO_TICKS(2000));
+        vTaskDelay(pdMS_TO_TICKS(LYRICS_RETRY_DELAY_MS));
         if (lyrics_abort_requested) {
             lyrics_fetching = false;
             lyrics_abort_requested = false;
@@ -339,11 +416,11 @@ static void lyricsTaskFunc(void* param) {
     vTaskDelete(NULL);
 }
 
-void requestLyrics(const String& artist, const String& title, int durationSec) {
-    if (artist.length() == 0 || title.length() == 0) return;
+bool requestLyrics(const String& artist, const String& title, int durationSec) {
+    if (artist.length() == 0 || title.length() == 0) return false;
     if (!lyric_lines) {
         Serial.println("[LYRICS] Buffer not initialized - call initLyrics() first");
-        return;
+        return false;
     }
 
     bool sameTrack = (strcmp(artist.c_str(), pending_artist) == 0 &&
@@ -354,7 +431,7 @@ void requestLyrics(const String& artist, const String& title, int durationSec) {
     // spawn a new lyrics task, creating an HTTPS retry storm that exhausts C6 SDIO buffers.
     if (strcmp(artist.c_str(), lyrics_failed_artist) == 0 &&
         strcmp(title.c_str(), lyrics_failed_title) == 0) {
-        return;  // Already attempted this track — skip silently
+        return false;  // Already attempted this track — skip silently
     }
 
     // New song: clear the failed-song record so it gets a fresh attempt
@@ -363,18 +440,36 @@ void requestLyrics(const String& artist, const String& title, int durationSec) {
         lyrics_failed_title[0]  = '\0';
     }
 
-    // If already fetching, abort the previous task (track changed)
-    if (lyrics_fetching) {
-        Serial.println("[LYRICS] Track changed, aborting previous fetch");
+    // CRITICAL: If the previous task is still running (lyricsTaskHandle != NULL), do NOT
+    // spawn a new task yet. Spawning with the same lyrics_task_stack and lyricsTaskTCB
+    // while the old task is alive (e.g. blocked inside http.GET() with up to 10s timeout)
+    // causes FreeRTOS to re-initialise the TCB in-place. The old task is zombified: its
+    // stack-allocated WiFiClientSecure is never destructed → ~32KB TLS DMA session buffers
+    // are permanently leaked. After 2-3 rapid track changes: DMA floor drops ~64-96KB →
+    // art pre-GET check fails → no album art loads for any subsequent song.
+    //
+    // Fix: signal abort + update pending parameters, but return false without spawning.
+    // Caller (updateUI) does NOT update lyrics_last_track when we return false, so the
+    // condition fires again next frame. Old task exits when its current network call
+    // completes or times out (≤ 10s) and sees lyrics_abort_requested → cleans up TLS
+    // properly → sets lyricsTaskHandle = NULL. Next frame: we spawn normally.
+    if (lyricsTaskHandle != NULL) {
+        Serial.println("[LYRICS] Previous task still running — aborting, will retry next frame");
         lyrics_abort_requested = true;
-        // Wait a bit for previous task to abort (it checks the flag every delay/loop)
-        vTaskDelay(pdMS_TO_TICKS(100));
+        clearLyrics();  // Clear old song lyrics from display immediately
+        // Update pending params so the new task fetches the correct song when spawned
+        strncpy(pending_artist, artist.c_str(), sizeof(pending_artist) - 1);
+        pending_artist[sizeof(pending_artist) - 1] = '\0';
+        strncpy(pending_title, title.c_str(), sizeof(pending_title) - 1);
+        pending_title[sizeof(pending_title) - 1] = '\0';
+        pending_duration = durationSec;
+        return false;  // Caller should NOT update lyrics_last_track; retry next frame
     }
 
-    // Clear previous lyrics
-    clearLyrics();
+    // No previous task running — proceed with spawn.
 
-    // Reset abort flag, retry counter, and any pending status for new fetch
+    // Clear previous lyrics and reset state
+    clearLyrics();
     lyrics_abort_requested = false;
     lyrics_retry_count = 0;
     lyrics_status_msg[0] = '\0';
@@ -389,8 +484,18 @@ void requestLyrics(const String& artist, const String& title, int durationSec) {
     lyrics_fetching = true;
     updateLyricsStatus();  // Show "fetching" status
 
-    // Spawn one-shot background task (reduced stack: lyrics task is lightweight)
-    xTaskCreatePinnedToCore(lyricsTaskFunc, "lyrics", LYRICS_TASK_STACK, NULL, LYRICS_TASK_PRIORITY, &lyricsTaskHandle, 0);
+    // Spawn one-shot background task with PSRAM stack to save DMA SRAM
+    if (!lyrics_task_stack)
+        lyrics_task_stack = (StackType_t*)heap_caps_malloc(LYRICS_TASK_STACK, MALLOC_CAP_SPIRAM);
+    if (lyrics_task_stack) {
+        lyricsTaskHandle = xTaskCreateStaticPinnedToCore(
+            lyricsTaskFunc, "lyrics", LYRICS_TASK_STACK / sizeof(StackType_t),
+            NULL, LYRICS_TASK_PRIORITY, lyrics_task_stack, &lyricsTaskTCB, 0);
+    } else {
+        Serial.println("[LYRICS] PSRAM stack alloc failed — using internal SRAM");
+        xTaskCreatePinnedToCore(lyricsTaskFunc, "lyrics", LYRICS_TASK_STACK, NULL, LYRICS_TASK_PRIORITY, &lyricsTaskHandle, 0);
+    }
+    return (lyricsTaskHandle != NULL);
 }
 
 void clearLyrics() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,6 @@
 #include "clock_screen.h"
 #include <esp_flash.h>
 #include <esp_task_wdt.h>
-
 // Sonos logo
 LV_IMG_DECLARE(Sonos_idnu60bqes_1);
 
@@ -124,6 +123,48 @@ void setup() {
         Serial.printf("[NTP] Sync started, TZ=%s\n", CLOCK_ZONES[clock_tz_idx].name);
     } else {
         Serial.println("\n[WIFI] Connection failed - will retry from settings");
+    }
+
+    // === Memory map logged once at boot (post-WiFi, pre-LVGL) ===
+    // Used to diagnose DMA depletion: compare to runtime [ART/*/MEM] logs.
+    // DMA SRAM is the crash-critical pool — WiFi/TCP/JPEG all draw from it.
+    {
+        size_t dma_free    = heap_caps_get_free_size(MALLOC_CAP_DMA);
+        size_t dma_total   = heap_caps_get_total_size(MALLOC_CAP_DMA);
+        size_t psram_free  = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+        size_t psram_total = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
+        size_t int_free    = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+        size_t int_total   = heap_caps_get_total_size(MALLOC_CAP_INTERNAL);
+        size_t wifi_used   = dma_total > dma_free ? dma_total - dma_free : 0;
+        Serial.println("\n=== MEMORY MAP (post-WiFi, pre-LVGL) ===");
+        Serial.printf("  DMA SRAM:   %4uKB free / %4uKB total  (WiFi permanent: %uKB)\n",
+                      dma_free/1024, dma_total/1024, wifi_used/1024);
+        Serial.printf("  PSRAM:      %4uKB free / %4uKB total\n",
+                      psram_free/1024, psram_total/1024);
+        Serial.printf("  IRAM/DRAM:  %4uKB free / %4uKB total\n",
+                      int_free/1024, int_total/1024);
+        Serial.println("  --- DMA SRAM consumer estimates ---");
+        Serial.printf("  WiFi/SDIO permanent:     ~%uKB (pkt_rxbuff, DMA descs, HMAC, LMAC)\n",
+                      wifi_used/1024);
+        Serial.printf("  lwIP TIME_WAIT PCBs:     0-??KB (variable; use [SOAP/DMA] logs)\n");
+        Serial.printf("  Art TCP SO_RCVBUF=8KB:   ~9KB  (during art HTTP download only)\n");
+        Serial.printf("  JPEG HW decode output:   ~??KB (log [ART/pre-decode vs post-decode] MEM)\n");
+        Serial.printf("  mbedTLS HTTPS session:   ~5KB  (during lyrics/clock HTTPS only)\n");
+        Serial.printf("  Safe idle floor:         ~%uKB (ART_MIN_FREE_DMA threshold)\n",
+                      ART_MIN_FREE_DMA/1024);
+        Serial.println("  --- PSRAM consumer estimates ---");
+        Serial.printf("  LVGL frame bufs: ~%uKB (2 x %ux%ux2)\n",
+                      2*DISPLAY_WIDTH*DISPLAY_HEIGHT*2/1024, DISPLAY_WIDTH, DISPLAY_HEIGHT);
+        Serial.printf("  Art LRU cache:   ~230KB (2 slots x 240x240x2)\n");
+        Serial.printf("  Art task stack:    %uKB\n", ART_TASK_STACK_SIZE/1024);
+        Serial.printf("  Art download buf:  %uKB max (alloc+free per download)\n",
+                      ART_MAX_DOWNLOAD_SIZE/1024);
+        Serial.println("  --- Internal SRAM task stacks ---");
+        Serial.printf("  mainAppTask: %uKB  SonosPoll: %uKB  SonosNet: %uKB\n",
+                      MAIN_APP_TASK_STACK/1024, SONOS_POLL_TASK_STACK/1024, SONOS_NET_TASK_STACK/1024);
+        Serial.printf("  Lyrics: %uKB  ClockBG: %uKB\n",
+                      LYRICS_TASK_STACK/1024, CLOCK_BG_TASK_STACK/1024);
+        Serial.println("=========================================\n");
     }
 
     lv_init();

--- a/src/screens/ui_clock_screen.cpp
+++ b/src/screens/ui_clock_screen.cpp
@@ -13,6 +13,7 @@
 
 #include "ui_common.h"
 #include "config.h"
+#include "ui_network_guard.h"
 #include "clock_screen.h"
 
 LV_FONT_DECLARE(lv_font_montserrat_140);
@@ -246,11 +247,7 @@ static void fetchClockWeather() {
             lon = clock_auto_lon;
         } else {
             // First fetch this session — call ip-api.com (plain HTTP, no TLS)
-            while (!clock_bg_shutdown_requested) {
-                if (millis() - last_network_end_ms >= 200) break;
-                vTaskDelay(pdMS_TO_TICKS(50));
-            }
-            if (clock_bg_shutdown_requested) return;
+            if (!sdioPreWait("CLKWX", 0, &clock_bg_shutdown_requested)) return;
 
             if (xSemaphoreTake(network_mutex, pdMS_TO_TICKS(5000)) != pdTRUE) {
                 Serial.println("[CLKWX] No mutex for IP-locate");
@@ -317,12 +314,8 @@ static void fetchClockWeather() {
         lat, lon, clock_wx_fahrenheit ? "fahrenheit" : "celsius");
 
     for (int attempt = 1; attempt <= 2 && !clock_bg_shutdown_requested; attempt++) {
-        // HTTPS cooldown
-        while (!clock_bg_shutdown_requested) {
-            if (millis() - last_https_end_ms >= 2000) break;
-            vTaskDelay(pdMS_TO_TICKS(50));
-        }
-        if (clock_bg_shutdown_requested) return;
+        // SDIO crash-defence: general + HTTPS cooldowns before Open-Meteo HTTPS.
+        if (!sdioPreWait("CLKWX", 0, &clock_bg_shutdown_requested)) return;
 
         if (xSemaphoreTake(network_mutex, pdMS_TO_TICKS(5000)) != pdTRUE) {
             Serial.println("[CLKWX] No mutex for Open-Meteo");
@@ -444,12 +437,8 @@ void clockBgTask(void* /*param*/) {
 
             for (int attempt = 1; attempt <= MAX_ATTEMPTS && dl_total == 0 && !clock_bg_shutdown_requested; attempt++) {
 
-                // General network cooldown (HTTP — no TLS overhead)
-                while (!clock_bg_shutdown_requested) {
-                    if (millis() - last_network_end_ms >= 200) break;
-                    vTaskDelay(pdMS_TO_TICKS(50));
-                }
-                if (clock_bg_shutdown_requested) break;
+                // SDIO crash-defence: general + HTTPS cooldowns before BG photo download.
+                if (!sdioPreWait("CLKBG", 0, &clock_bg_shutdown_requested)) break;
 
                 if (xSemaphoreTake(network_mutex, pdMS_TO_TICKS(8000)) != pdTRUE) {
                     Serial.printf("[CLKBG] No mutex (attempt %d)\n", attempt);
@@ -523,7 +512,8 @@ void clockBgTask(void* /*param*/) {
                         photo_http.end();
                         photo_client.stop();
                     }
-                    last_network_end_ms = millis();
+                    last_network_end_ms      = millis();
+                    last_art_download_end_ms = millis();  // gate art/lyrics inter-download cooldowns
                 }
 
                 xSemaphoreGive(network_mutex);
@@ -806,6 +796,30 @@ void checkClockTrigger() {
 
         // ------------------------------------------------------------------
         case CLOCK_IDLE: {
+            // Periodic debug: log which condition is blocking (once per 30s)
+            {
+                static uint32_t last_dbg_ms = 0;
+                if (millis() - last_dbg_ms >= 30000) {
+                    last_dbg_ms = millis();
+                    uint32_t inact_ms  = (uint32_t)clock_timeout_min * 60000UL;
+                    uint32_t since_exit  = millis() - last_clock_exit_ms;
+                    uint32_t since_touch = millis() - last_touch_time;
+                    uint32_t since_trk   = last_track_change_ms ? millis() - last_track_change_ms : 999999;
+                    bool trig = (clock_mode == CLOCK_MODE_INACTIVITY) ? true
+                              : (clock_mode == CLOCK_MODE_PAUSED)     ? !ui_playing
+                              : (clock_mode == CLOCK_MODE_NOTHING)    ? (!ui_playing && ui_title.isEmpty())
+                              : false;
+                    Serial.printf("[CLOCK DBG] mode=%d timeout=%dmin | exit_ok=%d(+%lus) disabled=%d inact_ok=%d(%lu/%lus) trig=%d settle_ok=%d(+%lus) playing=%d art_dl=%d title='%s'\n",
+                        clock_mode, clock_timeout_min,
+                        (since_exit >= CLOCK_EXIT_COOLDOWN_MS),  since_exit/1000,
+                        (clock_mode == CLOCK_MODE_DISABLED),
+                        (since_touch >= inact_ms),               since_touch/1000, inact_ms/1000,
+                        trig,
+                        (since_trk >= SDIO_TRACK_CHANGE_SETTLE_MS), since_trk/1000,
+                        ui_playing, (int)art_download_in_progress, ui_title.c_str());
+                }
+            }
+
             // Not re-triggering soon after a manual dismiss
             if (millis() - last_clock_exit_ms < CLOCK_EXIT_COOLDOWN_MS) return;
             if (clock_mode == CLOCK_MODE_DISABLED) return;
@@ -813,11 +827,34 @@ void checkClockTrigger() {
             uint32_t inactivity_ms = (uint32_t)clock_timeout_min * 60000UL;
             if (millis() - last_touch_time < inactivity_ms) return;
 
+            // Track how long ui_playing has been continuously false.
+            // PAUSED/NOTHING modes debounce for 2s to ignore the brief isPlaying=false
+            // (~300-500ms) that Sonos reports during HLS track transitions.
+            static bool   s_was_not_playing   = false;
+            static uint32_t s_not_playing_since = 0;
+            if (!ui_playing) {
+                if (!s_was_not_playing) {
+                    s_was_not_playing   = true;
+                    s_not_playing_since = millis();
+                }
+            } else {
+                s_was_not_playing   = false;
+                s_not_playing_since = 0;
+            }
+            uint32_t not_playing_ms = s_was_not_playing ? millis() - s_not_playing_since : 0;
+
+            // "paused and stable" = not-playing for 2s AND no art download in progress.
+            // art_download_in_progress is true during every HLS track transition (set by
+            // requestAlbumArt() on track change, cleared only after the art cycle completes).
+            // This prevents the screensaver firing mid-transition when ui_playing is
+            // briefly false but music is about to resume on the new track.
+            bool paused_and_stable = (not_playing_ms >= 2000) && !art_download_in_progress;
+
             bool trigger = false;
             switch (clock_mode) {
-                case CLOCK_MODE_INACTIVITY: trigger = true;                               break;
-                case CLOCK_MODE_PAUSED:     trigger = !ui_playing;                        break;
-                case CLOCK_MODE_NOTHING:    trigger = !ui_playing && ui_title.isEmpty();  break;
+                case CLOCK_MODE_INACTIVITY: trigger = true;                                           break;
+                case CLOCK_MODE_PAUSED:     trigger = paused_and_stable;                              break;
+                case CLOCK_MODE_NOTHING:    trigger = paused_and_stable && ui_title.isEmpty();        break;
             }
             if (!trigger) return;
 

--- a/src/screens/ui_settings_screens.cpp
+++ b/src/screens/ui_settings_screens.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "ui_common.h"
+#include "config.h"
 
 // Forward declaration for sidebar (now in ui_sidebar.cpp)
 lv_obj_t* createSettingsSidebar(lv_obj_t* screen, int activeIdx);
@@ -17,11 +18,21 @@ void refreshQueueList() {
     SonosDevice* d = sonos.getCurrentDevice();
     if (!d) { lv_label_set_text(lbl_queue_status, "No device"); return; }
     if (d->queueSize == 0) { lv_label_set_text(lbl_queue_status, "Queue is empty"); return; }
-    lv_label_set_text_fmt(lbl_queue_status, "%d %s in queue", d->queueSize, d->queueSize == 1 ? "track" : "tracks");
+
+    // Show window range when we have a partial view, e.g. "Tracks 4–13 of 47"
+    int firstTrack = d->queue[0].trackNumber;
+    int lastTrack  = d->queue[d->queueSize - 1].trackNumber;
+    if (d->totalTracks > 0 && d->queueSize < d->totalTracks) {
+        lv_label_set_text_fmt(lbl_queue_status, "Tracks %d-%d of %d",
+                              firstTrack, lastTrack, d->totalTracks);
+    } else {
+        lv_label_set_text_fmt(lbl_queue_status, "%d %s",
+                              d->queueSize, d->queueSize == 1 ? "track" : "tracks");
+    }
 
     for (int i = 0; i < d->queueSize; i++) {
         QueueItem* item = &d->queue[i];
-        int trackNum = i + 1;
+        int trackNum = item->trackNumber;  // absolute 1-based position in the full queue
         bool isPlaying = (trackNum == d->currentTrackNumber);
 
         lv_obj_t* btn = lv_btn_create(list_queue);
@@ -104,7 +115,20 @@ void createQueueScreen() {
     lv_obj_set_style_bg_color(btn_refresh, lv_color_hex(0x333333), 0);
     lv_obj_set_style_radius(btn_refresh, 25, 0);
     lv_obj_set_style_shadow_width(btn_refresh, 0, 0);
-    lv_obj_add_event_cb(btn_refresh, [](lv_event_t* e) { sonos.updateQueue(); refreshQueueList(); }, LV_EVENT_CLICKED, NULL);
+    lv_obj_add_event_cb(btn_refresh, [](lv_event_t* e) {
+        // Request a windowed fetch from the polling task (safe: no SOAP on UI thread).
+        SonosDevice* d = sonos.getCurrentDevice();
+        int start = 0;
+        if (d && d->currentTrackNumber > 0) {
+            start = d->currentTrackNumber - SONOS_QUEUE_BATCH_SIZE / 2;
+            if (start < 0) start = 0;
+            if (d->totalTracks > 0 && start + SONOS_QUEUE_BATCH_SIZE > d->totalTracks)
+                start = d->totalTracks - SONOS_QUEUE_BATCH_SIZE;
+            if (start < 0) start = 0;
+        }
+        queue_fetch_start_index = start;
+        queue_fetch_requested   = true;
+    }, LV_EVENT_CLICKED, NULL);
     lv_obj_t* ico_refresh = lv_label_create(btn_refresh);
     lv_label_set_text(ico_refresh, LV_SYMBOL_REFRESH);
     lv_obj_set_style_text_color(ico_refresh, lv_color_hex(0xFFFFFF), 0);

--- a/src/sonos_controller.cpp
+++ b/src/sonos_controller.cpp
@@ -5,11 +5,18 @@
 
 #include "sonos_controller.h"
 #include "config.h"
+#include "ui_network_guard.h"
 #include <HTTPClient.h>
 #include "lvgl.h"
 #include "ui_common.h"
 #include <new>  // placement new for PSRAM device array
 #include "esp_memory_utils.h"  // esp_ptr_external_ram()
+// Note: #include <lwip/sockets.h> removed — SO_LINGER (CONFIG_LWIP_SO_LINGER) is NOT
+// compiled into the pioarduino pre-built ESP-IDF framework. sdkconfig.defaults has no
+// effect on pre-compiled libs. lwip_setsockopt(fd, SO_LINGER) always returns -1.
+// TCP teardowns use FIN → TIME_WAIT (120s, CONFIG_LWIP_TCP_MSL=60000ms, also fixed).
+// The 16-slot PCB pool (CONFIG_LWIP_MAX_SOCKETS=16) is managed by tcp_kill_timewait()
+// which auto-recycles oldest TIME_WAIT slot when pool is exhausted — no crash.
 
 // Command debounce tracking
 static uint32_t lastCommandTime = 0;
@@ -33,6 +40,8 @@ SonosController::SonosController() {
     uiUpdateQueue = NULL;
     networkTaskHandle = NULL;
     pollingTaskHandle = NULL;
+    networkTaskStack  = nullptr;
+    pollingTaskStack  = nullptr;
 }
 
 SonosController::~SonosController() {
@@ -85,12 +94,30 @@ void SonosController::begin() {
 
 void SonosController::startTasks() {
     if (networkTaskHandle == NULL) {
-        xTaskCreatePinnedToCore(networkTaskFunction, "SonosNet", SONOS_NET_TASK_STACK,
-                                this, SONOS_NET_TASK_PRIORITY, &networkTaskHandle, 1);
+        if (!networkTaskStack)
+            networkTaskStack = (StackType_t*)heap_caps_malloc(SONOS_NET_TASK_STACK, MALLOC_CAP_SPIRAM);
+        if (networkTaskStack) {
+            networkTaskHandle = xTaskCreateStaticPinnedToCore(
+                networkTaskFunction, "SonosNet", SONOS_NET_TASK_STACK / sizeof(StackType_t),
+                this, SONOS_NET_TASK_PRIORITY, networkTaskStack, &networkTaskTCB, 1);
+        } else {
+            Serial.println("[SONOS] Net PSRAM stack alloc failed — using internal SRAM");
+            xTaskCreatePinnedToCore(networkTaskFunction, "SonosNet", SONOS_NET_TASK_STACK,
+                                    this, SONOS_NET_TASK_PRIORITY, &networkTaskHandle, 1);
+        }
     }
     if (pollingTaskHandle == NULL) {
-        xTaskCreatePinnedToCore(pollingTaskFunction, "SonosPoll", SONOS_POLL_TASK_STACK,
-                                this, SONOS_POLL_TASK_PRIORITY, &pollingTaskHandle, 1);
+        if (!pollingTaskStack)
+            pollingTaskStack = (StackType_t*)heap_caps_malloc(SONOS_POLL_TASK_STACK, MALLOC_CAP_SPIRAM);
+        if (pollingTaskStack) {
+            pollingTaskHandle = xTaskCreateStaticPinnedToCore(
+                pollingTaskFunction, "SonosPoll", SONOS_POLL_TASK_STACK / sizeof(StackType_t),
+                this, SONOS_POLL_TASK_PRIORITY, pollingTaskStack, &pollingTaskTCB, 1);
+        } else {
+            Serial.println("[SONOS] Poll PSRAM stack alloc failed — using internal SRAM");
+            xTaskCreatePinnedToCore(pollingTaskFunction, "SonosPoll", SONOS_POLL_TASK_STACK,
+                                    this, SONOS_POLL_TASK_PRIORITY, &pollingTaskHandle, 1);
+        }
     }
     Serial.println("[SONOS] Background tasks started");
 }
@@ -175,31 +202,33 @@ String SonosController::sendSOAP(const char* service, const char* action, const 
     // Build SOAPAction header
     snprintf(soapAction, sizeof(soapAction), "urn:schemas-upnp-org:service:%s:1#%s", service, action);
 
-    // Simple, robust: Create fresh HTTPClient for each request (no pooling)
+    // Fresh HTTPClient per request — Sonos's embedded HTTP server does not support
+    // HTTP/1.1 keep-alive (persistent connections cause -1 / connection-refused errors).
     HTTPClient http;
     http.begin(url);
     http.setTimeout(2000);
     http.addHeader("Content-Type", "text/xml; charset=\"utf-8\"");
+    // Tell Sonos to close the connection after the response. Sonos already does this
+    // (no keep-alive per comment above), but making it explicit ensures the server
+    // sends its FIN immediately after the response body → FIN-wait loop (below) reliably
+    // detects CLOSE_WAIT → passive close → zero DMA cost per SOAP.
+    http.addHeader("Connection", "close");
 
     // Build full header value with quotes
     static char soapActionHeader[280];
     snprintf(soapActionHeader, sizeof(soapActionHeader), "\"%s\"", soapAction);
     http.addHeader("SOAPAction", soapActionHeader);
 
-    // PRE-WAIT: Wait for SDIO cooldown BEFORE acquiring mutex
-    // This prevents blocking other SOAP requests during cooldown waits
-    // SOAP itself is plain HTTP, but must also respect the HTTPS cooldown — lyrics fetches
-    // (lrclib.net, always HTTPS) leave TLS teardown traffic on SDIO for ~2000ms after release.
-    // Without this, SOAP fires instantly after lyrics releases the mutex and crashes SDIO RX.
-    {
-        unsigned long now = millis();
-        unsigned long elapsed = now - last_network_end_ms;
-        if (last_network_end_ms > 0 && elapsed < 200) {
-            vTaskDelay(pdMS_TO_TICKS(200 - elapsed));
-        }
-        unsigned long elapsed_https = millis() - last_https_end_ms;
-        if (last_https_end_ms > 0 && elapsed_https < 2000) {
-            vTaskDelay(pdMS_TO_TICKS(2000 - elapsed_https));
+    // PRE-WAIT: general 200ms cooldown only. SOAP is plain HTTP — it does NOT need the
+    // HTTPS cooldown (SDIO_HTTPS_COOLDOWN_MS = 3s). That cooldown was preventing SOAPs
+    // from firing for 3s after every lyrics fetch → SDIO DMA idled → pkt_rxbuff :928
+    // overflow when the next art download started on a cold DMA.
+    // mbedTLS DMA buffers from lyrics HTTPS are irrelevant to plain HTTP SOAP traffic.
+    // TCP FIN-ACKs from a prior HTTPS session drain within the 200ms general cooldown.
+    if (last_network_end_ms > 0) {
+        unsigned long elapsed = millis() - last_network_end_ms;
+        if (elapsed < SDIO_GENERAL_COOLDOWN_MS) {
+            vTaskDelay(pdMS_TO_TICKS(SDIO_GENERAL_COOLDOWN_MS - elapsed));
         }
     }
 
@@ -210,17 +239,12 @@ String SonosController::sendSOAP(const char* service, const char* action, const 
         return "";
     }
 
-    // POST-MUTEX re-check: SOAP may have been waiting on xSemaphoreTake while lyrics ran a full
-    // HTTPS session. The pre-wait check above is stale in that case — re-check both cooldowns
-    // now that we hold the mutex and know exactly when the previous session ended.
+    // POST-MUTEX re-check: another task may have used the network while we waited.
+    // General 200ms only — no HTTPS cooldown (see pre-wait comment above).
     {
         unsigned long elapsed = millis() - last_network_end_ms;
-        if (last_network_end_ms > 0 && elapsed < 200) {
-            vTaskDelay(pdMS_TO_TICKS(200 - elapsed));
-        }
-        unsigned long elapsed_https = millis() - last_https_end_ms;
-        if (last_https_end_ms > 0 && elapsed_https < 2000) {
-            vTaskDelay(pdMS_TO_TICKS(2000 - elapsed_https));
+        if (last_network_end_ms > 0 && elapsed < SDIO_GENERAL_COOLDOWN_MS) {
+            vTaskDelay(pdMS_TO_TICKS(SDIO_GENERAL_COOLDOWN_MS - elapsed));
         }
     }
 
@@ -233,11 +257,19 @@ String SonosController::sendSOAP(const char* service, const char* action, const 
         dev->connected = true;
     } else if (code == 500) {
         // Sonos returns 500 during source transitions (e.g. radio switching)
-        // This is transient - don't count as error
+        // This is transient - don't count as error.
+        // Read and discard the 500 response body: this lets the server send its FIN
+        // alongside/after the body → we reach CLOSE_WAIT → passive close → no TIME_WAIT.
+        http.getString();
+        last_transient_500_ms = millis();  // arm 3s storm gate in art task pre-wait (unthrottled)
         // Throttle logging to avoid spam (only log first 500 in a burst)
         static unsigned long last_500_log = 0;
         if (millis() - last_500_log > 2000) {  // 2s throttle
-            Serial.printf("[SOAP] Transient 500 for %s.%s (source changing)\n", service, action);
+            Serial.printf("[SOAP] Transient 500 for %s.%s | adlp=%d heap=%u dma=%u\n",
+                service, action,
+                (int)art_download_in_progress,
+                heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
+                heap_caps_get_free_size(MALLOC_CAP_DMA));
             last_500_log = millis();
         }
     } else {
@@ -268,7 +300,44 @@ String SonosController::sendSOAP(const char* service, const char* action, const 
         }
     }
 
+    // Passive close: wait up to 100ms for server's FIN to arrive.
+    // With Connection:close header, Sonos sends FIN immediately after response body.
+    // stream->connected() = false once lwIP receives FIN → we're in CLOSE_WAIT.
+    // http.end() from CLOSE_WAIT → LAST_ACK → CLOSED: server enters TIME_WAIT, not us.
+    // Result: zero DMA cost per SOAP. 100ms (was 20ms) gives more margin for Sonos FINs.
+    // Fallback: if no FIN in 100ms → active close (TIME_WAIT on our side, ~400B PCB DMA).
+    // DMA savings: even 50% passive-close success at 1 SOAP/300ms = ~3KB DMA saved per 300ms.
+    if (code == 200 || code == 500) {
+        if (WiFiClient* s = http.getStreamPtr()) {
+            for (int i = 0; i < 100 && s->connected(); i++)
+                vTaskDelay(pdMS_TO_TICKS(1));
+        }
+    }
+
+    // Measure DMA delta across http.end() to track per-SOAP PCB cost.
+    // Passive close (FIN already received → CLOSE_WAIT): delta ≈ 0, no TIME_WAIT.
+    // Active close fallback (no FIN in 5ms): delta ~6KB, TIME_WAIT on our side.
+    size_t dma_pre_end = heap_caps_get_free_size(MALLOC_CAP_DMA);
     http.end();
+    vTaskDelay(pdMS_TO_TICKS(1));  // allow lwIP to process RST/FIN synchronously
+    size_t dma_post_end = heap_caps_get_free_size(MALLOC_CAP_DMA);
+
+    // Per-SOAP DMA tracking: detects gradual DMA depletion from TIME_WAIT PCBs.
+    // Logs: every SOAP when DMA < 50KB (danger zone), else every 50 SOAPs.
+    {
+        static size_t session_start_dma = 0;
+        static int soap_count = 0;
+        if (session_start_dma == 0) session_start_dma = dma_post_end;
+        soap_count++;
+        int delta_end  = (int)((long)dma_post_end  - (long)dma_pre_end);
+        int delta_sess = (int)((long)dma_post_end  - (long)session_start_dma);
+        if (dma_post_end < 50000 || delta_end < -2048 || soap_count % 10 == 0) {
+            Serial.printf("[SOAP/DMA] #%d: pre=%uKB post=%uKB delta=%+dB session=%+dKB\n",
+                          soap_count,
+                          (unsigned)dma_pre_end/1024, (unsigned)dma_post_end/1024,
+                          delta_end, delta_sess/1024);
+        }
+    }
 
     // Update timestamp before releasing mutex (for SDIO cooldown tracking)
     last_network_end_ms = millis();
@@ -1255,12 +1324,18 @@ void SonosController::processCommand(CommandRequest_t* cmd) {
             break;
 
         case CMD_NEXT:
+            // Suppress pollingTask before the SOAP fires: art_download_in_progress=true blocks
+            // the early-exit guard. Without this, pollingTask races through during the 200ms
+            // vTaskDelay and fires GetPositionInfo concurrently with the Next SOAP + subsequent
+            // updateTrackInfo SOAP — 3 simultaneous TCP teardowns overflow C6 pkt_rxbuff → :928.
+            art_download_in_progress = true;
             sendSOAP("AVTransport", "Next", "<InstanceID>0</InstanceID>");
             vTaskDelay(pdMS_TO_TICKS(200));
-            updateTrackInfo();
+            updateTrackInfo();  // sets pending_art_url → requestAlbumArt() keeps flag true
             break;
 
         case CMD_PREV:
+            art_download_in_progress = true;  // same race fix as CMD_NEXT
             sendSOAP("AVTransport", "Previous", "<InstanceID>0</InstanceID>");
             vTaskDelay(pdMS_TO_TICKS(200));
             updateTrackInfo();
@@ -1320,6 +1395,11 @@ void SonosController::processCommand(CommandRequest_t* cmd) {
         }
 
         case CMD_PLAY_QUEUE_ITEM: {
+            Serial.printf("[CMD] PLAY_QUEUE_ITEM: track=%d | heap=%u dma=%u\n",
+                cmd->value,
+                heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
+                heap_caps_get_free_size(MALLOC_CAP_DMA));
+            art_download_in_progress = true;  // same race fix: suppress polling during Seek+Play+settle
             snprintf(args, sizeof(args),
                 "<InstanceID>0</InstanceID><Unit>TRACK_NR</Unit><Target>%d</Target>",
                 cmd->value);
@@ -1408,9 +1488,102 @@ void SonosController::pollingTaskFunction(void* param) {
         }
 
         if (dev && dev->connected) {
+            // ── Per-cycle DMA snapshot ────────────────────────────────────────────
+            // Log DMA at the START of every poll cycle (before any SOAP fires).
+            // This pinpoints exactly when/where the mystery 68KB drop occurs.
+            {
+                static size_t cycle_session_start = 0;
+                static uint32_t cycle_count = 0;
+                size_t dma_cycle = heap_caps_get_free_size(MALLOC_CAP_DMA);
+                if (cycle_session_start == 0) cycle_session_start = dma_cycle;
+                cycle_count++;
+                int cycle_delta = (int)((long)dma_cycle - (long)cycle_session_start);
+                // Log: every cycle when DMA < 60KB (danger zone), else every 20 cycles
+                if (dma_cycle < 60000 || cycle_count % 20 == 0) {
+                    Serial.printf("[POLL/DMA] cycle=%u dma=%uKB session=%+dKB art_dl=%d\n",
+                                  (unsigned)cycle_count,
+                                  (unsigned)(dma_cycle / 1024),
+                                  cycle_delta / 1024,
+                                  (int)art_download_in_progress);
+                }
+            }
+            // ── SDIO early-exit guard ─────────────────────────────────────────────
+            {
+                bool in_500_storm   = last_transient_500_ms > 0 &&
+                                      millis() - last_transient_500_ms < (SDIO_STORM_COOLDOWN_MS + SDIO_POST_STORM_SETTLE_MS);
+                bool post_download  = last_art_download_end_ms > 0 &&
+                                      millis() - last_art_download_end_ms < SDIO_INTER_DOWNLOAD_MS;
+                bool track_settling = last_track_change_ms > 0 &&
+                                      millis() - last_track_change_ms < SDIO_TRACK_CHANGE_SETTLE_MS;
+
+                // Art downloading (or post-download residue): skip ALL SOAPs, short sleep.
+                if (art_download_in_progress || post_download || track_settling) {
+                    static unsigned long last_poll_skip_log = 0;
+                    if (millis() - last_poll_skip_log > 2000) {
+                        Serial.printf("[POLL] Skip: art_dl=%d post_dl=%d settling=%d\n",
+                            (int)art_download_in_progress, (int)post_download, (int)track_settling);
+                        last_poll_skip_log = millis();
+                    }
+                    vTaskDelay(pdMS_TO_TICKS(track_settling ? 1000 : POLL_BASE_INTERVAL_MS));
+                    continue;
+                }
+
+                // NOTE: in_500_storm early-exit REMOVED.
+                // Sleeping 1000ms during 500-storm caused SDIO idle → C6 DMA clock-gate →
+                // pkt_rxbuff overflow when art download started (intermittent :928 crash).
+                // The protection it provided (preventing SOAP FIN-ACKs from competing with
+                // art burst) is already handled by:
+                //   (a) art inside-mutex post-500 drain (SDIO_TCP_CLOSE_MS = 200ms)
+                //   (b) art_download_in_progress=true blocking polling during actual download
+                //   (c) post-SOAP-1 guard (in_500_now) skipping updatePlaybackState
+                // Polling now fires at normal rate during 500-storm, keeping SDIO warm.
+                // One SOAP per 300ms cycle (only updateTrackInfo fires; post-SOAP-1 guard
+                // blocks updatePlaybackState when in_500_now=true). Harmless traffic.
+                (void)in_500_storm;
+            }
+            // ─────────────────────────────────────────────────────────────────────
+
             // Track info every cycle for instant updates when changing sources
             ctrl->updateTrackInfo();
+
+            // ── Post-SOAP-1 guard ─────────────────────────────────────────────────
+            // updateTrackInfo() calls onSonosUpdate() which may set pending_art_url
+            // synchronously (same task). If a track just changed, skip GetTransportInfo
+            // this cycle — its SOAP response + UPnP NOTIFY burst overlap in pkt_rxbuff.
+            // Guard uses pending != last (not just isEmpty) so it clears once the art
+            // task downloads and syncs them. isEmpty() never cleared → d->isPlaying stuck.
+            // in_500_now: also skip GetTransportInfo when GetPositionInfo just returned
+            // 500 — both SOAP responses + Sonos NOTIFYs in same cycle overflow pkt_rxbuff.
+            // Timeout (10s): if art permanently fails (DMA floor), guard would fire forever
+            // → updatePlaybackState() never runs → progress bar freezes. After 10s we give
+            // up waiting and let GetTransportInfo through so playback state stays live.
+            {
+                bool in_500_now = last_transient_500_ms > 0 &&
+                                  millis() - last_transient_500_ms < SDIO_STORM_COOLDOWN_MS;
+                bool art_still_pending = pending_art_url != last_art_url &&
+                                         last_track_change_ms > 0 &&
+                                         millis() - last_track_change_ms < 10000;
+                if (art_still_pending || in_500_now) {
+                    tick++;
+                    vTaskDelay(pdMS_TO_TICKS(POLL_BASE_INTERVAL_MS));
+                    continue;
+                }
+            }
+
             ctrl->updatePlaybackState();
+
+            // ── Mid-cycle guard ───────────────────────────────────────────────────
+            // art task wakes within 100ms of requestAlbumArt() setting pending_art_url.
+            // Until then, skip optional SOAPs — their responses land in pkt_rxbuff at
+            // the same time as the UPnP NOTIFY burst from the new track.
+            // Use !isEmpty() (not pending!=last) — isEmpty() clears only when art URL
+            // disappears (radio to no-art), never during stable playback. This ensures
+            // optional SOAPs stay suppressed for the full NOTIFY storm window.
+            if (art_download_in_progress || !pending_art_url.isEmpty()) {
+                tick++;
+                continue;
+            }
+            // ─────────────────────────────────────────────────────────────────────
 
             // Detect station change and fetch station name immediately
             if (dev->isRadioStation && dev->currentURI != previousURI) {
@@ -1441,9 +1614,22 @@ void SonosController::pollingTaskFunction(void* param) {
                 ctrl->updateTransportSettings();
             }
 
-            // Queue polling - skip for radio stations
+            // Queue polling - skip for radio stations and when DMA is low.
+            // updateQueue() returns ~20KB Browse response. Confirmed: firing it when
+            // DMA is already depleted (WiFi dynamic buffers allocated) pushes DMA floor
+            // further and triggers the WiFi buffer full-allocation event (~71KB one-time
+            // drop). Gate on DMA > ART_MIN_DMA_PRE_BURST (36KB) — if DMA is below the
+            // art download threshold, the queue poll residue would prevent art from loading
+            // anyway, so skipping it has no functional cost.
             if (tick % POLL_QUEUE_MODULO == 0 && !dev->isRadioStation) {
-                ctrl->updateQueue();
+                size_t dma_now = heap_caps_get_free_size(MALLOC_CAP_DMA);
+                if (dma_now >= ART_MIN_DMA_PRE_BURST) {
+                    ctrl->updateQueue();
+                    vTaskDelay(pdMS_TO_TICKS(SDIO_POST_QUEUE_DRAIN_MS));
+                } else {
+                    Serial.printf("[POLL] Queue poll skipped: DMA too low (%uKB < %uKB)\n",
+                                  (unsigned)(dma_now / 1024), (unsigned)(ART_MIN_DMA_PRE_BURST / 1024));
+                }
             }
 
             tick++;

--- a/src/sonos_controller.cpp
+++ b/src/sonos_controller.cpp
@@ -1229,22 +1229,35 @@ bool SonosController::updateTransportSettings() {
     return false;
 }
 
-bool SonosController::updateQueue() {
-    String resp = sendSOAP("ContentDirectory", "Browse",
+bool SonosController::updateQueue(int startIndex) {
+    // SONOS_QUEUE_BATCH_SIZE=10 → ~4KB response, ~3 WiFi RX buffers.
+    // Was 50 items → ~20KB, 14 TCP segs, all 32 WiFi RX buffers (~51KB DMA) — never released.
+    // startIndex: 0-based offset into queue. For a window centred on currentTrackNumber:
+    //   startIndex = max(0, currentTrackNumber - SONOS_QUEUE_BATCH_SIZE/2)
+    // so the view shows ~5 tracks before and ~5 after the currently playing track.
+    if (startIndex < 0) startIndex = 0;
+
+    String queueArgs =
         "<ObjectID>Q:0</ObjectID>"
         "<BrowseFlag>BrowseDirectChildren</BrowseFlag>"
         "<Filter>*</Filter>"
-        "<StartingIndex>0</StartingIndex>"
-        "<RequestedCount>50</RequestedCount>"
-        "<SortCriteria></SortCriteria>");
-    
+        "<StartingIndex>" + String(startIndex) + "</StartingIndex>"
+        "<RequestedCount>" + String(SONOS_QUEUE_BATCH_SIZE) + "</RequestedCount>"
+        "<SortCriteria></SortCriteria>";
+
+    size_t dma_pre_q = heap_caps_get_free_size(MALLOC_CAP_DMA);
+    String resp = sendSOAP("ContentDirectory", "Browse", queueArgs.c_str());
+    size_t dma_post_q = heap_caps_get_free_size(MALLOC_CAP_DMA);
+    Serial.printf("[QUEUE/DMA] pre=%uKB post=%uKB delta=%+dB start=%d batch=%d\n",
+                  (unsigned)(dma_pre_q / 1024), (unsigned)(dma_post_q / 1024),
+                  (int)((long)dma_post_q - (long)dma_pre_q), startIndex, SONOS_QUEUE_BATCH_SIZE);
+
     if (resp.length() == 0) {
         Serial.printf("[SONOS] Queue response empty\n");
         return false;
     }
 
-    // Large XML response (~50 items, ~20KB) stresses SDIO RX pool. Record completion
-    // time so the art task can wait before starting a large download after this.
+    // Record completion time so art/lyrics tasks wait before starting a large download.
     // sendSOAP() does NOT check this — SOAP play/pause commands are unaffected.
     last_queue_fetch_time = millis();
 
@@ -1279,7 +1292,7 @@ bool SonosController::updateQueue() {
             dev->queue[dev->queueSize].artist = decodeHTML(extractXMLRange(result, "dc:creator", itemStart, itemEnd));
             dev->queue[dev->queueSize].album = decodeHTML(extractXMLRange(result, "upnp:album", itemStart, itemEnd));
             dev->queue[dev->queueSize].albumArtURL = decodeHTML(extractXMLRange(result, "upnp:albumArtURI", itemStart, itemEnd));
-            dev->queue[dev->queueSize].trackNumber = dev->queueSize + 1;
+            dev->queue[dev->queueSize].trackNumber = startIndex + dev->queueSize + 1;  // 1-based absolute position
             dev->queueSize++;
 
             pos = itemEnd + 7;
@@ -1572,14 +1585,48 @@ void SonosController::pollingTaskFunction(void* param) {
 
             ctrl->updatePlaybackState();
 
+            // ── On-demand queue window fetch ──────────────────────────────────────
+            // Placed here (after both mandatory SOAPs, BEFORE mid-cycle guard) so
+            // it executes even during stable playback when pending==last_art_url.
+            // Two triggers:
+            //   (a) User opens queue screen / taps refresh → ev_queue() sets flag
+            //   (b) Track number changed → auto-set below so Next Up stays current
+            {
+                static int lastQueuedTrackNum = -1;
+                // Auto-trigger when track number changes (keeps Next Up populated)
+                if (!dev->isRadioStation && dev->currentTrackNumber > 0 &&
+                    dev->currentTrackNumber != lastQueuedTrackNum) {
+                    int half  = SONOS_QUEUE_BATCH_SIZE / 2;
+                    int start = dev->currentTrackNumber - half;
+                    if (start < 0) start = 0;
+                    if (dev->totalTracks > 0 && start + SONOS_QUEUE_BATCH_SIZE > dev->totalTracks)
+                        start = dev->totalTracks - SONOS_QUEUE_BATCH_SIZE;
+                    if (start < 0) start = 0;
+                    queue_fetch_start_index = start;
+                    queue_fetch_requested   = true;
+                    lastQueuedTrackNum = dev->currentTrackNumber;
+                }
+
+                if (queue_fetch_requested) {
+                    queue_fetch_requested = false;
+                    size_t dma_now = heap_caps_get_free_size(MALLOC_CAP_DMA);
+                    if (dma_now >= ART_MIN_DMA_PRE_BURST) {
+                        ctrl->updateQueue(queue_fetch_start_index);
+                        vTaskDelay(pdMS_TO_TICKS(SDIO_POST_QUEUE_DRAIN_MS));
+                    } else {
+                        Serial.printf("[POLL] Queue fetch deferred: DMA too low (%uKB)\n",
+                                      (unsigned)(dma_now / 1024));
+                        queue_fetch_requested = true;  // retry next cycle
+                    }
+                }
+            }
+
             // ── Mid-cycle guard ───────────────────────────────────────────────────
-            // art task wakes within 100ms of requestAlbumArt() setting pending_art_url.
-            // Until then, skip optional SOAPs — their responses land in pkt_rxbuff at
-            // the same time as the UPnP NOTIFY burst from the new track.
-            // Use !isEmpty() (not pending!=last) — isEmpty() clears only when art URL
-            // disappears (radio to no-art), never during stable playback. This ensures
-            // optional SOAPs stay suppressed for the full NOTIFY storm window.
-            if (art_download_in_progress || !pending_art_url.isEmpty()) {
+            // Skip optional SOAPs while a new track's art is still pending download.
+            // Guard clears once the art task downloads and syncs pending_art_url=last_art_url.
+            // Uses != last_art_url (NOT !isEmpty()): isEmpty() is true for any stream with
+            // art → would block volume/transport/queue polling forever during stable playback.
+            if (art_download_in_progress || pending_art_url != last_art_url) {
                 tick++;
                 continue;
             }
@@ -1614,17 +1661,18 @@ void SonosController::pollingTaskFunction(void* param) {
                 ctrl->updateTransportSettings();
             }
 
-            // Queue polling - skip for radio stations and when DMA is low.
-            // updateQueue() returns ~20KB Browse response. Confirmed: firing it when
-            // DMA is already depleted (WiFi dynamic buffers allocated) pushes DMA floor
-            // further and triggers the WiFi buffer full-allocation event (~71KB one-time
-            // drop). Gate on DMA > ART_MIN_DMA_PRE_BURST (36KB) — if DMA is below the
-            // art download threshold, the queue poll residue would prevent art from loading
-            // anyway, so skipping it has no functional cost.
+            // Background queue refresh every POLL_QUEUE_MODULO cycles (60s).
+            // Uses windowed fetch centred on currentTrackNumber — same window as on-demand.
             if (tick % POLL_QUEUE_MODULO == 0 && !dev->isRadioStation) {
                 size_t dma_now = heap_caps_get_free_size(MALLOC_CAP_DMA);
                 if (dma_now >= ART_MIN_DMA_PRE_BURST) {
-                    ctrl->updateQueue();
+                    int half  = SONOS_QUEUE_BATCH_SIZE / 2;
+                    int start = (dev->currentTrackNumber > 0) ? (dev->currentTrackNumber - half) : 0;
+                    if (start < 0) start = 0;
+                    if (dev->totalTracks > 0 && start + SONOS_QUEUE_BATCH_SIZE > dev->totalTracks)
+                        start = dev->totalTracks - SONOS_QUEUE_BATCH_SIZE;
+                    if (start < 0) start = 0;
+                    ctrl->updateQueue(start);
                     vTaskDelay(pdMS_TO_TICKS(SDIO_POST_QUEUE_DRAIN_MS));
                 } else {
                     Serial.printf("[POLL] Queue poll skipped: DMA too low (%uKB < %uKB)\n",

--- a/src/ui_album_art.cpp
+++ b/src/ui_album_art.cpp
@@ -10,6 +10,9 @@
 
 #include "ui_common.h"
 #include "config.h"
+#include "ui_network_guard.h"
+#include <lwip/sockets.h>   // lwip_setsockopt / SO_RCVBUF
+#include <lwip/netdb.h>     // getaddrinfo / freeaddrinfo (for artPreConnectHTTP)
 #include <PNGdec.h>
 // Undefine shared macros from PNGdec before JPEGDEC redefines them (same author, same macros)
 #undef INTELSHORT
@@ -30,6 +33,118 @@ extern bool decodeJPEGProgressiveStb(const uint8_t* buf, size_t len,
 static uint16_t* sw_jpeg_output = nullptr;
 static int sw_jpeg_width = 0;
 static int sw_jpeg_height = 0;
+
+// ── Pre-connect helpers (SO_RCVBUF BEFORE TCP SYN) ───────────────────────────
+// Root cause of pkt_rxbuff :928: server blasts initial TCP cwnd (~10 segments)
+// into C6 pkt_rxbuff before P4 lwIP can ACK. After a storm-gate idle (3s),
+// SDIO DMA may have clock-gated; the wake latency means even 10 segments can
+// overflow the 42-slot buffer pool. Setting SO_RCVBUF AFTER http.GET() is too
+// late — the SYN-ACK has already advertised the 65534-byte default window.
+// Fix: create the socket manually, set SO_RCVBUF=ART_TCP_RCVBUF BEFORE
+// lwip_connect() so the TCP SYN-ACK advertises the constrained window (8192 bytes,
+// ~6 segments max burst). HTTPClient::connect() reuses the pre-connected socket
+// instead of reconnecting (it checks connected() first — returns true).
+
+// Parse "http://HOST:PORT/PATH" URL. Fills host_buf, *port_out. Returns true on success.
+static bool artParseHttpHost(const char* url, char* host_buf, size_t host_buf_len, uint16_t* port_out) {
+    if (strncmp(url, "http://", 7) != 0) return false;
+    const char* p = url + 7;
+    const char* slash = strchr(p, '/');
+    size_t auth_len = slash ? (size_t)(slash - p) : strlen(p);
+    const char* colon = (const char*)memchr(p, ':', auth_len);
+    size_t host_len;
+    if (colon) {
+        host_len = (size_t)(colon - p);
+        *port_out = (uint16_t)atoi(colon + 1);
+    } else {
+        host_len = auth_len;
+        *port_out = 80;
+    }
+    if (host_len == 0 || host_len >= host_buf_len) return false;
+    memcpy(host_buf, p, host_len);
+    host_buf[host_len] = '\0';
+    return true;
+}
+
+// Pre-connect HTTP socket with SO_RCVBUF set BEFORE TCP SYN.
+// Returns connected WiFiClient on success, unconnected on failure (caller falls back to http.begin(url)).
+static WiFiClient artPreConnectHTTP(const char* url, int timeout_ms) {
+    char host[128];
+    uint16_t port = 80;
+    if (!artParseHttpHost(url, host, sizeof(host), &port)) return WiFiClient();
+
+    // Resolve host (IP string → no DNS; hostname → DNS query)
+    struct addrinfo hints = {}, *res = nullptr;
+    hints.ai_family   = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    char port_str[8];
+    snprintf(port_str, sizeof(port_str), "%u", (unsigned)port);
+    if (getaddrinfo(host, port_str, &hints, &res) != 0 || !res) return WiFiClient();
+
+    int sockfd = lwip_socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0) { freeaddrinfo(res); return WiFiClient(); }
+
+    // KEY: set SO_RCVBUF BEFORE lwip_connect() so the TCP SYN-ACK advertises
+    // ART_TCP_RCVBUF as the receive window → server limited to ~6 segments/burst.
+    int rcvbuf = ART_TCP_RCVBUF;
+    lwip_setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+
+    // Non-blocking connect with select timeout (matches NetworkClient::connect())
+    fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL, 0) | O_NONBLOCK);
+    lwip_connect(sockfd, res->ai_addr, res->ai_addrlen);
+    freeaddrinfo(res);
+
+    fd_set fdset;
+    struct timeval tv;
+    FD_ZERO(&fdset); FD_SET(sockfd, &fdset);
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    if (lwip_select(sockfd + 1, nullptr, &fdset, nullptr, &tv) <= 0) {
+        lwip_close(sockfd); return WiFiClient();
+    }
+    int sockerr = 0; socklen_t slen = sizeof(int);
+    lwip_getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &sockerr, &slen);
+    if (sockerr != 0) { lwip_close(sockfd); return WiFiClient(); }
+
+    // Set timeouts, switch back to blocking (matches NetworkClient::connect())
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    lwip_setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    lwip_setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL, 0) & (~O_NONBLOCK));
+
+    // Set SO_RCVBUF AGAIN now that the PCB exists (PCB is created by lwip_connect()).
+    // The pre-connect setsockopt (line ~90) races with the SYN: the PCB doesn't exist
+    // yet, so lwIP cannot apply the window constraint to the SYN. The server sees the
+    // default TCP_WND (65534) and can blast up to 65KB immediately. By setting SO_RCVBUF
+    // here — after the 3-way handshake completes but BEFORE the GET request is sent —
+    // lwIP updates pcb->rcv_wnd to 8192. The GET's ACK will carry this small window.
+    // Server sees window=8192 and limits its initial response burst to ~6KB → safe.
+    lwip_setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+
+    return WiFiClient(sockfd);  // NetworkClient(int fd) — marks as _connected=true
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Diagnostic logging helpers ────────────────────────────────────────────────
+static void artLogSDIO(const char* tag) {
+    unsigned long now = millis();
+    Serial.printf("[ART/%s] SDIO: 500=%ldms net=%ldms https=%ldms q=%ldms art_end=%ldms adlp=%d\n", tag,
+        last_transient_500_ms    ? (long)(now - last_transient_500_ms)    : -1L,
+        last_network_end_ms      ? (long)(now - last_network_end_ms)      : -1L,
+        last_https_end_ms        ? (long)(now - last_https_end_ms)        : -1L,
+        last_queue_fetch_time    ? (long)(now - last_queue_fetch_time)    : -1L,
+        last_art_download_end_ms ? (long)(now - last_art_download_end_ms) : -1L,
+        (int)art_download_in_progress);
+}
+static void artLogMem(const char* tag) {
+    Serial.printf("[ART/%s] MEM: heap=%u dma=%u psram=%u stk=%u\n", tag,
+        heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
+        heap_caps_get_free_size(MALLOC_CAP_DMA),
+        heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
+        uxTaskGetStackHighWaterMark(NULL));
+}
+// ─────────────────────────────────────────────────────────────────────────────
 
 // Album Art Functions
 static uint32_t color_r_sum = 0, color_g_sum = 0, color_b_sum = 0;
@@ -329,6 +444,295 @@ static int pngDraw(PNGDRAW* pDraw) {
     return 1;  // Continue decoding
 }
 
+// ── Decode result ─────────────────────────────────────────────────────────────
+struct DecodeResult {
+    uint16_t* pixels;  // PSRAM RGB565 buffer; caller must heap_caps_free() if ok==true
+    int       w;       // actual image width
+    int       h;       // actual image height
+    int       stride;  // row pitch in pixels (may differ from w for HW JPEG padded output)
+    bool      ok;
+};
+static const DecodeResult kDecodeFail = {nullptr, 0, 0, 0, false};
+
+// ── Unified decode dispatcher ──────────────────────────────────────────────────
+// Detects format, strips COM markers, dispatches to the appropriate decoder.
+// On success: returns allocated PSRAM RGB565 buffer — caller must heap_caps_free(result.pixels).
+// On failure: returns kDecodeFail (pixels==nullptr).
+static DecodeResult decodeToRGB565(uint8_t* buf, size_t len, bool isJPEG, bool isPNG) {
+
+    // ── PNG PATH ──────────────────────────────────────────────────────────────
+    if (isPNG) {
+        int pngResult = png.openRAM(buf, (int)len, pngDraw);
+        if (pngResult != 0) {
+            Serial.printf("[ART] PNG openRAM failed - error code: %d\n", pngResult);
+            return kDecodeFail;
+        }
+        int w = png.getWidth();
+        int h = png.getHeight();
+        if (w <= 0 || h <= 0 || w > 2048 || h > 2048 || (size_t)w * h * 2 > 10 * 1024 * 1024) {
+            Serial.printf("[ART] Invalid PNG dimensions: %dx%d (max 2048x2048, 10MB)\n", w, h);
+            png.close();
+            return kDecodeFail;
+        }
+        size_t decoded_size = (size_t)w * h * 2;
+        uint16_t* decoded_buffer = (uint16_t*)heap_caps_malloc(decoded_size, MALLOC_CAP_SPIRAM);
+        if (!decoded_buffer) {
+            Serial.printf("[ART] Failed to allocate %d bytes for decoded image\n", (int)decoded_size);
+            png.close();
+            return kDecodeFail;
+        }
+        memset(decoded_buffer, 0, decoded_size);
+
+        // Set globals for pngDraw callback
+        jpeg_decode_buffer  = decoded_buffer;
+        jpeg_image_width    = w;
+        jpeg_image_height   = h;
+        jpeg_output_width   = 0;
+        jpeg_output_height  = 0;
+
+        png.decode(NULL, 0);
+        png.close();
+        jpeg_decode_buffer = nullptr;
+
+        // Compact step: if callback only wrote a sub-region, crop to actual output
+        int out_w = (jpeg_output_width  > 0) ? jpeg_output_width  : w;
+        int out_h = (jpeg_output_height > 0) ? jpeg_output_height : h;
+
+        uint16_t* src_buffer = decoded_buffer;
+        if (out_w != w || out_h != h) {
+            size_t compact_size = (size_t)out_w * out_h * 2;
+            uint16_t* compact_buffer = (uint16_t*)heap_caps_malloc(compact_size, MALLOC_CAP_SPIRAM);
+            if (compact_buffer) {
+                for (int y = 0; y < out_h; y++)
+                    memcpy(compact_buffer + (size_t)y * out_w,
+                           decoded_buffer + (size_t)y * w,
+                           out_w * 2);
+                heap_caps_free(decoded_buffer);
+                src_buffer = compact_buffer;
+            } else {
+                // compact alloc failed — use full decoded_buffer with original dims
+                out_w = w;
+                out_h = h;
+            }
+        }
+        return {src_buffer, out_w, out_h, out_w, true};
+    }
+
+    // ── JPEG PATH ─────────────────────────────────────────────────────────────
+    if (isJPEG) {
+
+        if (hw_jpeg_decoder) {
+            // Step 0: strip COM markers (0xFFFE) — HW decoder returns error 258 on them
+            size_t cleaned_size = len;
+            {
+                uint8_t* p   = buf;
+                uint8_t* end = buf + len;
+                uint8_t* dst = buf;
+                while (p + 3 < end) {
+                    if (p[0] == 0xFF && p[1] == 0xFE) {
+                        uint16_t marker_len = ((uint16_t)p[2] << 8) | p[3];
+                        if (marker_len < 2) break;
+                        p += 2 + marker_len;
+                        continue;
+                    }
+                    if (dst != p) *dst = *p;
+                    dst++; p++;
+                }
+                while (p < end) { if (dst != p) *dst = *p; dst++; p++; }
+                cleaned_size = (size_t)(dst - buf);
+            }
+
+            // Step 0b: scan for SOF2 (progressive JPEG marker)
+            bool is_progressive = false;
+            bool use_sw_fallback = false;
+            for (size_t pi = 0; pi + 1 < cleaned_size; pi++) {
+                if (buf[pi] == 0xFF && buf[pi+1] == 0xC2) { is_progressive = true; break; }
+            }
+            if (is_progressive) use_sw_fallback = true;
+
+            // Step 1: HW header parse
+            jpeg_decode_picture_info_t pic_info = {};
+            uint16_t* decoded_pixels = nullptr;
+            int final_w = 0, final_h = 0, final_stride = 0;
+            bool hw_decode_success = false;
+
+            if (!use_sw_fallback) {
+                esp_err_t hw_ret = jpeg_decoder_get_info(buf, cleaned_size, &pic_info);
+                int w = (int)pic_info.width;
+                int h = (int)pic_info.height;
+                if (hw_ret == ESP_OK && w == 0 && h == 0) {
+                    // Progressive detected by HW parser
+                    use_sw_fallback = true;
+                    is_progressive  = true;
+                } else if (hw_ret != ESP_OK) {
+                    Serial.printf("[ART] HW header parse failed: %d, trying SW fallback\n", hw_ret);
+                    use_sw_fallback = true;
+                } else if (w <= 0 || h <= 0 || w > 2048 || h > 2048) {
+                    Serial.printf("[ART] JPEG dimensions out of range: %dx%d\n", w, h);
+                    return kDecodeFail;
+                } else {
+                    bool hw_compatible = (w % 8 == 0) && (h % 8 == 0);
+                    if (!hw_compatible) {
+                        Serial.printf("[ART] JPEG %dx%d not HW-compatible (non-div-8), using SW fallback\n", w, h);
+                        use_sw_fallback = true;
+                    } else {
+                        // HW FAST PATH
+                        int out_w = ((w + 15) / 16) * 16;
+                        int out_h = ((h + 15) / 16) * 16;
+                        bool is_grayscale = (pic_info.sample_method == JPEG_DOWN_SAMPLING_GRAY);
+                        Serial.printf("[ART] JPEG: %dx%d (output: %dx%d)%s\n", w, h, out_w, out_h,
+                                      is_grayscale ? " [GRAYSCALE]" : "");
+                        size_t bytes_per_pixel = is_grayscale ? 1 : 2;
+                        size_t decoded_size_hw = (size_t)out_w * out_h * bytes_per_pixel;
+                        jpeg_decode_memory_alloc_cfg_t rx_mem_cfg = {
+                            .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER
+                        };
+                        size_t rx_buffer_size = 0;
+                        uint8_t* hw_out_buf = (uint8_t*)jpeg_alloc_decoder_mem(decoded_size_hw,
+                                                                                &rx_mem_cfg,
+                                                                                &rx_buffer_size);
+                        if (!hw_out_buf) {
+                            Serial.printf("[ART] DMA alloc failed (%d bytes), trying SW fallback\n",
+                                          (int)decoded_size_hw);
+                            use_sw_fallback = true;
+                        } else {
+                            jpeg_decode_cfg_t decode_cfg = {
+                                .output_format = is_grayscale ? JPEG_DECODE_OUT_FORMAT_GRAY
+                                                              : JPEG_DECODE_OUT_FORMAT_RGB565,
+                                .rgb_order     = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,
+                                .conv_std      = JPEG_YUV_RGB_CONV_STD_BT601,
+                            };
+                            uint32_t out_size = 0;
+                            esp_err_t hw_ret2 = jpeg_decoder_process(hw_jpeg_decoder, &decode_cfg,
+                                                                      buf, cleaned_size,
+                                                                      hw_out_buf, rx_buffer_size,
+                                                                      &out_size);
+                            if (hw_ret2 != ESP_OK) {
+                                Serial.printf("[ART] HW decode failed: %d, trying SW fallback\n", hw_ret2);
+                                heap_caps_free(hw_out_buf);
+                                use_sw_fallback = true;
+                            } else {
+                                if (is_grayscale) {
+                                    Serial.println("[ART] Converting grayscale to RGB565");
+                                    uint16_t* rgb_buf = (uint16_t*)heap_caps_malloc(
+                                        (size_t)out_w * out_h * 2, MALLOC_CAP_SPIRAM);
+                                    if (rgb_buf) {
+                                        for (int i = 0; i < out_w * out_h; i++) {
+                                            uint8_t g = hw_out_buf[i];
+                                            rgb_buf[i] = ((g >> 3) << 11) | ((g >> 2) << 5) | (g >> 3);
+                                        }
+                                        heap_caps_free(hw_out_buf);
+                                        hw_out_buf = (uint8_t*)rgb_buf;
+                                    } else {
+                                        heap_caps_free(hw_out_buf);
+                                        hw_ret2 = ESP_FAIL;
+                                        use_sw_fallback = true;
+                                    }
+                                }
+                                if (hw_ret2 == ESP_OK) {
+                                    Serial.printf("[ART] HW decoded: %u bytes\n", out_size);
+                                    decoded_pixels   = (uint16_t*)hw_out_buf;
+                                    final_w          = w;
+                                    final_h          = h;
+                                    final_stride     = out_w;
+                                    hw_decode_success = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Step 2: SW fallback
+            if (use_sw_fallback && !hw_decode_success) {
+                uint16_t* sw_buf = nullptr;
+                int sw_w = 0, sw_h = 0;
+                bool sw_ok;
+                if (is_progressive) {
+                    Serial.println("[ART] Progressive JPEG → stb_image decode");
+                    sw_ok = decodeJPEGProgressiveStb(buf, cleaned_size, &sw_buf, &sw_w, &sw_h);
+                } else {
+                    sw_ok = decodeJPEGSoftware(buf, cleaned_size, &sw_buf, &sw_w, &sw_h);
+                }
+                if (sw_ok) {
+                    decoded_pixels   = sw_buf;
+                    final_w          = sw_w;
+                    final_h          = sw_h;
+                    final_stride     = sw_w;
+                    hw_decode_success = true;
+                }
+            }
+
+            if (hw_decode_success && decoded_pixels)
+                return {decoded_pixels, final_w, final_h, final_stride, true};
+            return kDecodeFail;
+
+        } else {
+            // hw_jpeg_decoder == nullptr — SW-only path
+            // FIX: scan for SOF2 so progressive JPEGs route to stb_image (not JPEGDEC)
+            bool is_progressive = false;
+            for (size_t pi = 0; pi + 1 < len; pi++) {
+                if (buf[pi] == 0xFF && buf[pi+1] == 0xC2) { is_progressive = true; break; }
+            }
+            uint16_t* sw_buf = nullptr;
+            int sw_w = 0, sw_h = 0;
+            bool sw_ok;
+            if (is_progressive) {
+                Serial.println("[ART] Progressive JPEG → stb_image decode (HW unavailable)");
+                sw_ok = decodeJPEGProgressiveStb(buf, len, &sw_buf, &sw_w, &sw_h);
+            } else {
+                Serial.println("[ART] HW JPEG unavailable, using SW decode");
+                sw_ok = decodeJPEGSoftware(buf, len, &sw_buf, &sw_w, &sw_h);
+            }
+            if (sw_ok) return {sw_buf, sw_w, sw_h, sw_w, true};
+            return kDecodeFail;
+        }
+    }
+
+    // Unknown format
+    Serial.println("[ART] Unknown image format (not JPEG or PNG)");
+    return kDecodeFail;
+}
+
+// ── Scale decoded pixels to 420×420 and push to display ───────────────────────
+static void displayArt(const DecodeResult& dec, const char* url) {
+    memset(art_temp_buffer, 0, ART_SIZE * ART_SIZE * 2);
+    Serial.printf("[ART] Bilinear scaling %dx%d -> 420x420 (stride=%d)\n", dec.w, dec.h, dec.stride);
+    scaleImageBilinear(dec.pixels, dec.w, dec.h, dec.stride, art_temp_buffer, ART_SIZE, ART_SIZE);
+    Serial.println("[ART] Scaling complete");
+
+    sampleDominantColor(art_temp_buffer, ART_SIZE, ART_SIZE);
+    uint32_t new_color = 0x1a1a1a;
+    if (color_sample_count > 0) {
+        uint8_t avg_r = color_r_sum / color_sample_count;
+        uint8_t avg_g = color_g_sum / color_sample_count;
+        uint8_t avg_b = color_b_sum / color_sample_count;
+        avg_r = (avg_r * 4) / 10;
+        avg_g = (avg_g * 4) / 10;
+        avg_b = (avg_b * 4) / 10;
+        new_color = ((uint32_t)avg_r << 16) | ((uint32_t)avg_g << 8) | avg_b;
+    }
+
+    if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
+        memcpy(art_buffer, art_temp_buffer, ART_SIZE * ART_SIZE * 2);
+        last_art_url   = url;
+        dominant_color = new_color;
+        art_ready      = true;
+        color_ready    = true;
+        xSemaphoreGive(art_mutex);
+    }
+
+    if (art_cache[0].pixels && art_cache[1].pixels) {
+        int slot = 1 - art_cache_lru;
+        memcpy(art_cache[slot].pixels, art_temp_buffer, ART_SIZE * ART_SIZE * 2);
+        strncpy(art_cache[slot].url, url, sizeof(art_cache[slot].url) - 1);
+        art_cache[slot].url[sizeof(art_cache[slot].url) - 1] = '\0';
+        art_cache[slot].dominant_color = new_color;
+        art_cache[slot].valid          = true;
+        art_cache_lru = slot;
+    }
+}
+
 // Prepare and sanitize album art URL
 // Handles: HTML entity decoding, Sonos Radio URL extraction, size reduction, URL encoding
 static String prepareAlbumArtURL(const String& rawUrl) {
@@ -483,9 +887,6 @@ void albumArtTask(void* param) {
     static char last_failed_url[512] = "";  // Track failed URLs to prevent infinite retry
     static int consecutive_failures = 0;
 
-    // Temporary buffer for decoded full-size image
-    uint16_t* decoded_buffer = nullptr;
-
     while (1) {
         // Check if shutdown requested (for OTA update)
         if (art_shutdown_requested) {
@@ -530,7 +931,26 @@ void albumArtTask(void* param) {
             }
             xSemaphoreGive(art_mutex);
         }
+        if (url[0] == '\0') {
+            // No URL pending. If a download just completed, flag=true (set after sdioPreWait).
+            // Keep it true for SDIO_INTER_DOWNLOAD_MS so that if a back-to-back URL arrives,
+            // the url!='\0' path below clears it before sdioPreWait (where polling runs).
+            // After SDIO_INTER_DOWNLOAD_MS with no new URL, clear it — nothing is downloading.
+            if (last_art_download_end_ms == 0 ||
+                millis() - last_art_download_end_ms >= SDIO_INTER_DOWNLOAD_MS) {
+                art_download_in_progress = false;  // nothing to download — polling can resume
+            }
+            vTaskDelay(pdMS_TO_TICKS(ART_CHECK_INTERVAL_MS));
+            continue;
+        }
         if (url[0] != '\0') {
+            // Clear flag BEFORE sdioPreWait so polling keeps SDIO warm during the wait.
+            // Flag is set to true AFTER sdioPreWait returns, just before the mutex acquire.
+            // This is the key fix for the storm-gate / DMA clock-gate conflict:
+            //   - flag=true during sdioPreWait → polling blocked → SDIO idle → DMA clock-gate → crash
+            //   - flag=false during sdioPreWait → polling runs → SDIO stays warm → no clock-gate
+            //     → storm gate drains pkt_rxbuff → server burst fits → no :928 crash
+            art_download_in_progress = false;
             Serial.printf("[ART] URL: %s\n", url);
 
             // LRU cache check — serve instantly without network if we already have this art
@@ -576,87 +996,158 @@ void albumArtTask(void* param) {
 
             // Scoped HTTP/HTTPS download - ensures TLS session is freed after each download
             {
+                // preClient MUST be declared before http: C++ destroys locals in reverse
+                // order, so preClient outlives http → http.end() can call _client->stop()
+                // on a still-valid preClient before preClient's destructor runs.
+                WiFiClient preClient;   // pre-connected with SO_RCVBUF (HTTP only)
                 HTTPClient http;
                 WiFiClientSecure secure_client;
                 bool mutex_acquired = false;
+                bool http_early_closed = false;  // set true after early http.end() before decode/scale
 
-                // PRE-WAIT: Wait for cooldowns BEFORE acquiring mutex
-                // This prevents blocking SOAP commands (Next/Prev/Play) during cooldown waits
-                // 200ms general cooldown applies to ALL URLs - even local HTTP generates SDIO
-                // traffic when lyrics/SOAP releases mutex just before art fires (Crash B pattern)
-                {
-                    unsigned long now = millis();
-                    unsigned long elapsed = now - last_network_end_ms;
-                    if (last_network_end_ms > 0 && elapsed < 200) {
-                        vTaskDelay(pdMS_TO_TICKS(200 - elapsed));
-                    }
+                // PRE-WAIT: SDIO crash-defence before acquiring mutex.
+                // art_download_in_progress is FALSE here — polling runs during this wait,
+                // keeping SDIO active (prevents C6 DMA clock-gate from SDIO idle).
+                //
+                // Queue-poll cooldown only: after updateQueue() 20KB Browse response,
+                // combined SDIO traffic with art download overflows pkt_rxbuff.
+                // Storm gate and HTTPS cooldown omitted: cause unnecessary SDIO idle
+                // → DMA clock-gate → crash.
+                uint32_t prewait_flags = SDIO_WAIT_QUEUE_POLL;
+                if (!sdioPreWait("ART", prewait_flags, &art_abort_download, &art_shutdown_requested)) {
+                    art_abort_download = false;  // track changed during wait — pick up new URL
+                    continue;
                 }
 
-                // HTTPS residue cooldown - C6 needs 2000ms to free TLS buffers after any HTTPS session.
-                // Applied to ALL subsequent downloads (local AND internet) — local getaa crashes too.
-                if (last_https_end_ms > 0) {
-                    unsigned long now = millis();
-                    unsigned long elapsed = now - last_https_end_ms;
-                    if (elapsed < 2000) {
-                        unsigned long wait_ms = 2000 - elapsed;
-                        Serial.printf("[ART] HTTPS residue cooldown: waiting %lums\n", wait_ms);
-                        vTaskDelay(pdMS_TO_TICKS(wait_ms));
+                // Suppress polling. DMA safety check BEFORE mutex or TCP connection.
+                // Burst size 13-22KB observed from 192.168.2.36:1400 (server cached TCP cwnd;
+                // SO_RCVBUF does NOT limit initial burst on this platform). Need DMA ≥
+                // ART_MIN_DMA_PRE_BURST to ensure dl-start DMA ≥ ART_TCP_RCVBUF_DL_SAFETY.
+                art_download_in_progress = true;
+                // Read DMA ONCE: same value used for the log and the check (TOCTOU fix).
+                size_t dma_snap = heap_caps_get_free_size(MALLOC_CAP_DMA);
+                artLogSDIO("flag-set");
+                Serial.printf("[ART/flag-set] MEM: heap=%u dma=%u psram=%u stk=%u\n",
+                    heap_caps_get_free_size(MALLOC_CAP_DEFAULT), (unsigned)dma_snap,
+                    heap_caps_get_free_size(MALLOC_CAP_SPIRAM), uxTaskGetStackHighWaterMark(NULL));
+                if (dma_snap < ART_MIN_DMA_PRE_BURST) {
+                    // Count consecutive failures for this URL.
+                    static char dma_fail_url[512] = "";
+                    static int  dma_fail_count    = 0;
+                    if (strncmp(dma_fail_url, url, sizeof(dma_fail_url) - 1) != 0) {
+                        strncpy(dma_fail_url, url, sizeof(dma_fail_url) - 1);
+                        dma_fail_url[sizeof(dma_fail_url) - 1] = '\0';
+                        dma_fail_count = 0;
                     }
-                }
-
-                // Queue poll cooldown - 50-item XML response (~20KB) stresses SDIO RX pool.
-                // sendSOAP() does NOT check this — only art download is gated here.
-                if (last_queue_fetch_time > 0) {
-                    unsigned long elapsed = millis() - last_queue_fetch_time;
-                    if (elapsed < 2000) {
-                        unsigned long wait_ms = 2000 - elapsed;
-                        Serial.printf("[ART] Queue poll cooldown: waiting %lums\n", wait_ms);
-                        vTaskDelay(pdMS_TO_TICKS(wait_ms));
+                    dma_fail_count++;
+                    size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_DMA);
+                    Serial.printf("[ART] DMA too low (%u < %u, largest=%uKB) — abort #%d\n",
+                                  (unsigned)dma_snap, (unsigned)ART_MIN_DMA_PRE_BURST,
+                                  (unsigned)(largest / 1024), dma_fail_count);
+                    if (dma_fail_count >= 3) {
+                        // Give up: mark URL as handled so the outer loop stops retrying
+                        // until the track changes (same as WiFi-not-connected path).
+                        // DMA won't recover without a reboot; retrying wastes CPU/log.
+                        Serial.printf("[ART] DMA low x%d — giving up, showing placeholder\n",
+                                      dma_fail_count);
+                        if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
+                            last_art_url = url;  // marks URL "handled" → outer loop skips it
+                            xSemaphoreGive(art_mutex);
+                        }
+                        dma_fail_count = 0;
+                        dma_fail_url[0] = '\0';
+                        // Do NOT set last_art_download_end_ms — no network traffic happened.
+                        // Do NOT set art_download_in_progress — cleared by outer no-URL path.
+                    } else {
+                        vTaskDelay(pdMS_TO_TICKS(2000));  // brief wait before retry
+                        // Do NOT set last_art_download_end_ms — no network happened.
                     }
-                }
-
-                // ABORT CHECK: If track changed during cooldown, bail out before acquiring mutex
-                if (art_abort_download) {
-                    art_abort_download = false;
                     continue;
                 }
 
                 // Acquire network mutex (all network activity serialized)
+                uint32_t t_mutex_start = millis();
                 mutex_acquired = xSemaphoreTake(network_mutex, pdMS_TO_TICKS(NETWORK_MUTEX_TIMEOUT_ART_MS));
                 if (!mutex_acquired) {
                     Serial.println("[ART] Failed to acquire network mutex - skipping download");
                 }
 
                 if (mutex_acquired) {
+                    Serial.printf("[ART/mutex] acquired after %lums\n", millis() - t_mutex_start);
+                    artLogMem("mutex");
+                    artLogSDIO("mutex");
                     // ABORT CHECK: If track changed while waiting for mutex, bail out immediately
                     if (art_abort_download) {
                         Serial.println("[ART] Track changed while waiting for mutex - skipping");
                         art_abort_download = false;
+                        if (preClient.connected()) {
+                            // preClient destructor (scope exit) fires TCP RST — give SDIO time to flush
+                            // before next download attempt starts.
+                            last_network_end_ms = millis();
+                            vTaskDelay(pdMS_TO_TICKS(SDIO_TCP_CLOSE_MS));
+                        }
                         xSemaphoreGive(network_mutex);
                         mutex_acquired = false;
                         continue;
                     }
 
                     // Re-check cooldowns under mutex (another task may have used network while we waited)
-                    // 200ms applies to ALL URLs (even local HTTP can cause SDIO RX overflow)
+                    // SDIO_GENERAL_COOLDOWN_MS (200ms) applied OUTSIDE the mutex in sdioPreWait.
+                    // Inside the mutex, only a short TCP FIN-ACK drain is needed (LAN <1ms).
+                    // Using 200ms here blocks the mutex for 200ms → SDIO idle → C6 power-save
+                    // → DMA clock-gate → pkt_rxbuff overflow → :928 on next TCP connection.
+                    // 10ms covers the FIN-ACK race window without triggering clock-gate.
                     {
-                        unsigned long now = millis();
-                        unsigned long elapsed = now - last_network_end_ms;
-                        if (last_network_end_ms > 0 && elapsed < 200) {
-                            vTaskDelay(pdMS_TO_TICKS(200 - elapsed));
+                        const unsigned long kInnerNetCooldownMs = 10;
+                        if (last_network_end_ms > 0) {
+                            unsigned long elapsed = millis() - last_network_end_ms;
+                            if (elapsed < kInnerNetCooldownMs) {
+                                vTaskDelay(pdMS_TO_TICKS(kInnerNetCooldownMs - elapsed));
+                            }
                         }
                     }
+                    // HTTPS TCP residue drain — catches lyrics→art race.
+                    // If lyrics HTTPS completed while art waited for the mutex, last_https_end_ms
+                    // is fresh. Art is HTTP-only (HTTPS downgraded in prepareAlbumArtURL), so we
+                    // only need TCP FIN-ACK drain time (SDIO_HTTPS_TCP_CLOSE_MS = 500ms), NOT the
+                    // full 3000ms DMA settle used between two HTTPS sessions. Using 3000ms here
+                    // caused 3s of SDIO silence → P4 SDIO DMA clock-gate → pkt_rxbuff overflow.
                     if (last_https_end_ms > 0) {
-                        unsigned long now = millis();
-                        unsigned long elapsed = now - last_https_end_ms;
-                        if (elapsed < 2000) {
-                            vTaskDelay(pdMS_TO_TICKS(2000 - elapsed));
+                        unsigned long elapsed = millis() - last_https_end_ms;
+                        if (elapsed < SDIO_HTTPS_TCP_CLOSE_MS) {
+                            vTaskDelay(pdMS_TO_TICKS(SDIO_HTTPS_TCP_CLOSE_MS - elapsed));
                         }
                     }
+                    // Inside-mutex rechecks for queue-poll and inter-download: the full cooldowns
+                    // (3000ms / 1000ms) already ran in sdioPreWait OUTSIDE the mutex where
+                    // pollingTask can fire SOAPs to keep SDIO warm. Here we only guard against
+                    // the race where the timestamp was updated AFTER sdioPreWait returned but
+                    // BEFORE we acquired the mutex. In that window the elapsed time is at most
+                    // a few hundred ms, so TCP residue drain time (SDIO_TCP_CLOSE_MS = 200ms)
+                    // is all we need. Waiting the full 3000ms / 1000ms inside the mutex blocks
+                    // pollingTask and creates SDIO silence → P4 SDIO DMA clock-gate → crash.
                     if (last_queue_fetch_time > 0) {
                         unsigned long elapsed = millis() - last_queue_fetch_time;
-                        if (elapsed < 2000) {
-                            vTaskDelay(pdMS_TO_TICKS(2000 - elapsed));
+                        if (elapsed < SDIO_TCP_CLOSE_MS) {
+                            vTaskDelay(pdMS_TO_TICKS(SDIO_TCP_CLOSE_MS - elapsed));
+                        }
+                    }
+                    if (last_art_download_end_ms > 0) {
+                        unsigned long elapsed = millis() - last_art_download_end_ms;
+                        if (elapsed < SDIO_TCP_CLOSE_MS) {
+                            vTaskDelay(pdMS_TO_TICKS(SDIO_TCP_CLOSE_MS - elapsed));
+                        }
+                    }
+                    // Post-500 settle: if a Sonos 500 occurred within the last SDIO_TCP_CLOSE_MS
+                    // (200ms), wait for its TCP FIN-ACK to drain before starting the art connection.
+                    // Keeps inside-mutex wait ≤ 200ms — longer waits block pollingTask (holds
+                    // network_mutex) → SDIO idle → P4 DMA clock-gate → pkt_rxbuff overflow.
+                    // TCP FIN-ACK on LAN completes in <5ms; 200ms is more than sufficient.
+                    if (last_transient_500_ms > 0) {
+                        unsigned long elapsed = millis() - last_transient_500_ms;
+                        if (elapsed < SDIO_TCP_CLOSE_MS) {
+                            Serial.printf("[ART] Post-500 drain: waiting %lums\n", SDIO_TCP_CLOSE_MS - elapsed);
+                            vTaskDelay(pdMS_TO_TICKS(SDIO_TCP_CLOSE_MS - elapsed));
                         }
                     }
 
@@ -665,7 +1156,18 @@ void albumArtTask(void* param) {
                         secure_client.setInsecure();
                         http.begin(secure_client, url);
                     } else {
-                        http.begin(url);
+                        // Pre-connect: note SO_RCVBUF set here may not take effect on the SYN
+                        // (lwIP PCB doesn't exist until lwip_connect()). We set SO_RCVBUF again
+                        // on the actual stream fd after GET returns — see below.
+                        int pre_timeout = isLocalNetwork ? 3000 : 10000;
+                        preClient = artPreConnectHTTP(url, pre_timeout);
+                        if (preClient.connected()) {
+                            Serial.printf("[ART] TCP pre-connect OK fd=%d SO_RCVBUF=%d\n", preClient.fd(), ART_TCP_RCVBUF);
+                            http.begin(preClient, url);
+                        } else {
+                            Serial.println("[ART] TCP pre-connect FAILED — fallback http.begin() (NO SO_RCVBUF!)");
+                            http.begin(url);
+                        }
                     }
                     // Local network: 3s timeout (LAN responds in <1s, 3s catches slow devices)
                     // Internet: 10s timeout (CDN/remote servers can be slow)
@@ -675,32 +1177,156 @@ void albumArtTask(void* param) {
                     // unexpected TLS session). Non-200 responses show placeholder instead.
                     http.setFollowRedirects(HTTPC_DISABLE_FOLLOW_REDIRECTS);
 
+                    // Re-apply SO_RCVBUF immediately before GET (belt-and-suspenders).
+                    // artPreConnectHTTP sets it post-connect, but if lwIP's internal ACK for
+                    // SYN-ACK carried TCP_WND=65534 (before our setsockopt), the server may
+                    // still believe the window is large. Resetting here forces pcb->rcv_wnd
+                    // to 4096 so the GET's TCP header advertises the constrained window.
+                    // vTaskDelay(1ms) gives the lwIP task a scheduling slice to propagate
+                    // the option change to the PCB before the GET segment is sent.
+                    if (!use_https && preClient.connected()) {
+                        int rcvbuf = ART_TCP_RCVBUF;
+                        lwip_setsockopt(preClient.fd(), SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+                        vTaskDelay(pdMS_TO_TICKS(1));
+                    }
+                    // Pre-allocate art buffer BEFORE GET so the full body can drain directly
+                    // into the final download buffer immediately after GET() returns.
+                    const size_t max_art_size = MAX_ART_SIZE;
+                    uint8_t* jpgBuf = (uint8_t*)heap_caps_malloc(max_art_size, MALLOC_CAP_SPIRAM);
+                    size_t pre_drained = 0;
+                    if (!jpgBuf) Serial.println("[ART] Pre-alloc failed — full drain disabled");
+                    size_t dma_pre_get = heap_caps_get_free_size(MALLOC_CAP_DMA);
+                    artLogMem("pre-GET");
+                    artLogSDIO("pre-GET");
+                    uint32_t t_get = millis();
                     int code = http.GET();
+                    // Full body drain: read the ENTIRE content-length immediately after GET
+                    // returns, before any other processing. Each readBytes() calls tcp_recved()
+                    // which frees pbufs and opens the window for the next server window.
+                    // With SO_RCVBUF=4096, server sends ≤4096 bytes at a time; we drain
+                    // each window as it arrives. By the time the main read loop starts,
+                    // the server has nothing left to send → no burst → no pkt_rxbuff overflow.
+                    // Root cause of :928: pre-drain stopping at available()==0 left the NEXT
+                    // in-flight window arriving during setup code (size checks / logs / setsockopt)
+                    // → two simultaneous windows fill C6 pkt_rxbuff → crash.
+                    int full_drain_target = (code == 200) ? http.getSize() : 0;
+                    if (code == 200 && jpgBuf) {
+                        WiFiClient* _sd = http.getStreamPtr();
+                        bool _known = (full_drain_target > 0 &&
+                                       full_drain_target < (int)max_art_size);
+                        size_t _target = _known ? (size_t)full_drain_target : max_art_size;
+                        if (_sd) {
+                            uint32_t _ds = millis();
+                            while (pre_drained < _target && millis() - _ds < 15000) {
+                                if (art_abort_download || art_shutdown_requested) break;
+                                int _a = _sd->available();
+                                if (_a <= 0) {
+                                    if (!_sd->connected()) break;  // server closed = EOF
+                                    vTaskDelay(pdMS_TO_TICKS(1));  // yield for TCP stack
+                                    continue;
+                                }
+                                size_t _c = min((size_t)min(_a, 4096), _target - pre_drained);
+                                size_t _g = _sd->readBytes(jpgBuf + pre_drained, _c);
+                                if (!_g) break;
+                                pre_drained += _g;
+                            }
+                        }
+                    }
+                    Serial.printf("[ART] GET+drain → code=%d in %lums (drained=%u/%d DMA=%uKB)\n",
+                        code, millis() - t_get, (unsigned)pre_drained, full_drain_target,
+                        (unsigned)(heap_caps_get_free_size(MALLOC_CAP_DMA) / 1024));
                     // Keep mutex locked for entire download
 
                     if (code == 200) {
-                int len = http.getSize();
-                const size_t max_art_size = MAX_ART_SIZE;
+                int len = full_drain_target > 0 ? full_drain_target : http.getSize();
                 const bool len_known = (len > 0);
                 if ((len_known && len < (int)max_art_size) || !len_known) {
+                    size_t alloc_len = len_known ? (size_t)len : max_art_size;
+                    // jpgBuf pre-allocated (max_art_size PSRAM bytes) above; alloc_len ≤ max_art_size.
+                    // pre_drained bytes already in jpgBuf[0..pre_drained-1] (full body if drain succeeded).
+                    // Fall back to a fresh alloc if the pre-alloc failed.
+                    if (!jpgBuf) jpgBuf = (uint8_t*)heap_caps_malloc(alloc_len, MALLOC_CAP_SPIRAM);
+
                     if (len_known) {
                         Serial.printf("[ART] Downloading album art: %d bytes\n", len);
                     } else {
                         Serial.println("[ART] Downloading album art: unknown length");
                     }
-                    size_t alloc_len = len_known ? (size_t)len : max_art_size;
-                    uint8_t* jpgBuf = (uint8_t*)heap_caps_malloc(alloc_len, MALLOC_CAP_SPIRAM);
+                    artLogMem("dl-start");
+                    // DL-start DMA check — after pre-drain, burst pbufs should be freed.
+                    // If DMA still low (pre-drain insufficient or alloc failed), abort.
+                    size_t dma_dl_start = heap_caps_get_free_size(MALLOC_CAP_DMA);
+                    Serial.printf("[ART/burst] pre-GET=%u dl-start=%u burst=%u bytes\n",
+                                  (unsigned)dma_pre_get, (unsigned)dma_dl_start,
+                                  dma_pre_get > dma_dl_start ? (unsigned)(dma_pre_get - dma_dl_start) : 0u);
+                    if (dma_dl_start < ART_TCP_RCVBUF_DL_SAFETY || !jpgBuf) {
+                        if (!jpgBuf)
+                            Serial.println("[ART] jpgBuf PSRAM alloc failed — aborting");
+                        else
+                            Serial.printf("[ART] DMA too low at dl-start (%u < %u) — aborting\n",
+                                          (unsigned)dma_dl_start, (unsigned)ART_TCP_RCVBUF_DL_SAFETY);
+                        if (jpgBuf) { heap_caps_free(jpgBuf); jpgBuf = nullptr; }
+                        http.end();
+                        vTaskDelay(pdMS_TO_TICKS(SDIO_TCP_CLOSE_MS));
+                        last_network_end_ms      = millis();
+                        last_art_download_end_ms = millis();
+                        xSemaphoreGive(network_mutex);
+                        mutex_acquired = false;
+                        continue;
+                    }
+                    {  // scope: dma_dl_start >= ART_TCP_RCVBUF_DL_SAFETY && jpgBuf valid
                     if (jpgBuf) {
                         WiFiClient* stream = http.getStreamPtr();
 
+                        // SO_RCVBUF: set on the actual stream fd immediately after GET.
+                        // artPreConnectHTTP() tries to set this BEFORE lwip_connect(), but
+                        // lwIP doesn't create the PCB (and thus pcb->rcv_wnd) until connect()
+                        // is called. If SO_RCVBUF is set before the PCB exists, lwIP cannot
+                        // apply it to the SYN → server sees TCP_WND=65534 → blasts 53KB initial
+                        // burst into C6 pkt_rxbuff → SDIO overflow. Setting it HERE, after GET,
+                        // takes effect immediately: subsequent ACKs advertise the constrained
+                        // window → server slows to ≤8KB chunks → SDIO handles them safely.
+                        // The initial burst (already received) is absorbed by the 5ms inter-chunk
+                        // delay and the chunked read loop — no additional SDIO frames arrive until
+                        // we read and ACK, at which point the new window applies.
+                        if (!use_https && stream) {
+                            int rcvbuf = ART_TCP_RCVBUF;
+                            int stream_fd = stream->fd();
+                            int pre_fd   = preClient.connected() ? preClient.fd() : -1;
+                            Serial.printf("[ART] stream->fd()=%d preClient.fd()=%d SO_RCVBUF=%d\n",
+                                          stream_fd, pre_fd, rcvbuf);
+                            if (stream_fd >= 0) {
+                                lwip_setsockopt(stream_fd, SOL_SOCKET, SO_RCVBUF,
+                                                &rcvbuf, sizeof(rcvbuf));
+                            }
+                        }
+
                         // Chunked reading to avoid WiFi buffer issues
                         const size_t chunkSize = ART_CHUNK_SIZE;
-                        size_t bytesRead = 0;
+                        size_t bytesRead = pre_drained;  // continue from pre-drain position
                         bool readSuccess = true;
+                        uint32_t t_dl_start = millis();
 
-                        // Read loop: keep going while connected OR data still buffered
-                        // Server may close connection before we read all buffered bytes
-                        while ((stream->connected() || stream->available()) && bytesRead < alloc_len) {
+                        // Read loop: keep going while connected OR data still buffered.
+                        // IMPORTANT: check bytesRead < alloc_len FIRST (short-circuit).
+                        // When full body pre-drain succeeded (bytesRead == alloc_len), this
+                        // exits immediately WITHOUT calling stream->connected(). After full EOF
+                        // drain, WiFiClient may free its internal socket handle — calling
+                        // connected() on it causes a Load Access Fault (confirmed by addr2line).
+                        while (bytesRead < alloc_len && stream &&
+                               (stream->connected() || stream->available())) {
+                            // Belt-and-suspenders: check DMA during read. If WiFi dynamic RX
+                            // buffers allocate ~15KB after dl-start (pool not yet fully used),
+                            // DMA can drop from ~22KB to ~7KB — near the :928 crash floor.
+                            // ART_DMA_MID_READ_MIN (8KB) catches this before it becomes fatal.
+                            // Checked every chunk (4KB) = at most ~200ms sampling interval.
+                            if (heap_caps_get_free_size(MALLOC_CAP_DMA) < ART_DMA_MID_READ_MIN) {
+                                Serial.printf("[ART] DMA critical during read (%u < %u) — aborting\n",
+                                    (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA),
+                                    (unsigned)ART_DMA_MID_READ_MIN);
+                                readSuccess = false;
+                                break;
+                            }
                             // Check if source changed or OTA starting - abort download immediately
                             if (art_abort_download || art_shutdown_requested) {
                                 Serial.printf("[ART] %s - aborting current download\n",
@@ -733,12 +1359,21 @@ void albumArtTask(void* param) {
                             }
 
                             bytesRead += actualRead;
-                            // Yield to WiFi/SDIO task between chunks.
-                            // taskYIELD() = 0ms if no higher-prio task ready, so Sonos SOAP
-                            // response packets pile up in SDIO RX pool → sdio_push_data_to_queue crash.
-                            // 5ms guaranteed delay lets SDIO receive task drain packets between chunks.
-                            // Local HTTP: 5ms, Internet HTTP: 5ms, Internet HTTPS: 15ms (TLS overhead)
-                            vTaskDelay(pdMS_TO_TICKS(use_https ? 15 : 5));
+                            // Log every ~80KB (20 chunks × 4KB)
+                            if (chunkSize > 0 && (bytesRead / chunkSize) % 20 == 1 && bytesRead < (size_t)(len > 0 ? len : (int)alloc_len)) {
+                                Serial.printf("[ART] DL progress: %u/%d bytes avail=%u conn=%d\n",
+                                    (unsigned)bytesRead, len, (unsigned)stream->available(), (int)stream->connected());
+                            }
+                            // 5ms inter-chunk yield: gives lwIP uninterrupted time between reads
+                            // to drain any background WiFi frames (Sonos SSDP/mDNS multicast
+                            // announcements that arrive as HLS transition completes) from C6
+                            // pkt_rxbuff. Without this, art's TCP data + concurrent multicast
+                            // bursts exhaust pkt_rxbuff → sdio_push_data_to_queue :928.
+                            // This is safe: WiFi.setSleep(false) prevents C6 power-save so no
+                            // wake-up burst occurs, and Sonos uses pure SOAP-polling (no UPnP
+                            // NOTIFY push events) so the only traffic is art's own TCP segments
+                            // plus occasional network multicasts.
+                            vTaskDelay(pdMS_TO_TICKS(5));
                         }
 
                         // Re-acquire mutex for cleanup (http.end, timestamp update)
@@ -754,13 +1389,13 @@ void albumArtTask(void* param) {
                             readSuccess = false;
                         }
 
-                        Serial.printf("[ART] Album art read: %d bytes (len_known=%d)\n", (int)bytesRead, len_known ? 1 : 0);
+                        Serial.printf("[ART] Album art read: %d bytes (len_known=%d) in %lums\n", (int)bytesRead, len_known ? 1 : 0, millis() - t_dl_start);
 
                         // If download failed/aborted, close connection and free TLS/DMA resources
                         if (!readSuccess) {
                             Serial.println("[ART] Download failed/aborted - closing connection");
                             stream->stop();  // TCP RST - kills connection immediately
-                            heap_caps_free(jpgBuf);
+                            heap_caps_free(jpgBuf); jpgBuf = nullptr;
                             // CRITICAL: http.end() + secure_client.stop() free TLS/DMA memory
                             // After TCP RST, these won't send SDIO traffic (socket is dead)
                             // but they WILL release DMA buffers used by esp-aes
@@ -773,7 +1408,8 @@ void albumArtTask(void* param) {
                             // Internet HTTP: 300ms (simple TCP cleanup)
                             // Internet HTTPS: 1000ms (TLS session + TCP cleanup)
                             vTaskDelay(pdMS_TO_TICKS(isLocalNetwork ? 300 : (use_https ? 1000 : 300)));
-                            last_network_end_ms = millis();
+                            last_network_end_ms      = millis();
+                            last_art_download_end_ms = millis();   // partial downloads still leave SDIO residue
                             if (use_https) last_https_end_ms = millis();
                             if (mutex_acquired) {
                                 xSemaphoreGive(network_mutex);
@@ -812,453 +1448,61 @@ void albumArtTask(void* param) {
                             }
                         }
                         if (sizeOk && readSuccess) {
-                            // Detect image format by magic bytes
-                            bool isJPEG = (read >= 3 && jpgBuf[0] == 0xFF && jpgBuf[1] == 0xD8 && jpgBuf[2] == 0xFF);
-                            bool isPNG = (read >= 4 && jpgBuf[0] == 0x89 && jpgBuf[1] == 0x50 && jpgBuf[2] == 0x4E && jpgBuf[3] == 0x47);
+                            // Keep TCP open during decode/scale (PASSIVE CLOSE fix):
+                            // Previously we closed early with http.end() + SO_LINGER{1,0} before decode.
+                            // SO_LINGER is NOT compiled in the pioarduino pre-built framework → setsockopt
+                            // returns -1 silently → FIN-close → TIME_WAIT → each art PCB holds ~8.7KB DMA
+                            // for 120s. 3 downloads = 26KB DMA lost; combined with SOAP PCBs = 91KB lost
+                            // total → art DMA wait stuck at 28KB indefinitely → art never loads.
+                            //
+                            // Fix: Leave TCP open. Server sends FIN after last byte (arrives in pkt_rxbuff
+                            // during decode/scale as 1 tiny TCP segment — safe, polling suppressed by
+                            // art_download_in_progress=true, no UPnP NOTIFY events to compound it).
+                            // lwIP auto-ACKs server FIN → we enter CLOSE_WAIT. After decode/scale, http.end()
+                            // sends our FIN → LAST_ACK → CLOSED. Server enters TIME_WAIT, not us → zero DMA
+                            // cost on P4 side per art download.
+                            artLogMem("post-close");
 
-                            // Decode PNG for both station logos and regular album art (e.g. Plex serves PNG)
-                            if (isPNG) {
-                                Serial.printf("[ART] Opening PNG with %d bytes\n", read);
-                                int pngResult = png.openRAM(jpgBuf, read, pngDraw);
-                                if (pngResult == 0) {  // PNG_SUCCESS = 0 (different from JPEG!)
-                                    Serial.println("[ART] PNG openRAM success");
-                                    int w = png.getWidth();
-                                    int h = png.getHeight();
+                            // ── Format detection ──────────────────────────────
+                            bool isJPEG = (read >= 3 && jpgBuf[0] == 0xFF
+                                                      && jpgBuf[1] == 0xD8
+                                                      && jpgBuf[2] == 0xFF);
+                            bool isPNG  = (read >= 4 && jpgBuf[0] == 0x89
+                                                      && jpgBuf[1] == 0x50
+                                                      && jpgBuf[2] == 0x4E
+                                                      && jpgBuf[3] == 0x47);
 
-                                    // Validate PNG dimensions to prevent crashes from malformed files
-                                    // Also check for integer overflow: w*h*2 must fit in size_t and be reasonable (< 10MB)
-                                    if (w == 0 || h == 0 || w > 2048 || h > 2048 ||
-                                        (size_t)w * (size_t)h * 2 > 10*1024*1024) {
-                                        Serial.printf("[ART] Invalid PNG dimensions: %dx%d (max 2048x2048, 10MB)\n", w, h);
-                                        png.close();
-                                        if (decoded_buffer) { heap_caps_free(decoded_buffer); decoded_buffer = nullptr; }
-                                        heap_caps_free(jpgBuf);
-                                        jpgBuf = nullptr;
-                                        // Cleanup HTTP and release mutex before continue
-                                        http.end();
-                                        if (use_https) secure_client.stop();
-                                        vTaskDelay(pdMS_TO_TICKS(200));
-                                        last_network_end_ms = millis();
-                                        if (use_https) last_https_end_ms = millis();
-                                        xSemaphoreGive(network_mutex);
-                                        mutex_acquired = false;
-                                        continue;
-                                    }
-
-                                    jpeg_image_width = w;   // Reuse for PNG
-                                    jpeg_image_height = h;  // Reuse for PNG
-                                    jpeg_output_width = 0;
-                                    jpeg_output_height = 0;
-                                    Serial.printf("[ART] PNG: %dx%d\n", w, h);
-
-                                    // Allocate buffer for full decoded image
-                                    size_t decoded_size = w * h * 2;
-                                    if (decoded_buffer) {
-                                        heap_caps_free(decoded_buffer);
-                                    }
-                                    decoded_buffer = (uint16_t*)heap_caps_malloc(decoded_size, MALLOC_CAP_SPIRAM);
-
-                                    if (decoded_buffer) {
-                                        jpeg_decode_buffer = decoded_buffer;
-                                        memset(decoded_buffer, 0, decoded_size);
-
-                                        // Decode PNG
-                                        png.decode(NULL, 0);
-                                        png.close();
-
-                                        Serial.printf("[ART] Decoded %dx%d\n", w, h);
-                                        jpeg_decode_buffer = nullptr;
-
-                                        if (art_temp_buffer) {
-                                            int out_w = jpeg_output_width > 0 ? jpeg_output_width : w;
-                                            int out_h = jpeg_output_height > 0 ? jpeg_output_height : h;
-                                            uint16_t* src_buffer = decoded_buffer;
-                                            bool needs_compact = (out_w != w) || (out_h != h);
-
-                                            if (needs_compact) {
-                                                Serial.printf("[ART] Output size: %dx%d (scaled)\n", out_w, out_h);
-                                                size_t compact_size = (size_t)out_w * (size_t)out_h * 2;
-                                                uint16_t* compact_buffer = (uint16_t*)heap_caps_malloc(compact_size, MALLOC_CAP_SPIRAM);
-                                                if (compact_buffer) {
-                                                    for (int y = 0; y < out_h; y++) {
-                                                        memcpy(&compact_buffer[y * out_w],
-                                                               &decoded_buffer[y * w],
-                                                               (size_t)out_w * 2);
-                                                    }
-                                                    src_buffer = compact_buffer;
-                                                } else {
-                                                    Serial.println("[ART] Failed to allocate compact buffer");
-                                                    out_w = w;
-                                                    out_h = h;
-                                                }
-                                            }
-
-                                            // Clear output buffer
-                                            memset(art_temp_buffer, 0, ART_SIZE * ART_SIZE * 2);
-
-                                            // Scale to exact 420x420 using bilinear interpolation
-                                            Serial.printf("[ART] Bilinear scaling %dx%d -> 420x420\n", out_w, out_h);
-                                            scaleImageBilinear(src_buffer, out_w, out_h, out_w, art_temp_buffer, ART_SIZE, ART_SIZE);
-                                            Serial.println("[ART] Scaling complete");
-
-                                            if (src_buffer != decoded_buffer) {
-                                                heap_caps_free(src_buffer);
-                                            }
-                                            // Free decoded buffer immediately - don't hold 800KB until next image
-                                            heap_caps_free(decoded_buffer);
-                                            decoded_buffer = nullptr;
-
-                                            // Sample dominant color from scaled image
-                                            sampleDominantColor(art_temp_buffer, ART_SIZE, ART_SIZE);
-
-                                            // Calculate dominant color
-                                            uint32_t new_color = 0x1a1a1a;  // Default dark color
-                                            if (color_sample_count > 0) {
-                                                uint8_t avg_r = color_r_sum / color_sample_count;
-                                                uint8_t avg_g = color_g_sum / color_sample_count;
-                                                uint8_t avg_b = color_b_sum / color_sample_count;
-
-                                                // Darken for background (multiply by 0.4)
-                                                avg_r = (avg_r * 4) / 10;
-                                                avg_g = (avg_g * 4) / 10;
-                                                avg_b = (avg_b * 4) / 10;
-
-                                                new_color = (avg_r << 16) | (avg_g << 8) | avg_b;
-                                            }
-
-                                            // Copy pixels and signal ready — art_dsc is written by
-                                            // the main thread in updateUI() to prevent a race with
-                                            // the LVGL renderer (both on main thread, no concurrency).
-                                            if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
-                                                memcpy(art_buffer, art_temp_buffer, ART_SIZE * ART_SIZE * 2);
-                                                last_art_url = url;
-                                                dominant_color = new_color;
-                                                art_ready = true;
-                                                color_ready = true;
-                                                xSemaphoreGive(art_mutex);
-                                            }
-                                            // Store to LRU cache (art_cache is art-task-private, no mutex needed)
-                                            if (art_cache[0].pixels && art_cache[1].pixels) {
-                                                int slot = 1 - art_cache_lru;
-                                                memcpy(art_cache[slot].pixels, art_temp_buffer, ART_SIZE * ART_SIZE * 2);
-                                                strncpy(art_cache[slot].url, url, sizeof(art_cache[slot].url) - 1);
-                                                art_cache[slot].url[sizeof(art_cache[slot].url) - 1] = '\0';
-                                                art_cache[slot].dominant_color = new_color;
-                                                art_cache[slot].valid = true;
-                                                art_cache_lru = slot;
-                                            }
-                                            // Reset failure counter on success
-                                            consecutive_failures = 0;
-                                            last_failed_url[0] = '\0';
-                                        }
-                                    } else {
-                                        Serial.printf("[ART] Failed to allocate %d bytes for decoded image\n", (int)decoded_size);
-                                    }
+                            artLogMem("pre-decode");  // DMA before HW JPEG alloc (expect ~90KB)
+                            DecodeResult dec = decodeToRGB565(jpgBuf, (size_t)read,
+                                                              isJPEG, isPNG);
+                            artLogMem("post-decode");  // DMA after decode — delta shows JPEG DMA cost
+                            if (dec.ok) {
+                                displayArt(dec, url);
+                                heap_caps_free(dec.pixels);
+                                consecutive_failures = 0;
+                                last_failed_url[0] = '\0';
+                            } else {
+                                if (strcmp(url, last_failed_url) == 0) {
+                                    consecutive_failures++;
                                 } else {
-                                    Serial.printf("[ART] PNG openRAM failed - error code: %d\n", pngResult);
+                                    strncpy(last_failed_url, url, sizeof(last_failed_url) - 1);
+                                    last_failed_url[sizeof(last_failed_url) - 1] = '\0';
+                                    consecutive_failures = 1;
                                 }
-                            } else if (isJPEG && hw_jpeg_decoder) {
-                                // ESP32-P4 Hardware JPEG Decoder - fast and stable!
-                                Serial.printf("[ART] HW JPEG decode: %d bytes\n", read);
-
-                                // CRITICAL: ESP32-P4 HW decoder fails on COM markers (error 258)
-                                // Strip COM markers (0xFFFE) to prevent "COM marker data underflow" errors
-                                size_t cleaned_size = read;
-                                for (size_t i = 0; i < read - 1; ) {
-                                    if (jpgBuf[i] == 0xFF && jpgBuf[i+1] == 0xFE) {
-                                        // Found COM marker - get length
-                                        if (i + 3 < read) {
-                                            uint16_t marker_len = (jpgBuf[i+2] << 8) | jpgBuf[i+3];
-                                            // Remove marker + length + data
-                                            size_t marker_total = 2 + marker_len;
-                                            if (i + marker_total <= read) {
-                                                memmove(&jpgBuf[i], &jpgBuf[i + marker_total], read - i - marker_total);
-                                                cleaned_size -= marker_total;
-                                                Serial.printf("[ART] Stripped COM marker (%d bytes)\n", marker_total);
-                                                continue;  // Don't increment i, check same position again
-                                            }
-                                        }
-                                    }
-                                    i++;
-                                }
-
-                                // Determine decode strategy: HW fast path vs SW fallback
-                                bool use_sw_fallback = false;
-                                bool is_progressive_jpeg = false;
-                                bool hw_decode_success = false;
-                                uint16_t* decoded_pixels = nullptr;  // Final RGB565 pixels for scaling
-                                int final_w = 0, final_h = 0;
-                                int final_stride = 0;  // Row stride in pixels (may differ from width for HW decode)
-
-                                // Pre-check: detect progressive JPEG (SOF2 = 0xFF 0xC2).
-                                // The ESP32-P4 HW decoder supports baseline JPEG (SOF0) only.
-                                // Progressive JPEGs cause jpeg_decoder_get_info to return ESP_OK
-                                // with 0x0 dimensions (it doesn't error — it just can't parse SOF2).
-                                // Detecting early avoids the wasted HW attempt and confusing log.
-                                // Scan the full buffer — large EXIF/ICC headers can push SOF2
-                                // well beyond 4096 bytes (old limit that caused missed detection).
-                                for (size_t pi = 0; pi + 1 < cleaned_size; pi++) {
-                                    if (jpgBuf[pi] == 0xFF && jpgBuf[pi + 1] == 0xC2) {
-                                        Serial.println("[ART] Progressive JPEG (SOF2) — using stb_image");
-                                        use_sw_fallback = true;
-                                        is_progressive_jpeg = true;
-                                        break;
-                                    }
-                                }
-
-                                // Step 1: Try HW decoder header parse (baseline JPEG only)
-                                jpeg_decode_picture_info_t pic_info;
-                                esp_err_t hw_ret = ESP_FAIL;
-                                if (!use_sw_fallback) {
-                                    hw_ret = jpeg_decoder_get_info(jpgBuf, cleaned_size, &pic_info);
-                                }
-
-                                if (!use_sw_fallback) {
-                                if (hw_ret == ESP_OK && pic_info.width > 0 && pic_info.height > 0 &&
-                                    pic_info.width <= 2048 && pic_info.height <= 2048) {
-                                    int w = pic_info.width;
-                                    int h = pic_info.height;
-
-                                    // Check if HW decoder can handle this (dimensions must be div-8)
-                                    bool hw_compatible = (w % 8 == 0) && (h % 8 == 0);
-
-                                    if (hw_compatible && hw_jpeg_decoder) {
-                                        // HW fast path
-                                        int out_w = ((w + 15) / 16) * 16;
-                                        int out_h = ((h + 15) / 16) * 16;
-                                        bool is_grayscale = (pic_info.sample_method == JPEG_DOWN_SAMPLING_GRAY);
-                                        Serial.printf("[ART] JPEG: %dx%d (output: %dx%d)%s\n", w, h, out_w, out_h,
-                                                      is_grayscale ? " [GRAYSCALE]" : "");
-
-                                        size_t bytes_per_pixel = is_grayscale ? 1 : 2;
-                                        size_t decoded_size = out_w * out_h * bytes_per_pixel;
-                                        jpeg_decode_memory_alloc_cfg_t rx_mem_cfg = {
-                                            .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
-                                        };
-                                        size_t rx_buffer_size = 0;
-                                        uint8_t* hw_out_buf = (uint8_t*)jpeg_alloc_decoder_mem(decoded_size, &rx_mem_cfg, &rx_buffer_size);
-
-                                        if (hw_out_buf) {
-                                            jpeg_decode_cfg_t decode_cfg = {
-                                                .output_format = is_grayscale ? JPEG_DECODE_OUT_FORMAT_GRAY : JPEG_DECODE_OUT_FORMAT_RGB565,
-                                                .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,
-                                                .conv_std = JPEG_YUV_RGB_CONV_STD_BT601,
-                                            };
-
-                                            uint32_t out_size = 0;
-                                            hw_ret = jpeg_decoder_process(hw_jpeg_decoder, &decode_cfg, jpgBuf, cleaned_size, hw_out_buf, rx_buffer_size, &out_size);
-
-                                            // For grayscale: convert GRAY8 to RGB565
-                                            if (hw_ret == ESP_OK && is_grayscale) {
-                                                Serial.println("[ART] Converting grayscale to RGB565");
-                                                uint16_t* rgb_buf = (uint16_t*)heap_caps_malloc(out_w * out_h * 2, MALLOC_CAP_SPIRAM);
-                                                if (rgb_buf) {
-                                                    int total_pixels = out_w * out_h;
-                                                    for (int i = 0; i < total_pixels; i++) {
-                                                        uint8_t g = hw_out_buf[i];
-                                                        rgb_buf[i] = ((g >> 3) << 11) | ((g >> 2) << 5) | (g >> 3);
-                                                    }
-                                                    heap_caps_free(hw_out_buf);
-                                                    hw_out_buf = (uint8_t*)rgb_buf;
-                                                } else {
-                                                    Serial.println("[ART] Grayscale conversion alloc failed");
-                                                    heap_caps_free(hw_out_buf);
-                                                    hw_out_buf = nullptr;
-                                                    hw_ret = ESP_FAIL;
-                                                }
-                                            }
-
-                                            if (hw_ret == ESP_OK && hw_out_buf) {
-                                                Serial.printf("[ART] HW decoded: %d bytes\n", out_size);
-                                                hw_decode_success = true;
-                                                decoded_pixels = (uint16_t*)hw_out_buf;
-                                                final_w = w;
-                                                final_h = h;
-                                                final_stride = out_w;  // HW buffer has padded stride
-                                            } else {
-                                                Serial.printf("[ART] HW decode failed: %d, trying SW fallback\n", hw_ret);
-                                                if (hw_out_buf) heap_caps_free(hw_out_buf);
-                                                use_sw_fallback = true;
-                                            }
-                                        } else {
-                                            Serial.printf("[ART] DMA alloc failed (%d bytes), trying SW fallback\n", (int)decoded_size);
-                                            use_sw_fallback = true;
-                                        }
-                                    } else {
-                                        // Non-div-8 dimensions - HW can't handle, use SW
-                                        Serial.printf("[ART] JPEG %dx%d not HW-compatible (non-div-8), using SW fallback\n", w, h);
-                                        use_sw_fallback = true;
-                                    }
-                                } else if (hw_ret == ESP_OK) {
-                                    // HW parser returned OK but 0x0 dimensions — progressive JPEG.
-                                    // Must also set is_progressive_jpeg so Step 2 routes to stb_image,
-                                    // not JPEGDEC (which gives DC-only 1/8-scale output for SOF2).
-                                    Serial.printf("[ART] HW reports 0x0 (progressive), using stb_image\n");
-                                    use_sw_fallback = true;
-                                    is_progressive_jpeg = true;
-                                } else {
-                                    // HW header parse completely failed
-                                    Serial.printf("[ART] HW header parse failed: %d, trying SW fallback\n", hw_ret);
-                                    use_sw_fallback = true;
-                                }
-                                } // end if (!use_sw_fallback) — HW decode block
-
-                                // Step 2: SW fallback if HW couldn't handle it
-                                if (use_sw_fallback && !hw_decode_success) {
-                                    uint16_t* sw_buf = nullptr;
-                                    int sw_w = 0, sw_h = 0;
-                                    if (is_progressive_jpeg) {
-                                        // Progressive JPEG: skip JPEGDEC (DC-only 1/8 scale output).
-                                        // stb_image decodes all scan segments → full-quality output.
-                                        if (decodeJPEGProgressiveStb(jpgBuf, cleaned_size, &sw_buf, &sw_w, &sw_h)) {
-                                            decoded_pixels = sw_buf;
-                                            final_w = sw_w;
-                                            final_h = sw_h;
-                                            final_stride = sw_w;
-                                            hw_decode_success = true;
-                                        }
-                                    } else {
-                                        // Non-progressive: JPEGDEC handles non-div-8 dimensions, etc.
-                                        if (decodeJPEGSoftware(jpgBuf, cleaned_size, &sw_buf, &sw_w, &sw_h)) {
-                                            decoded_pixels = sw_buf;
-                                            final_w = sw_w;
-                                            final_h = sw_h;
-                                            final_stride = sw_w;
-                                            hw_decode_success = true;
-                                        }
-                                    }
-                                }
-
-                                // Step 3: Scale and display (common path for both HW and SW)
-                                if (hw_decode_success && decoded_pixels) {
-                                    memset(art_temp_buffer, 0, ART_SIZE * ART_SIZE * 2);
-                                    Serial.printf("[ART] Bilinear scaling %dx%d -> 420x420 (stride=%d)\n", final_w, final_h, final_stride);
-                                    scaleImageBilinear(decoded_pixels, final_w, final_h, final_stride, art_temp_buffer, ART_SIZE, ART_SIZE);
-                                    Serial.println("[ART] Scaling complete");
-
-                                    heap_caps_free(decoded_pixels);
-                                    decoded_pixels = nullptr;
-
-                                    // Sample dominant color from scaled image
-                                    sampleDominantColor(art_temp_buffer, ART_SIZE, ART_SIZE);
-
-                                    uint32_t new_color = 0x1a1a1a;
-                                    if (color_sample_count > 0) {
-                                        uint8_t avg_r = color_r_sum / color_sample_count;
-                                        uint8_t avg_g = color_g_sum / color_sample_count;
-                                        uint8_t avg_b = color_b_sum / color_sample_count;
-                                        avg_r = (avg_r * 4) / 10;
-                                        avg_g = (avg_g * 4) / 10;
-                                        avg_b = (avg_b * 4) / 10;
-                                        new_color = (avg_r << 16) | (avg_g << 8) | avg_b;
-                                    }
-
-                                    // Copy pixels and signal ready — art_dsc is written by
-                                    // the main thread in updateUI() to prevent a race with
-                                    // the LVGL renderer (both on main thread, no concurrency).
+                                if (consecutive_failures > 1)
+                                    vTaskDelay(pdMS_TO_TICKS(consecutive_failures * 200));
+                                if (consecutive_failures >= ART_DECODE_MAX_FAILURES) {
                                     if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
-                                        memcpy(art_buffer, art_temp_buffer, ART_SIZE * ART_SIZE * 2);
-                                        last_art_url = url;
-                                        dominant_color = new_color;
-                                        art_ready = true;
-                                        color_ready = true;
-                                        xSemaphoreGive(art_mutex);
-                                    }
-                                    // Store to LRU cache (art_cache is art-task-private, no mutex needed)
-                                    if (art_cache[0].pixels && art_cache[1].pixels) {
-                                        int slot = 1 - art_cache_lru;
-                                        memcpy(art_cache[slot].pixels, art_temp_buffer, ART_SIZE * ART_SIZE * 2);
-                                        strncpy(art_cache[slot].url, url, sizeof(art_cache[slot].url) - 1);
-                                        art_cache[slot].url[sizeof(art_cache[slot].url) - 1] = '\0';
-                                        art_cache[slot].dominant_color = new_color;
-                                        art_cache[slot].valid = true;
-                                        art_cache_lru = slot;
-                                    }
-                                    consecutive_failures = 0;
-                                    last_failed_url[0] = '\0';
-                                } else {
-                                    // Both HW and SW decode failed
-                                    if (decoded_pixels) { heap_caps_free(decoded_pixels); decoded_pixels = nullptr; }
-                                    Serial.println("[ART] All JPEG decode methods failed");
-                                    // Track failures to prevent infinite retry
-                                    if (strcmp(url, last_failed_url) == 0) {
-                                        consecutive_failures++;
-                                    } else {
-                                        strncpy(last_failed_url, url, sizeof(last_failed_url) - 1);
-                                        last_failed_url[sizeof(last_failed_url) - 1] = '\0';
-                                        consecutive_failures = 1;
-                                    }
-                                    if (consecutive_failures > 1) {
-                                        vTaskDelay(pdMS_TO_TICKS(consecutive_failures * 200));
-                                    }
-                                    if (consecutive_failures >= ART_DECODE_MAX_FAILURES) {
-                                        Serial.printf("[ART] Decode failed %d times, skipping URL\n", consecutive_failures);
-                                        if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
-                                            last_art_url = url;
-                                            art_show_placeholder = true;
-                                            xSemaphoreGive(art_mutex);
-                                        }
-                                        consecutive_failures = 0;
-                                        last_failed_url[0] = '\0';
-                                    }
-                                }
-                            } else if (isJPEG) {
-                                // HW JPEG decoder not initialized - use SW only
-                                Serial.println("[ART] HW JPEG unavailable, using SW decode");
-                                uint16_t* sw_buf = nullptr;
-                                int sw_w = 0, sw_h = 0;
-                                if (decodeJPEGSoftware(jpgBuf, read, &sw_buf, &sw_w, &sw_h)) {
-                                    memset(art_temp_buffer, 0, ART_SIZE * ART_SIZE * 2);
-                                    scaleImageBilinear(sw_buf, sw_w, sw_h, sw_w, art_temp_buffer, ART_SIZE, ART_SIZE);
-                                    heap_caps_free(sw_buf);
-                                    sampleDominantColor(art_temp_buffer, ART_SIZE, ART_SIZE);
-                                    uint32_t new_color = 0x1a1a1a;
-                                    if (color_sample_count > 0) {
-                                        uint8_t avg_r = color_r_sum / color_sample_count;
-                                        uint8_t avg_g = color_g_sum / color_sample_count;
-                                        uint8_t avg_b = color_b_sum / color_sample_count;
-                                        new_color = ((avg_r * 4 / 10) << 16) | ((avg_g * 4 / 10) << 8) | (avg_b * 4 / 10);
-                                    }
-                                    // Copy pixels and signal ready — art_dsc is written by
-                                    // the main thread in updateUI() to prevent a race with
-                                    // the LVGL renderer (both on main thread, no concurrency).
-                                    if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
-                                        memcpy(art_buffer, art_temp_buffer, ART_SIZE * ART_SIZE * 2);
-                                        last_art_url = url;
-                                        dominant_color = new_color;
-                                        art_ready = true;
-                                        color_ready = true;
-                                        xSemaphoreGive(art_mutex);
-                                    }
-                                    // Store to LRU cache (art_cache is art-task-private, no mutex needed)
-                                    if (art_cache[0].pixels && art_cache[1].pixels) {
-                                        int slot = 1 - art_cache_lru;
-                                        memcpy(art_cache[slot].pixels, art_temp_buffer, ART_SIZE * ART_SIZE * 2);
-                                        strncpy(art_cache[slot].url, url, sizeof(art_cache[slot].url) - 1);
-                                        art_cache[slot].url[sizeof(art_cache[slot].url) - 1] = '\0';
-                                        art_cache[slot].dominant_color = new_color;
-                                        art_cache[slot].valid = true;
-                                        art_cache_lru = slot;
-                                    }
-                                } else {
-                                    // SW also failed - mark as done
-                                    if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
-                                        last_art_url = url;
+                                        last_art_url        = url;
                                         art_show_placeholder = true;
                                         xSemaphoreGive(art_mutex);
                                     }
-                                }
-                            } else {
-                                Serial.println("[ART] Unknown image format (not JPEG or PNG)");
-                                // Mark as done to prevent retry loop
-                                if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
-                                    last_art_url = url;
-                                    art_show_placeholder = true;
-                                    xSemaphoreGive(art_mutex);
+                                    consecutive_failures = 0;
+                                    last_failed_url[0] = '\0';
                                 }
                             }
                         }
-                        heap_caps_free(jpgBuf);
+                        heap_caps_free(jpgBuf); jpgBuf = nullptr;
                     } else {
                         Serial.printf("[ART] Failed to allocate %d bytes for album art\n", len);
                         // Mark as done - memory issue, retry won't help
@@ -1268,6 +1512,7 @@ void albumArtTask(void* param) {
                             xSemaphoreGive(art_mutex);
                         }
                     }
+                    } // end: dma_dl_start >= ART_TCP_RCVBUF_DL_SAFETY
                 } else if (len >= (int)max_art_size) {
                     Serial.printf("[ART] Album art too large: %d bytes (max %dKB)\n", len, (int)(max_art_size/1000));
                     // Force close - don't drain (overwhelms SDIO buffer)
@@ -1284,8 +1529,10 @@ void albumArtTask(void* param) {
                     if (use_https) secure_client.stop();
                     // Wait for in-flight packets to flush (HTTP: 300ms, HTTPS: 1000ms)
                     vTaskDelay(pdMS_TO_TICKS(use_https ? 1000 : 300));
-                    last_network_end_ms = millis();
+                    last_network_end_ms      = millis();
+                    last_art_download_end_ms = millis();   // gate inter-download cooldown after oversized abort
                     if (use_https) last_https_end_ms = millis();
+                    if (jpgBuf) { heap_caps_free(jpgBuf); jpgBuf = nullptr; }
                     xSemaphoreGive(network_mutex);
                     mutex_acquired = false;
                     continue;
@@ -1335,21 +1582,27 @@ void albumArtTask(void* param) {
                         }
                     }
 
-                    // End HTTP and close TLS BEFORE releasing mutex
-                    http.end();
-                    if (use_https) secure_client.stop();
+                    if (!http_early_closed) {
+                        // Normal TCP close — always reached since early-close was removed.
+                        // By this point the server's FIN has arrived during decode/scale (~200-400ms).
+                        // lwIP auto-ACKed it → we're in CLOSE_WAIT. http.end() sends our FIN →
+                        // LAST_ACK → CLOSED. Server enters TIME_WAIT (not us) → zero DMA cost per download.
+                        // For HTTPS: also stop secure_client to free TLS DMA session buffers.
+                        http.end();
+                        if (use_https) secure_client.stop();
+                        artLogMem("post-close");
 
-                    // Wait for cleanup and SDIO buffer stabilization
-                    // Local Sonos: 10ms (minimal, no TLS)
-                    // Local NAS/Plex: 30ms (local HTTP, slightly more than Sonos)
-                    // Internet HTTP: 50ms (fast cleanup)
-                    // Internet HTTPS: 200ms (TLS cleanup)
-                    vTaskDelay(pdMS_TO_TICKS(isFromSonosDevice ? 10 : (isLocalNetwork ? 30 : (use_https ? 200 : 50))));
+                        // Drain delay: local HTTP needs 200ms for final ACK exchange, HTTPS needs 500ms.
+                        vTaskDelay(pdMS_TO_TICKS(use_https ? SDIO_HTTPS_TCP_CLOSE_MS : SDIO_TCP_CLOSE_MS));
 
-                    // Update timestamps before releasing mutex
-                    last_network_end_ms = millis();
-                    if (use_https) last_https_end_ms = millis();
+                        // Update timestamps before releasing mutex
+                        last_network_end_ms      = millis();
+                        last_art_download_end_ms = millis();   // gate lyrics + queue cooldowns + inter-download
+                        if (use_https) last_https_end_ms = millis();
+                    }
 
+                    // Safety: free jpgBuf if not already freed (HTTP error, alloc-fail paths)
+                    if (jpgBuf) { heap_caps_free(jpgBuf); jpgBuf = nullptr; }
                     // Release network_mutex after ALL network activity including TLS cleanup
                     if (mutex_acquired) {
                         xSemaphoreGive(network_mutex);
@@ -1363,6 +1616,15 @@ void albumArtTask(void* param) {
         }
         vTaskDelay(pdMS_TO_TICKS(100));  // Check for new URLs
     }
+}
+
+// Invalidate LRU art cache — call on track change so stale art never flashes.
+// Safe to call from any thread: valid flag is volatile-written then the art task
+// reads it; worst case the task serves one stale frame before seeing the clear.
+void clearAlbumArtCache() {
+    art_cache[0].valid = false;
+    art_cache[1].valid = false;
+    Serial.println("[ART] LRU cache cleared");
 }
 
 // URL encode helper for proxying HTTPS URLs through Sonos
@@ -1391,4 +1653,8 @@ void requestAlbumArt(const String& url) {
         pending_art_url = url;
         xSemaphoreGive(art_mutex);
     }
+    // Do NOT set art_download_in_progress here. Flag is set AFTER sdioPreWait in the
+    // art task loop, where flag=false allows polling to keep SDIO warm during the
+    // storm-gate wait. Setting it here blocks polling → SDIO idle → DMA clock-gate.
+    last_track_change_ms = millis();
 }

--- a/src/ui_album_art.cpp
+++ b/src/ui_album_art.cpp
@@ -870,6 +870,17 @@ void albumArtTask(void* param) {
         Serial.println("[ART] LRU cache allocation failed — cache disabled");
     }
 
+    // Permanent 280KB PSRAM download buffer — allocated once, never freed.
+    // Eliminates per-download PSRAM heap alloc/free fragmentation:
+    //   - Back-to-back downloads can't fail due to heap fragmentation (even with 10MB+ free PSRAM)
+    //   - No risk of malloc returning nullptr mid-download due to previous alloc not yet freed by lwIP
+    // Safe to reuse across iterations: bytesRead/pre_drained track how much is valid each download.
+    static uint8_t* art_jpgbuf = nullptr;
+    if (!art_jpgbuf)
+        art_jpgbuf = (uint8_t*)heap_caps_malloc(MAX_ART_SIZE, MALLOC_CAP_SPIRAM);
+    if (!art_jpgbuf)
+        Serial.println("[ART] art_jpgbuf PSRAM alloc failed — downloads will be disabled");
+
     // Initialize ESP32-P4 Hardware JPEG Decoder
     jpeg_decode_engine_cfg_t hw_jpeg_cfg = {
         .intr_priority = 0,
@@ -1045,20 +1056,19 @@ void albumArtTask(void* param) {
                                   (unsigned)dma_snap, (unsigned)ART_MIN_DMA_PRE_BURST,
                                   (unsigned)(largest / 1024), dma_fail_count);
                     if (dma_fail_count >= 3) {
-                        // Give up: mark URL as handled so the outer loop stops retrying
-                        // until the track changes (same as WiFi-not-connected path).
-                        // DMA won't recover without a reboot; retrying wastes CPU/log.
-                        Serial.printf("[ART] DMA low x%d — giving up, showing placeholder\n",
-                                      dma_fail_count);
-                        if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
-                            last_art_url = url;  // marks URL "handled" → outer loop skips it
-                            xSemaphoreGive(art_mutex);
-                        }
-                        dma_fail_count = 0;
-                        dma_fail_url[0] = '\0';
-                        // Do NOT set last_art_download_end_ms — no network traffic happened.
-                        // Do NOT set art_download_in_progress — cleared by outer no-URL path.
+                        // DMA permanently depleted — restart to restore ~115KB DMA.
+                        // Clear flag FIRST so polling fires SOAPs during the 3s flush wait,
+                        // keeping SDIO warm and preventing DMA clock-gate before restart.
+                        Serial.printf("[ART] DMA low x%d (largest=%uKB) — restarting to recover DMA\n",
+                                      dma_fail_count,
+                                      (unsigned)(heap_caps_get_largest_free_block(MALLOC_CAP_DMA)/1024));
+                        art_download_in_progress = false;  // keep SDIO warm during restart wait
+                        vTaskDelay(pdMS_TO_TICKS(3000));  // let serial flush + SDIO settle
+                        esp_restart();
                     } else {
+                        // Clear flag so polling keeps SDIO warm during recovery wait.
+                        // Flag will be set true again after sdioPreWait on the next iteration.
+                        art_download_in_progress = false;
                         vTaskDelay(pdMS_TO_TICKS(2000));  // brief wait before retry
                         // Do NOT set last_art_download_end_ms — no network happened.
                     }
@@ -1093,12 +1103,15 @@ void albumArtTask(void* param) {
 
                     // Re-check cooldowns under mutex (another task may have used network while we waited)
                     // SDIO_GENERAL_COOLDOWN_MS (200ms) applied OUTSIDE the mutex in sdioPreWait.
-                    // Inside the mutex, only a short TCP FIN-ACK drain is needed (LAN <1ms).
-                    // Using 200ms here blocks the mutex for 200ms → SDIO idle → C6 power-save
-                    // → DMA clock-gate → pkt_rxbuff overflow → :928 on next TCP connection.
-                    // 10ms covers the FIN-ACK race window without triggering clock-gate.
+                    // Inside the mutex we need enough time for the last SOAP's TCP FIN-ACK to
+                    // arrive and be drained from C6 pkt_rxbuff before we open the art connection.
+                    // WiFi FIN-ACK RTT on LAN: ~10-30ms. The old 10ms was too short:
+                    // SOAP #N completes → mutex released → art acquires mutex (net=0ms) → only
+                    // 23ms passes before http.GET() → FIN-ACK still in transit → GET response
+                    // arrives simultaneously → pkt_rxbuff overflow → :928.
+                    // 50ms covers WiFi RTT with margin and is well below DMA clock-gate threshold.
                     {
-                        const unsigned long kInnerNetCooldownMs = 10;
+                        const unsigned long kInnerNetCooldownMs = 50;
                         if (last_network_end_ms > 0) {
                             unsigned long elapsed = millis() - last_network_end_ms;
                             if (elapsed < kInnerNetCooldownMs) {
@@ -1109,13 +1122,15 @@ void albumArtTask(void* param) {
                     // HTTPS TCP residue drain — catches lyrics→art race.
                     // If lyrics HTTPS completed while art waited for the mutex, last_https_end_ms
                     // is fresh. Art is HTTP-only (HTTPS downgraded in prepareAlbumArtURL), so we
-                    // only need TCP FIN-ACK drain time (SDIO_HTTPS_TCP_CLOSE_MS = 500ms), NOT the
-                    // full 3000ms DMA settle used between two HTTPS sessions. Using 3000ms here
-                    // caused 3s of SDIO silence → P4 SDIO DMA clock-gate → pkt_rxbuff overflow.
+                    // only need TCP FIN-ACK drain time. On LAN, TLS close_notify + TCP FIN-ACK
+                    // completes in <30ms; SDIO_TCP_CLOSE_MS (200ms) is ample margin.
+                    // Was SDIO_HTTPS_TCP_CLOSE_MS (500ms) — too long: if lyrics finished 100ms
+                    // before mutex acquisition, art waits 400ms inside mutex → SDIO idle →
+                    // C6 DMA clock-gate → pkt_rxbuff overflow on next TCP connection.
                     if (last_https_end_ms > 0) {
                         unsigned long elapsed = millis() - last_https_end_ms;
-                        if (elapsed < SDIO_HTTPS_TCP_CLOSE_MS) {
-                            vTaskDelay(pdMS_TO_TICKS(SDIO_HTTPS_TCP_CLOSE_MS - elapsed));
+                        if (elapsed < SDIO_TCP_CLOSE_MS) {
+                            vTaskDelay(pdMS_TO_TICKS(SDIO_TCP_CLOSE_MS - elapsed));
                         }
                     }
                     // Inside-mutex rechecks for queue-poll and inter-download: the full cooldowns
@@ -1189,12 +1204,12 @@ void albumArtTask(void* param) {
                         lwip_setsockopt(preClient.fd(), SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
                         vTaskDelay(pdMS_TO_TICKS(1));
                     }
-                    // Pre-allocate art buffer BEFORE GET so the full body can drain directly
-                    // into the final download buffer immediately after GET() returns.
+                    // Use the permanent static PSRAM download buffer — no per-download alloc.
+                    // art_jpgbuf is allocated once in albumArtTask init and reused every iteration.
                     const size_t max_art_size = MAX_ART_SIZE;
-                    uint8_t* jpgBuf = (uint8_t*)heap_caps_malloc(max_art_size, MALLOC_CAP_SPIRAM);
+                    uint8_t* jpgBuf = art_jpgbuf;  // static PSRAM buffer; null only if init failed
                     size_t pre_drained = 0;
-                    if (!jpgBuf) Serial.println("[ART] Pre-alloc failed — full drain disabled");
+                    if (!jpgBuf) Serial.println("[ART] art_jpgbuf unavailable — full drain disabled");
                     size_t dma_pre_get = heap_caps_get_free_size(MALLOC_CAP_DMA);
                     artLogMem("pre-GET");
                     artLogSDIO("pre-GET");
@@ -1229,6 +1244,12 @@ void albumArtTask(void* param) {
                                 size_t _g = _sd->readBytes(jpgBuf + pre_drained, _c);
                                 if (!_g) break;
                                 pre_drained += _g;
+                                // 5ms inter-chunk yield: gives SDIO time to drain residual
+                                // packets (500 FIN-ACK, SSDP, etc.) between server windows.
+                                // Without this, rapid tcp_recved() calls fire successive
+                                // windows faster than P4 SDIO can pull them from C6
+                                // pkt_rxbuff → :928 overflow. Same fix as main read loop.
+                                vTaskDelay(pdMS_TO_TICKS(5));
                             }
                         }
                     }
@@ -1242,10 +1263,9 @@ void albumArtTask(void* param) {
                 const bool len_known = (len > 0);
                 if ((len_known && len < (int)max_art_size) || !len_known) {
                     size_t alloc_len = len_known ? (size_t)len : max_art_size;
-                    // jpgBuf pre-allocated (max_art_size PSRAM bytes) above; alloc_len ≤ max_art_size.
+                    // jpgBuf points to the static 280KB PSRAM buffer (art_jpgbuf).
                     // pre_drained bytes already in jpgBuf[0..pre_drained-1] (full body if drain succeeded).
-                    // Fall back to a fresh alloc if the pre-alloc failed.
-                    if (!jpgBuf) jpgBuf = (uint8_t*)heap_caps_malloc(alloc_len, MALLOC_CAP_SPIRAM);
+                    // alloc_len ≤ MAX_ART_SIZE, so the buffer is always large enough.
 
                     if (len_known) {
                         Serial.printf("[ART] Downloading album art: %d bytes\n", len);
@@ -1261,11 +1281,11 @@ void albumArtTask(void* param) {
                                   dma_pre_get > dma_dl_start ? (unsigned)(dma_pre_get - dma_dl_start) : 0u);
                     if (dma_dl_start < ART_TCP_RCVBUF_DL_SAFETY || !jpgBuf) {
                         if (!jpgBuf)
-                            Serial.println("[ART] jpgBuf PSRAM alloc failed — aborting");
+                            Serial.println("[ART] art_jpgbuf unavailable — aborting");
                         else
                             Serial.printf("[ART] DMA too low at dl-start (%u < %u) — aborting\n",
                                           (unsigned)dma_dl_start, (unsigned)ART_TCP_RCVBUF_DL_SAFETY);
-                        if (jpgBuf) { heap_caps_free(jpgBuf); jpgBuf = nullptr; }
+                        jpgBuf = nullptr;  // static buffer — don't free, just mark unavailable for this iteration
                         http.end();
                         vTaskDelay(pdMS_TO_TICKS(SDIO_TCP_CLOSE_MS));
                         last_network_end_ms      = millis();
@@ -1395,7 +1415,7 @@ void albumArtTask(void* param) {
                         if (!readSuccess) {
                             Serial.println("[ART] Download failed/aborted - closing connection");
                             stream->stop();  // TCP RST - kills connection immediately
-                            heap_caps_free(jpgBuf); jpgBuf = nullptr;
+                            jpgBuf = nullptr;  // static buffer — don't free
                             // CRITICAL: http.end() + secure_client.stop() free TLS/DMA memory
                             // After TCP RST, these won't send SDIO traffic (socket is dead)
                             // but they WILL release DMA buffers used by esp-aes
@@ -1502,9 +1522,9 @@ void albumArtTask(void* param) {
                                 }
                             }
                         }
-                        heap_caps_free(jpgBuf); jpgBuf = nullptr;
+                        jpgBuf = nullptr;  // static buffer — don't free
                     } else {
-                        Serial.printf("[ART] Failed to allocate %d bytes for album art\n", len);
+                        Serial.printf("[ART] art_jpgbuf unavailable — cannot download %d bytes\n", len);
                         // Mark as done - memory issue, retry won't help
                         if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
                             last_art_url = url;
@@ -1532,7 +1552,7 @@ void albumArtTask(void* param) {
                     last_network_end_ms      = millis();
                     last_art_download_end_ms = millis();   // gate inter-download cooldown after oversized abort
                     if (use_https) last_https_end_ms = millis();
-                    if (jpgBuf) { heap_caps_free(jpgBuf); jpgBuf = nullptr; }
+                    jpgBuf = nullptr;  // static buffer — don't free
                     xSemaphoreGive(network_mutex);
                     mutex_acquired = false;
                     continue;
@@ -1601,8 +1621,8 @@ void albumArtTask(void* param) {
                         if (use_https) last_https_end_ms = millis();
                     }
 
-                    // Safety: free jpgBuf if not already freed (HTTP error, alloc-fail paths)
-                    if (jpgBuf) { heap_caps_free(jpgBuf); jpgBuf = nullptr; }
+                    // jpgBuf points to static art_jpgbuf — never freed between downloads.
+                    jpgBuf = nullptr;
                     // Release network_mutex after ALL network activity including TLS cleanup
                     if (mutex_acquired) {
                         xSemaphoreGive(network_mutex);

--- a/src/ui_globals.cpp
+++ b/src/ui_globals.cpp
@@ -148,6 +148,10 @@ volatile unsigned long last_art_download_end_ms = 0; // Set after large HTTP dow
 volatile unsigned long last_track_change_ms  = 0; // Set by requestAlbumArt(); 2000ms NOTIFY settle
 volatile unsigned long last_transient_500_ms = 0; // Set by sendSOAP() on 500; 3000ms HLS storm gate
 
+// On-demand queue window fetch (set by ev_queue / refresh button; consumed by polling task)
+volatile bool queue_fetch_requested   = false;
+volatile int  queue_fetch_start_index = 0;    // 0-based SOAP StartingIndex for the window
+
 // ============================================================================
 // UI State
 // ============================================================================

--- a/src/ui_globals.cpp
+++ b/src/ui_globals.cpp
@@ -104,7 +104,7 @@ lv_obj_t *btn_groups_scan = nullptr;
 lv_obj_t *spinner_groups_scan = nullptr;
 
 // ============================================================================
-// Album Art
+// Album Art — Rendering State
 // ============================================================================
 lv_img_dsc_t art_dsc;
 uint16_t* art_buffer = nullptr;
@@ -114,26 +114,39 @@ String pending_art_url = "";
 volatile bool art_ready = false;
 volatile bool art_show_placeholder = false;  // Signal UI to show placeholder (art permanently failed)
 SemaphoreHandle_t art_mutex = nullptr;
-TaskHandle_t albumArtTaskHandle = nullptr;
-StaticTask_t albumArtTaskTCB;               // TCB in internal SRAM (tiny, ~88 bytes)
-StackType_t* art_task_stack = nullptr;      // Stack in PSRAM — allocated once in createArtTask()
-TaskHandle_t lyricsTaskHandle = nullptr;
-StaticTask_t lyricsTaskTCB;                 // TCB in internal SRAM
-StackType_t* lyrics_task_stack = nullptr;   // Stack in PSRAM — allocated once in initLyrics()
-volatile bool lyrics_shutdown_requested = false;  // Signal lyrics task to stop for OTA
-volatile bool art_shutdown_requested = false;  // Signal album art to stop gracefully
-volatile bool art_abort_download = false;      // Signal to abort current download (source changed)
-volatile bool sonos_tasks_shutdown_requested = false;  // Signal Sonos tasks to stop for OTA
 uint32_t dominant_color = 0x1a1a1a;
 volatile bool color_ready = false;
 int art_offset_x = 0;
 int art_offset_y = 0;
 bool is_sonos_radio_art = false;
 bool pending_is_station_logo = false;
-volatile unsigned long last_queue_fetch_time = 0;  // Last updateQueue() completion time (large HTTP — art waits 2000ms)
-SemaphoreHandle_t network_mutex = NULL;  // Created in main.cpp
-volatile unsigned long last_network_end_ms = 0;  // Last network operation end time (for SDIO cooldown)
-volatile unsigned long last_https_end_ms = 0;   // Last HTTPS operation end time (TLS needs longer cooldown)
+
+// ============================================================================
+// Network Tasks — FreeRTOS Handles and Shutdown Signals
+// ============================================================================
+TaskHandle_t albumArtTaskHandle = nullptr;
+StaticTask_t albumArtTaskTCB;               // TCB in internal SRAM (tiny, ~88 bytes)
+StackType_t* art_task_stack = nullptr;      // Stack in PSRAM — allocated once in createArtTask()
+volatile bool art_shutdown_requested = false;  // Signal album art task to stop gracefully
+volatile bool art_abort_download = false;      // Signal to abort current download (source changed)
+TaskHandle_t lyricsTaskHandle = nullptr;
+StaticTask_t lyricsTaskTCB;                 // TCB in internal SRAM
+StackType_t* lyrics_task_stack = nullptr;   // Stack in PSRAM — allocated once in initLyrics()
+volatile bool lyrics_shutdown_requested = false;  // Signal lyrics task to stop for OTA
+volatile bool sonos_tasks_shutdown_requested = false;  // Signal Sonos tasks to stop for OTA
+
+// ============================================================================
+// SDIO Crash Defence — Network Timing Globals
+// (See MEMORY.md and ui_network_guard.h for full crash-defence architecture)
+// ============================================================================
+SemaphoreHandle_t network_mutex = NULL;  // Created in main.cpp; serialises all WiFi/HTTPS ops
+volatile unsigned long last_network_end_ms  = 0;  // Last network op end (200ms general cooldown)
+volatile unsigned long last_https_end_ms    = 0;  // Last HTTPS session end (3000ms TLS residue)
+volatile unsigned long last_queue_fetch_time = 0; // Last updateQueue() end (3000ms Browse residue)
+volatile bool          art_download_in_progress = false; // True during download — suppresses SOAP polling
+volatile unsigned long last_art_download_end_ms = 0; // Set after large HTTP downloads; gates lyrics/queue/inter-download cooldowns
+volatile unsigned long last_track_change_ms  = 0; // Set by requestAlbumArt(); 2000ms NOTIFY settle
+volatile unsigned long last_transient_500_ms = 0; // Set by sendSOAP() on 500; 3000ms HLS storm gate
 
 // ============================================================================
 // UI State

--- a/src/ui_handlers.cpp
+++ b/src/ui_handlers.cpp
@@ -120,9 +120,20 @@ void ev_devices(lv_event_t* e) {
 }
 
 void ev_queue(lv_event_t* e) {
-    // Use cached queue data — background poll updates dev->queue[] every 30s.
-    // Calling updateQueue() here fires a large SOAP response immediately before
-    // the user selects a track (art download) → SDIO RX pool exhausted → crash.
+    // Show cached data immediately, then request a fresh windowed fetch.
+    // The polling task picks up queue_fetch_requested and calls updateQueue(startIndex)
+    // on its next cycle (safe: no SOAP on UI thread).
+    SonosDevice* d = sonos.getCurrentDevice();
+    int start = 0;
+    if (d && d->currentTrackNumber > 0) {
+        start = d->currentTrackNumber - SONOS_QUEUE_BATCH_SIZE / 2;
+        if (start < 0) start = 0;
+        if (d->totalTracks > 0 && start + SONOS_QUEUE_BATCH_SIZE > d->totalTracks)
+            start = d->totalTracks - SONOS_QUEUE_BATCH_SIZE;
+        if (start < 0) start = 0;
+    }
+    queue_fetch_start_index = start;
+    queue_fetch_requested   = true;
     refreshQueueList();
     lv_screen_load(scr_queue);
 }
@@ -1843,7 +1854,13 @@ void processUpdates() {
     static uint32_t lastUpdate = 0;
     UIUpdate_t upd;
     bool need = false;
-    while (xQueueReceive(sonos.getUIUpdateQueue(), &upd, 0)) need = true;
+    bool queue_updated = false;
+    while (xQueueReceive(sonos.getUIUpdateQueue(), &upd, 0)) {
+        need = true;
+        if (upd.type == UPDATE_QUEUE) queue_updated = true;
+    }
     if (need && (millis() - lastUpdate > 200)) { updateUI(); lastUpdate = millis(); }
     else displayCompletedArt();  // Run even without Sonos events (e.g. art ready while polling suppressed)
+    // Auto-refresh queue list if the queue screen is visible when new data arrives
+    if (queue_updated && lv_screen_active() == scr_queue) refreshQueueList();
 }

--- a/src/ui_handlers.cpp
+++ b/src/ui_handlers.cpp
@@ -695,55 +695,10 @@ static void otaRecovery() {
     Serial.println("[OTA] === Recovery complete ===");
 }
 
-static void performOTAUpdate() {
-    if (download_url.length() == 0) {
-        if (lbl_ota_status) {
-            lv_label_set_text(lbl_ota_status, LV_SYMBOL_WARNING " No update URL found");
-            lv_obj_set_style_text_color(lbl_ota_status, lv_color_hex(0xFF6B6B), 0);
-        }
-        return;
-    }
-
-    // ================================================================
-    // PHASE 1: IMMEDIATE UI FEEDBACK
-    // ================================================================
-    // Show "Preparing..." IMMEDIATELY so user knows button press registered
-    if (btn_install_update) lv_obj_add_state(btn_install_update, LV_STATE_DISABLED);
-    if (btn_check_update) lv_obj_add_state(btn_check_update, LV_STATE_DISABLED);
-    if (lbl_ota_status) {
-        lv_label_set_text(lbl_ota_status, LV_SYMBOL_REFRESH " Preparing update...");
-        lv_obj_set_style_text_color(lbl_ota_status, COL_ACCENT, 0);
-    }
-    if (bar_ota_progress) {
-        lv_obj_clear_flag(bar_ota_progress, LV_OBJ_FLAG_HIDDEN);
-        lv_bar_set_value(bar_ota_progress, 0, LV_ANIM_OFF);
-    }
-    lv_tick_inc(10);
-    lv_refr_now(NULL);  // Force immediate refresh so user sees feedback
-
-    Serial.println("[OTA] ========================================");
-    Serial.println("[OTA] PREPARING FOR FIRMWARE UPDATE");
-    Serial.println("[OTA] ========================================");
-
-    // ================================================================
-    // PHASE 2: WAIT FOR PREVIOUS HTTPS CLEANUP
-    // ================================================================
-    unsigned long now = millis();
-    unsigned long elapsed = now - last_https_end_ms;
-    if (last_https_end_ms > 0 && elapsed < OTA_HTTPS_COOLDOWN_MS) {
-        unsigned long wait_ms = OTA_HTTPS_COOLDOWN_MS - elapsed;
-        Serial.printf("[OTA] Waiting for previous HTTPS cleanup: %lums\n", wait_ms);
-        if (lbl_ota_status) {
-            lv_label_set_text(lbl_ota_status, LV_SYMBOL_REFRESH " Waiting for network cleanup...");
-        }
-        lv_tick_inc(10);
-        lv_refr_now(NULL);
-        vTaskDelay(pdMS_TO_TICKS(wait_ms));
-    }
-
-    // ================================================================
-    // PHASE 3: STOP ALL BACKGROUND TASKS
-    // ================================================================
+// Signals all background tasks to stop, waits up to 12s for clean exit,
+// force-kills stragglers, recreates the network mutex, sets ota_in_progress.
+// Returns true if any task was force-killed (indicates possible DMA leak).
+static bool otaStopTasks() {
     if (lbl_ota_status) {
         lv_label_set_text(lbl_ota_status, LV_SYMBOL_REFRESH " Stopping background tasks...");
     }
@@ -757,24 +712,9 @@ static void performOTAUpdate() {
     lyrics_shutdown_requested     = true;
     lyrics_abort_requested        = true;
     clock_bg_shutdown_requested   = true;
-    sonos_tasks_shutdown_requested = true;  // Sonos exits within its 2s SOAP timeout
+    sonos_tasks_shutdown_requested = true;
 
-    // ─── PARALLEL TASK SHUTDOWN ──────────────────────────────────────────────
-    // All tasks received their shutdown signals simultaneously above.
-    // We wait for ALL of them in ONE combined loop — the total wait is bounded
-    // by the SLOWEST task, not the sum of all tasks.
-    //
-    // Worst-case exit times after signal:
-    //   Art:     < 1 s   — checks art_abort_download every 5–15 ms
-    //   Lyrics: ≤ 10 s   — HTTPClient.GET() blocks until response or timeout
-    //   ClockBg: < 0.5 s — 500 ms polling loop; shutdown flag checked every tick
-    // → 12 s covers all tasks running simultaneously (not sequentially).
-    //
-    // CRITICAL: Force-deleting a task that holds an active TLS session leaks
-    // its mbedTLS DMA (~40 KB per session). WiFi.disconnect() clears TCP
-    // TIME_WAIT sockets but CANNOT reclaim mbedTLS DMA — those buffers are only
-    // freed by secure_client.stop(). Always prefer clean exit over force-kill.
-    // If a future task is added that does HTTPS, add its handle to this loop.
+    bool force_killed = false;
     {
         const uint32_t SHUTDOWN_BUDGET_MS = 12000;
         uint32_t shutdown_start = millis();
@@ -788,10 +728,6 @@ static void performOTAUpdate() {
             esp_task_wdt_reset();
         }
 
-        // Force-delete any stragglers that did not exit in time.
-        // A force-killed task that owned a TLS session leaks DMA; the DMA
-        // polling step below will detect this and wait for it to recover.
-        bool force_killed = false;
         if (albumArtTaskHandle) {
             Serial.println("[OTA] WARNING: Force-killing art task (possible DMA leak)");
             vTaskDelete(albumArtTaskHandle);
@@ -811,8 +747,6 @@ static void performOTAUpdate() {
             force_killed = true;
         }
         if (force_killed) {
-            // Let FreeRTOS idle task reclaim TCB memory and allow any pending
-            // SDIO DMA descriptor to flush before we proceed.
             vTaskDelay(pdMS_TO_TICKS(500));
             esp_task_wdt_reset();
         }
@@ -821,32 +755,29 @@ static void performOTAUpdate() {
                       heap_caps_get_free_size(MALLOC_CAP_DMA));
     }
 
-    // Sonos tasks: signaled at t=0 alongside the others and have had the full
-    // 12 s to exit cleanly (Sonos SOAP timeout is 2 s, so this is usually instant).
     Serial.println("[OTA] Suspending Sonos tasks...");
     sonos.suspendTasks();
 
-    // ─── NETWORK MUTEX RECREATION ────────────────────────────────────────────
-    // A force-deleted task may have held network_mutex, leaving it permanently
-    // poisoned — no owner remains to give it back, so xSemaphoreTake() would
-    // block until its 3 s timeout then silently continue with broken state.
-    // Solution: delete and recreate the mutex unconditionally after all tasks
-    // are dead. This is always safe here because:
-    //   • every user task is now dead or suspended,
-    //   • ota_in_progress (set below) suppresses network ops in loop().
-    // Post-OTA recovery restarts tasks with the new, clean mutex handle.
+    // Recreate network mutex — a force-killed task may have left it poisoned.
     if (network_mutex) {
         vSemaphoreDelete(network_mutex);
         network_mutex = xSemaphoreCreateMutex();
         Serial.println("[OTA] Network mutex recreated (clean state)");
     }
 
-    // Set OTA-in-progress flag (suppresses UI updates and non-OTA network ops)
     if (xSemaphoreTake(ota_progress_mutex, pdMS_TO_TICKS(1000))) {
         ota_in_progress = true;
         xSemaphoreGive(ota_progress_mutex);
     }
 
+    return force_killed;
+}
+
+// Waits for TIME_WAIT TCP sockets to release DMA after task shutdown.
+// If DMA remains below OTA_TARGET_FREE_DMA after OTA_DMA_POLL_MS, saves URL
+// to NVS and calls ESP.restart() — does NOT return in that case.
+// On success, configures WiFi for the download and returns normally.
+static void otaCheckDMA() {
     // ================================================================
     // PHASE 4: CLEAR NETWORK STATE AND VERIFY DMA
     // ================================================================
@@ -926,6 +857,63 @@ static void performOTAUpdate() {
     // WiFi already connected; disable auto-reconnect and power-save for download
     WiFi.setAutoReconnect(false);
     WiFi.setSleep(false);
+}
+
+static void performOTAUpdate() {
+    if (download_url.length() == 0) {
+        if (lbl_ota_status) {
+            lv_label_set_text(lbl_ota_status, LV_SYMBOL_WARNING " No update URL found");
+            lv_obj_set_style_text_color(lbl_ota_status, lv_color_hex(0xFF6B6B), 0);
+        }
+        return;
+    }
+
+    // ================================================================
+    // PHASE 1: IMMEDIATE UI FEEDBACK
+    // ================================================================
+    // Show "Preparing..." IMMEDIATELY so user knows button press registered
+    if (btn_install_update) lv_obj_add_state(btn_install_update, LV_STATE_DISABLED);
+    if (btn_check_update) lv_obj_add_state(btn_check_update, LV_STATE_DISABLED);
+    if (lbl_ota_status) {
+        lv_label_set_text(lbl_ota_status, LV_SYMBOL_REFRESH " Preparing update...");
+        lv_obj_set_style_text_color(lbl_ota_status, COL_ACCENT, 0);
+    }
+    if (bar_ota_progress) {
+        lv_obj_clear_flag(bar_ota_progress, LV_OBJ_FLAG_HIDDEN);
+        lv_bar_set_value(bar_ota_progress, 0, LV_ANIM_OFF);
+    }
+    lv_tick_inc(10);
+    lv_refr_now(NULL);  // Force immediate refresh so user sees feedback
+
+    Serial.println("[OTA] ========================================");
+    Serial.println("[OTA] PREPARING FOR FIRMWARE UPDATE");
+    Serial.println("[OTA] ========================================");
+
+    // ================================================================
+    // PHASE 2: WAIT FOR PREVIOUS HTTPS CLEANUP
+    // ================================================================
+    unsigned long now = millis();
+    unsigned long elapsed = now - last_https_end_ms;
+    if (last_https_end_ms > 0 && elapsed < OTA_HTTPS_COOLDOWN_MS) {
+        unsigned long wait_ms = OTA_HTTPS_COOLDOWN_MS - elapsed;
+        Serial.printf("[OTA] Waiting for previous HTTPS cleanup: %lums\n", wait_ms);
+        if (lbl_ota_status) {
+            lv_label_set_text(lbl_ota_status, LV_SYMBOL_REFRESH " Waiting for network cleanup...");
+        }
+        lv_tick_inc(10);
+        lv_refr_now(NULL);
+        vTaskDelay(pdMS_TO_TICKS(wait_ms));
+    }
+
+    // ================================================================
+    // PHASE 3: STOP ALL BACKGROUND TASKS
+    // ================================================================
+    bool force_killed = otaStopTasks();
+
+    // ================================================================
+    // PHASE 4: CLEAR NETWORK STATE AND VERIFY DMA
+    // ================================================================
+    otaCheckDMA();  // polls TIME_WAIT sockets; restarts if DMA still low; sets WiFi mode
 
     // ================================================================
     // PHASE 5+6: CONNECT AND DOWNLOAD (retry on connection failure)
@@ -1372,28 +1360,25 @@ void triggerPendingOTA() {
 }
 
 // ============================================================================
-// UI Update Function
 // ============================================================================
-void updateUI() {
-    SonosDevice* d = sonos.getCurrentDevice();
-    if (!d) return;
+// updateUI() Sub-Functions (static — implementation details, not in any header)
+// ============================================================================
 
-    // Track connection state - start as disconnected to avoid false triggers
-    static bool was_connected = false;
-    static bool ui_cleared = false;
+// Handles disconnect/reconnect UI state. Returns true if device is connected
+// and updateUI() should continue. Returns false → caller must return immediately.
+static bool updateConnectionState(SonosDevice* d) {
+    static bool was_connected  = false;
+    static bool ui_cleared     = false;
     static bool last_conn_state = false;
 
-    // Debug: Log connection state changes
     if (d->connected != last_conn_state) {
         Serial.printf("[UI] Connection state changed: %s (errorCount=%d)\n",
                      d->connected ? "CONNECTED" : "DISCONNECTED", d->errorCount);
         last_conn_state = d->connected;
     }
 
-    // Handle disconnection - only clear UI once
     if (!d->connected) {
         if (was_connected || !ui_cleared) {
-            // Device just disconnected or first time showing disconnect state
             lv_label_set_text(lbl_title, "Device Not Connected");
             lv_label_set_text(lbl_artist, "");
             lv_label_set_text(lbl_album, "");
@@ -1401,21 +1386,17 @@ void updateUI() {
             lv_label_set_text(lbl_time_remaining, "0:00");
             lv_slider_set_value(slider_progress, 0, LV_ANIM_OFF);
 
-            // Hide album art, show placeholder
             lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
             lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
 
-            // Hide next track info
             lv_obj_add_flag(img_next_album, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(lbl_next_title, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(lbl_next_artist, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(lbl_next_header, LV_OBJ_FLAG_HIDDEN);
 
-            // Reset background color to default dark
-            if (panel_art) lv_obj_set_style_bg_color(panel_art, lv_color_hex(0x1a1a1a), 0);
+            if (panel_art)   lv_obj_set_style_bg_color(panel_art,   lv_color_hex(0x1a1a1a), 0);
             if (panel_right) lv_obj_set_style_bg_color(panel_right, COL_BG, 0);
 
-            // Reset play button to pause icon
             lv_obj_t* lbl = lv_obj_get_child(btn_play, 0);
             lv_label_set_text(lbl, LV_SYMBOL_PAUSE);
             lv_obj_center(lbl);
@@ -1426,18 +1407,301 @@ void updateUI() {
             ui_cleared = true;
             Serial.println("[UI] Device disconnected - UI cleared");
         }
-        return;  // Don't update UI when disconnected
+        return false;  // not connected
     }
 
-    // Handle reconnection - force UI refresh
     if (d->connected && !was_connected) {
         was_connected = true;
         ui_cleared = false;
-        // Force refresh of all UI elements by clearing cached values
         ui_title = "";
         ui_artist = "";
         Serial.println("[UI] Device reconnected - forcing UI refresh");
     }
+    return true;  // connected
+}
+
+// Displays art or placeholder from the background art task.
+// Must be called on the main LVGL thread. Takes art_mutex internally.
+static void displayCompletedArt() {
+    if (!xSemaphoreTake(art_mutex, 0)) return;
+
+    if (art_ready) {
+        // Build art_dsc here on the main thread — same thread as lv_timer_handler() /
+        // LVGL renderer — so there is never concurrent read+write of the descriptor.
+        // The background art task only writes art_buffer (pixels); we set the header here.
+        memset(&art_dsc, 0, sizeof(art_dsc));
+        art_dsc.header.w    = ART_SIZE;
+        art_dsc.header.h    = ART_SIZE;
+        art_dsc.header.cf   = LV_COLOR_FORMAT_RGB565;
+        art_dsc.data_size   = ART_SIZE * ART_SIZE * 2;
+        art_dsc.data        = (const uint8_t*)art_buffer;
+        lv_img_set_src(img_album, &art_dsc);
+        lv_obj_set_size(img_album, ART_SIZE, ART_SIZE);
+        lv_obj_center(img_album);
+        lv_obj_remove_flag(img_album, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
+        art_ready = false;
+        art_show_placeholder = false;
+    } else if (art_show_placeholder) {
+        lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
+        art_show_placeholder = false;
+    }
+    if (color_ready && panel_art && panel_right) {
+        setBackgroundColor(dominant_color);
+        color_ready = false;
+    }
+    xSemaphoreGive(art_mutex);
+}
+
+// Updates the "Next Up" track labels from the cached queue.
+static void updateNextTrackUI(SonosDevice* d) {
+    static String last_next_title = "";
+
+    if (!d->isRadioStation && d->queueSize > 0 && d->currentTrackNumber > 0) {
+        int nextIdx = -1;
+
+        // Find next track after current
+        for (int i = 0; i < d->queueSize; i++) {
+            if (d->queue[i].trackNumber == d->currentTrackNumber + 1) {
+                nextIdx = i;
+                break;
+            }
+        }
+
+        // If we're on last track and repeat is on, show first track
+        if (nextIdx < 0 && (d->repeatMode == "ALL" || d->repeatMode == "ONE")) {
+            for (int i = 0; i < d->queueSize; i++) {
+                if (d->queue[i].trackNumber == 1) {
+                    nextIdx = i;
+                    break;
+                }
+            }
+        }
+
+        if (nextIdx >= 0 && d->queue[nextIdx].title.length() > 0) {
+            String nextTitle = d->queue[nextIdx].title;
+            if (nextTitle != last_next_title) {
+                lv_label_set_text(lbl_next_title, d->queue[nextIdx].title.c_str());
+                lv_label_set_text(lbl_next_artist, d->queue[nextIdx].artist.c_str());
+                lv_obj_clear_flag(lbl_next_header, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_clear_flag(lbl_next_title, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_clear_flag(lbl_next_artist, LV_OBJ_FLAG_HIDDEN);
+                last_next_title = nextTitle;
+            }
+        } else if (nextIdx < 0) {
+            // Only hide if next track is truly unavailable (not just temporarily)
+            if (last_next_title != "") {
+                lv_obj_add_flag(lbl_next_header, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_add_flag(lbl_next_title, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_add_flag(lbl_next_artist, LV_OBJ_FLAG_HIDDEN);
+                last_next_title = "";
+            }
+        }
+    } else {
+        if (last_next_title != "") {
+            lv_obj_add_flag(lbl_next_header, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(lbl_next_title, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(lbl_next_artist, LV_OBJ_FLAG_HIDDEN);
+            last_next_title = "";
+        }
+    }
+}
+
+// Selects the correct art URL and calls requestAlbumArt() when needed.
+// Also handles URI change detection and "not playing" transitions.
+static void updateAlbumArtRequest(SonosDevice* d) {
+    static String last_track_uri = "";
+    static String last_source_prefix = "";
+    static bool had_track = false;
+
+    // Extract source prefix to detect actual source changes (not just track changes)
+    String current_source_prefix = "";
+    if (d->currentURI.startsWith("x-sonos-vli:")) {
+        current_source_prefix = "x-sonos-vli";  // Spotify, Apple Music, etc
+    } else if (d->currentURI.startsWith("hls-radio://")) {
+        current_source_prefix = "hls-radio";  // Radio
+    } else if (d->currentURI.startsWith("x-sonos-http:")) {
+        current_source_prefix = "x-sonos-http";  // Radio
+    } else if (d->currentURI.startsWith("x-rincon-mp3radio:")) {
+        current_source_prefix = "x-rincon-mp3radio";  // Radio
+    } else {
+        // Extract first part before colon for unknown sources
+        int colonPos = d->currentURI.indexOf(':');
+        if (colonPos > 0) {
+            current_source_prefix = d->currentURI.substring(0, colonPos);
+        }
+    }
+
+    // Detect ACTUAL source changes (Spotify→Radio, not Spotify track1→track2)
+    bool actual_source_change = (current_source_prefix != last_source_prefix && current_source_prefix.length() > 0);
+
+    // Detect any URI change (track or source)
+    bool uri_changed = (d->currentURI != last_track_uri);
+
+    if (uri_changed) {
+        // Always update last_track_uri (even when empty) to prevent repeated firing
+        // when Sonos reports empty URI in stopped state
+        last_track_uri = d->currentURI;
+
+        if (d->currentURI.length() > 0) {
+            if (actual_source_change) {
+                Serial.printf("[ART] SOURCE CHANGE: %s -> %s\n", last_source_prefix.c_str(), current_source_prefix.c_str());
+                last_source_prefix = current_source_prefix;
+            } else {
+                Serial.printf("[ART] Track changed (same source: %s)\n", current_source_prefix.c_str());
+            }
+            // CRITICAL: Abort any in-progress album art download immediately
+            // Applies to ALL track changes (not just source changes) so the art task
+            // doesn't wait for a 10-second HTTP timeout before processing the new track
+            art_abort_download = true;
+            // CRITICAL: Must hold art_mutex when writing last_art_url/pending_art_url -
+            // the art task reads both under mutex, and String assignment is not atomic.
+            if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(50))) {
+                last_art_url    = "";  // Force art refresh on any URI change
+                pending_art_url = "";  // Prevent art task downloading old song's art during
+                                       // the window between URI detection and requestAlbumArt()
+                                       // call ~100 lines below. Without this, art task wakes,
+                                       // sees pending=old_url != last_art_url="" and starts
+                                       // downloading wrong art, wasting SDIO traffic and setting
+                                       // last_art_download_end_ms (adding 1s cooldown for new art).
+                art_ready = false;  // Discard any just-completed download — prevents old art
+                                    // flashing for the new track if displayCompletedArt() fires
+                                    // before the new art task iteration starts.
+                xSemaphoreGive(art_mutex);
+            }
+            // Clear LRU cache: prevents cached art from the OLD track flashing for
+            // the NEW track if the art task picks up the new URL within the same
+            // updateUI frame (cache hit would bypass the placeholder entirely).
+            clearAlbumArtCache();
+            // Show placeholder immediately (main thread = LVGL-safe)
+            if (img_album)       lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
+            if (art_placeholder) lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+
+    // Show placeholder when device transitions to "Not Playing" (no active track)
+    // Without this, the last track's art stays frozen when playback stops
+    bool has_track = (d->currentTrack.length() > 0);
+    if (had_track && !has_track) {
+        Serial.println("[ART] Not playing - clearing art display");
+        art_abort_download = true;  // Stop any in-progress download immediately
+        clearAlbumArtCache();
+        if (img_album) lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
+        if (art_placeholder) lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
+        if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(50))) {
+            last_art_url = "";
+            pending_art_url = "";  // Prevent art task re-fetching the old URL
+            art_ready = false;     // Discard any just-completed download (prevents art flash)
+            xSemaphoreGive(art_mutex);
+        }
+    }
+    had_track = has_track;
+
+    // Request album art if URL provided and (URL changed or track changed)
+    // Compare against last_requested_art_url (HTTPS, same type as d->albumArtURL) NOT pending_art_url.
+    // The art task converts pending_art_url to HTTP internally — comparing HTTPS vs HTTP always
+    // returns "changed", calling requestAlbumArt() every frame and keeping art_download_in_progress=true
+    // permanently (blocking the clock screensaver and spamming last_track_change_ms).
+    static String last_requested_art_url = "";
+    bool hasArt = (d->albumArtURL.length() > 0) || (d->isRadioStation && d->radioStationArtURL.length() > 0);
+    bool artChanged = uri_changed || (d->albumArtURL.length() > 0 && d->albumArtURL != last_requested_art_url);
+
+    // For radio stations: also check if radioStationArtURL changed (even if albumArtURL is empty)
+    if (d->isRadioStation && d->radioStationArtURL.length() > 0 && d->radioStationArtURL != last_requested_art_url) {
+        artChanged = true;
+    }
+
+    if (!hasArt && uri_changed) {
+        // Track changed but has NO art URL — clear old art and show placeholder immediately
+        // (Without this, the old track's art stays on screen forever)
+        Serial.println("[ART] No art URL for this track - showing placeholder");
+        if (img_album) lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
+        if (art_placeholder) lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
+        if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(50))) {
+            last_art_url = "";
+            pending_art_url = "";  // Prevent art task re-fetching the old URL
+            art_ready = false;     // Discard any just-completed download (prevents art flash)
+            xSemaphoreGive(art_mutex);
+        }
+    } else if (hasArt && artChanged) {
+        String artURL = "";
+        bool usingStationLogo = false;  // Track if we're using station logo (PNG allowed)
+
+        // Determine which art to use
+        if (d->albumArtURL.length() > 0) {
+            artURL = d->albumArtURL;
+        }
+
+        // RADIO STATION LOGO FALLBACK:
+        // If playing radio and no song art available, use station logo instead
+        if (d->isRadioStation) {
+            bool hasSongArt = (artURL.length() > 0);
+            bool hasStationLogo = (d->radioStationArtURL.length() > 0);
+            Serial.printf("[ART] Radio check - hasSongArt=%d, hasStationLogo=%d, artURL='%s', stationURL='%s'\n",
+                         hasSongArt, hasStationLogo, artURL.c_str(), d->radioStationArtURL.c_str());
+
+            // If no song art but have station logo, use the logo
+            if (!hasSongArt && hasStationLogo) {
+                artURL = d->radioStationArtURL;
+                usingStationLogo = true;
+                Serial.println("[ART] Radio: Using station logo (no song art)");
+            }
+            // If song art is just a generic Sonos radio icon, prefer the actual station logo
+            else if (hasSongArt && hasStationLogo && artURL.indexOf("/getaa?") > 0) {
+                // Check if it's pointing to the radio URI (generic icon)
+                if (artURL.indexOf("x-sonosapi-stream") > 0 ||
+                    artURL.indexOf("x-rincon-mp3radio") > 0 ||
+                    artURL.indexOf("x-sonosapi-radio") > 0 ||
+                    artURL.indexOf("x-sonosapi-hls") > 0) {
+                    artURL = d->radioStationArtURL;
+                    usingStationLogo = true;
+                    Serial.println("[ART] Radio: Using station logo (replacing generic icon)");
+                }
+            }
+        }
+
+        // Set the flag for album art task to know if PNG is allowed
+        pending_is_station_logo = usingStationLogo;
+
+        if (artURL.length() > 0) {
+            // Note: Using ESP32-P4 hardware JPEG decoder - can handle full 640x640 Spotify images!
+
+            // Apple Music: reduce image size to avoid "too large" errors (1400x1400 can be 500KB+)
+            if (artURL.indexOf("mzstatic.com") > 0) {
+                if (artURL.indexOf("/1400x1400bb.jpg") > 0) {
+                    artURL.replace("/1400x1400bb.jpg", "/400x400bb.jpg");
+                    Serial.println("[ART] Apple Music - reduced to 400x400");
+                } else if (artURL.indexOf("/1080x1080cc.jpg") > 0) {
+                    artURL.replace("/1080x1080cc.jpg", "/400x400cc.jpg");
+                    Serial.println("[ART] Apple Music - reduced to 400x400");
+                }
+            }
+
+            requestAlbumArt(artURL);
+            last_requested_art_url = artURL;  // track HTTPS URL; prevents HTTPS!=HTTP false-positive on next frame
+        } else {
+            // No art available - clear display
+            Serial.println("[ART] No art URL - clearing display");
+            if (img_album) lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
+            if (art_placeholder) lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
+            // CRITICAL: Must hold art_mutex when writing last_art_url (not atomic)
+            if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(50))) {
+                last_art_url = "";  // Clear to allow next art request
+                xSemaphoreGive(art_mutex);
+            }
+        }
+    }
+}
+
+// ============================================================================
+// UI Update Function
+// ============================================================================
+void updateUI() {
+    SonosDevice* d = sonos.getCurrentDevice();
+    if (!d) return;
+
+    if (!updateConnectionState(d)) return;
 
     // Device is connected - update UI normally
 
@@ -1457,10 +1721,19 @@ void updateUI() {
     static String lyrics_last_track = "";
     String lyrics_key = d->currentArtist + "|" + d->currentTrack;
     if (lyrics_key != lyrics_last_track && d->currentTrack.length() > 0) {
-        lyrics_last_track = lyrics_key;
+        last_track_change_ms = millis();
         if (lyrics_enabled && !d->isRadioStation) {
-            requestLyrics(d->currentArtist, d->currentTrack, d->durationSeconds);
+            // requestLyrics() returns false if the previous task is still running
+            // (e.g. blocked inside http.GET() with up to 10s timeout). In that case
+            // we do NOT update lyrics_last_track — the condition fires again next
+            // frame until the old task exits and requestLyrics() can safely spawn.
+            // This prevents TCB/stack reuse while the old task is alive, which would
+            // permanently leak ~32KB of TLS DMA buffers per rapid track change.
+            if (requestLyrics(d->currentArtist, d->currentTrack, d->durationSeconds)) {
+                lyrics_last_track = lyrics_key;
+            }
         } else {
+            lyrics_last_track = lyrics_key;
             clearLyrics();
         }
     }
@@ -1539,55 +1812,7 @@ void updateUI() {
 
     // Next track info - find next track in queue
     // SKIP FOR RADIO MODE - radio stations don't have a queue/next track
-    static String last_next_title = "";
-    if (!d->isRadioStation && d->queueSize > 0 && d->currentTrackNumber > 0) {
-        int nextIdx = -1;
-
-        // Find next track after current
-        for (int i = 0; i < d->queueSize; i++) {
-            if (d->queue[i].trackNumber == d->currentTrackNumber + 1) {
-                nextIdx = i;
-                break;
-            }
-        }
-
-        // If we're on last track and repeat is on, show first track
-        if (nextIdx < 0 && (d->repeatMode == "ALL" || d->repeatMode == "ONE")) {
-            for (int i = 0; i < d->queueSize; i++) {
-                if (d->queue[i].trackNumber == 1) {
-                    nextIdx = i;
-                    break;
-                }
-            }
-        }
-
-        if (nextIdx >= 0 && d->queue[nextIdx].title.length() > 0) {
-            String nextTitle = d->queue[nextIdx].title;
-            if (nextTitle != last_next_title) {
-                lv_label_set_text(lbl_next_title, d->queue[nextIdx].title.c_str());
-                lv_label_set_text(lbl_next_artist, d->queue[nextIdx].artist.c_str());
-                lv_obj_clear_flag(lbl_next_header, LV_OBJ_FLAG_HIDDEN);
-                lv_obj_clear_flag(lbl_next_title, LV_OBJ_FLAG_HIDDEN);
-                lv_obj_clear_flag(lbl_next_artist, LV_OBJ_FLAG_HIDDEN);
-                last_next_title = nextTitle;
-            }
-        } else if (nextIdx < 0) {
-            // Only hide if next track is truly unavailable (not just temporarily)
-            if (last_next_title != "") {
-                lv_obj_add_flag(lbl_next_header, LV_OBJ_FLAG_HIDDEN);
-                lv_obj_add_flag(lbl_next_title, LV_OBJ_FLAG_HIDDEN);
-                lv_obj_add_flag(lbl_next_artist, LV_OBJ_FLAG_HIDDEN);
-                last_next_title = "";
-            }
-        }
-    } else {
-        if (last_next_title != "") {
-            lv_obj_add_flag(lbl_next_header, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_add_flag(lbl_next_title, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_add_flag(lbl_next_artist, LV_OBJ_FLAG_HIDDEN);
-            last_next_title = "";
-        }
-    }
+    updateNextTrackUI(d);
 
     // Repeat
     if (d->repeatMode != ui_repeat) {
@@ -1607,198 +1832,8 @@ void updateUI() {
 
     // Album art - only request if URL changed to prevent download loops
     // NOTE: last_art_url is GLOBAL (extern in ui_common.h), don't shadow it!
-    static String last_track_uri = "";
-    static String last_source_prefix = "";
-
-    // Extract source prefix to detect actual source changes (not just track changes)
-    String current_source_prefix = "";
-    if (d->currentURI.startsWith("x-sonos-vli:")) {
-        current_source_prefix = "x-sonos-vli";  // Spotify, Apple Music, etc
-    } else if (d->currentURI.startsWith("hls-radio://")) {
-        current_source_prefix = "hls-radio";  // Radio
-    } else if (d->currentURI.startsWith("x-sonos-http:")) {
-        current_source_prefix = "x-sonos-http";  // Radio
-    } else if (d->currentURI.startsWith("x-rincon-mp3radio:")) {
-        current_source_prefix = "x-rincon-mp3radio";  // Radio
-    } else {
-        // Extract first part before colon for unknown sources
-        int colonPos = d->currentURI.indexOf(':');
-        if (colonPos > 0) {
-            current_source_prefix = d->currentURI.substring(0, colonPos);
-        }
-    }
-
-    // Detect ACTUAL source changes (Spotify→Radio, not Spotify track1→track2)
-    bool actual_source_change = (current_source_prefix != last_source_prefix && current_source_prefix.length() > 0);
-
-    // Detect any URI change (track or source)
-    bool uri_changed = (d->currentURI != last_track_uri);
-
-    if (uri_changed) {
-        // Always update last_track_uri (even when empty) to prevent repeated firing
-        // when Sonos reports empty URI in stopped state
-        last_track_uri = d->currentURI;
-
-        if (d->currentURI.length() > 0) {
-            if (actual_source_change) {
-                Serial.printf("[ART] SOURCE CHANGE: %s -> %s\n", last_source_prefix.c_str(), current_source_prefix.c_str());
-                last_source_prefix = current_source_prefix;
-            } else {
-                Serial.printf("[ART] Track changed (same source: %s)\n", current_source_prefix.c_str());
-            }
-            // CRITICAL: Abort any in-progress album art download immediately
-            // Applies to ALL track changes (not just source changes) so the art task
-            // doesn't wait for a 10-second HTTP timeout before processing the new track
-            art_abort_download = true;
-            // CRITICAL: Must hold art_mutex when writing last_art_url - the art task reads
-            // it under mutex, and String assignment is not atomic (race condition → corruption)
-            if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(50))) {
-                last_art_url = "";  // Force art refresh on any URI change
-                xSemaphoreGive(art_mutex);
-            }
-        }
-    }
-
-    // Show placeholder when device transitions to "Not Playing" (no active track)
-    // Without this, the last track's art stays frozen when playback stops
-    static bool had_track = false;
-    bool has_track = (d->currentTrack.length() > 0);
-    if (had_track && !has_track) {
-        Serial.println("[ART] Not playing - clearing art display");
-        art_abort_download = true;  // Stop any in-progress download immediately
-        if (img_album) lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
-        if (art_placeholder) lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
-        if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(50))) {
-            last_art_url = "";
-            pending_art_url = "";  // Prevent art task re-fetching the old URL
-            art_ready = false;     // Discard any just-completed download (prevents art flash)
-            xSemaphoreGive(art_mutex);
-        }
-    }
-    had_track = has_track;
-
-    // Request album art if URL provided and (URL changed or track changed)
-    // Note: Don't compare against last_art_url (HTTP) since d->albumArtURL is HTTPS
-    // Let art task handle deduplication after HTTP conversion
-    // For radio: also check radioStationArtURL if albumArtURL is empty
-    bool hasArt = (d->albumArtURL.length() > 0) || (d->isRadioStation && d->radioStationArtURL.length() > 0);
-    bool artChanged = (d->albumArtURL != pending_art_url) || uri_changed;
-
-    // For radio stations: also check if radioStationArtURL changed (even if albumArtURL is empty)
-    if (d->isRadioStation && d->radioStationArtURL.length() > 0 && d->radioStationArtURL != pending_art_url) {
-        artChanged = true;
-    }
-
-    if (!hasArt && uri_changed) {
-        // Track changed but has NO art URL — clear old art and show placeholder immediately
-        // (Without this, the old track's art stays on screen forever)
-        Serial.println("[ART] No art URL for this track - showing placeholder");
-        if (img_album) lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
-        if (art_placeholder) lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
-        if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(50))) {
-            last_art_url = "";
-            pending_art_url = "";  // Prevent art task re-fetching the old URL
-            art_ready = false;     // Discard any just-completed download (prevents art flash)
-            xSemaphoreGive(art_mutex);
-        }
-    } else if (hasArt && artChanged) {
-        String artURL = "";
-        bool usingStationLogo = false;  // Track if we're using station logo (PNG allowed)
-
-        // Determine which art to use
-        if (d->albumArtURL.length() > 0) {
-            artURL = d->albumArtURL;
-        }
-
-        // RADIO STATION LOGO FALLBACK:
-        // If playing radio and no song art available, use station logo instead
-        if (d->isRadioStation) {
-            bool hasSongArt = (artURL.length() > 0);
-            bool hasStationLogo = (d->radioStationArtURL.length() > 0);
-            Serial.printf("[ART] Radio check - hasSongArt=%d, hasStationLogo=%d, artURL='%s', stationURL='%s'\n",
-                         hasSongArt, hasStationLogo, artURL.c_str(), d->radioStationArtURL.c_str());
-
-            // If no song art but have station logo, use the logo
-            if (!hasSongArt && hasStationLogo) {
-                artURL = d->radioStationArtURL;
-                usingStationLogo = true;
-                Serial.println("[ART] Radio: Using station logo (no song art)");
-            }
-            // If song art is just a generic Sonos radio icon, prefer the actual station logo
-            else if (hasSongArt && hasStationLogo && artURL.indexOf("/getaa?") > 0) {
-                // Check if it's pointing to the radio URI (generic icon)
-                if (artURL.indexOf("x-sonosapi-stream") > 0 ||
-                    artURL.indexOf("x-rincon-mp3radio") > 0 ||
-                    artURL.indexOf("x-sonosapi-radio") > 0 ||
-                    artURL.indexOf("x-sonosapi-hls") > 0) {
-                    artURL = d->radioStationArtURL;
-                    usingStationLogo = true;
-                    Serial.println("[ART] Radio: Using station logo (replacing generic icon)");
-                }
-            }
-        }
-
-        // Set the flag for album art task to know if PNG is allowed
-        pending_is_station_logo = usingStationLogo;
-
-        if (artURL.length() > 0) {
-            // Note: Using ESP32-P4 hardware JPEG decoder - can handle full 640x640 Spotify images!
-
-            // Apple Music: reduce image size to avoid "too large" errors (1400x1400 can be 500KB+)
-            if (artURL.indexOf("mzstatic.com") > 0) {
-                if (artURL.indexOf("/1400x1400bb.jpg") > 0) {
-                    artURL.replace("/1400x1400bb.jpg", "/400x400bb.jpg");
-                    Serial.println("[ART] Apple Music - reduced to 400x400");
-                } else if (artURL.indexOf("/1080x1080cc.jpg") > 0) {
-                    artURL.replace("/1080x1080cc.jpg", "/400x400cc.jpg");
-                    Serial.println("[ART] Apple Music - reduced to 400x400");
-                }
-            }
-
-            requestAlbumArt(artURL);
-            // Don't set last_art_url here - let art task manage it (HTTP vs HTTPS conversion)
-        } else {
-            // No art available - clear display
-            Serial.println("[ART] No art URL - clearing display");
-            if (img_album) lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
-            if (art_placeholder) lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
-            // CRITICAL: Must hold art_mutex when writing last_art_url (not atomic)
-            if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(50))) {
-                last_art_url = "";  // Clear to allow next art request
-                xSemaphoreGive(art_mutex);
-            }
-        }
-    }
-    if (xSemaphoreTake(art_mutex, 0)) {
-        if (art_ready) {
-            // Build art_dsc here on the main thread — same thread as lv_timer_handler() /
-            // LVGL renderer — so there is never concurrent read+write of the descriptor.
-            // The background art task only writes art_buffer (pixels); we set the header here.
-            memset(&art_dsc, 0, sizeof(art_dsc));
-            art_dsc.header.w    = ART_SIZE;
-            art_dsc.header.h    = ART_SIZE;
-            art_dsc.header.cf   = LV_COLOR_FORMAT_RGB565;
-            art_dsc.data_size   = ART_SIZE * ART_SIZE * 2;
-            art_dsc.data        = (const uint8_t*)art_buffer;
-            lv_img_set_src(img_album, &art_dsc);
-            lv_obj_set_size(img_album, ART_SIZE, ART_SIZE);  // Re-enforce after LVGL v9 auto-resize
-            lv_obj_center(img_album);
-            lv_obj_remove_flag(img_album, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_add_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
-            art_ready = false;
-            art_show_placeholder = false;
-        } else if (art_show_placeholder) {
-            // Art permanently failed - hide old art, show placeholder
-            lv_obj_add_flag(img_album, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_remove_flag(art_placeholder, LV_OBJ_FLAG_HIDDEN);
-            art_show_placeholder = false;
-        }
-        if (color_ready && panel_art && panel_right) {
-            setBackgroundColor(dominant_color);
-            color_ready = false;
-        }
-        xSemaphoreGive(art_mutex);
-    }
+    updateAlbumArtRequest(d);
+    displayCompletedArt();
 
     // Radio mode UI adaptation - must be at the END of updateUI()
     updateRadioModeUI();
@@ -1810,4 +1845,5 @@ void processUpdates() {
     bool need = false;
     while (xQueueReceive(sonos.getUIUpdateQueue(), &upd, 0)) need = true;
     if (need && (millis() - lastUpdate > 200)) { updateUI(); lastUpdate = millis(); }
+    else displayCompletedArt();  // Run even without Sonos events (e.g. art ready while polling suppressed)
 }

--- a/src/ui_network_guard.cpp
+++ b/src/ui_network_guard.cpp
@@ -1,0 +1,138 @@
+#include "ui_network_guard.h"
+#include "ui_common.h"
+#include "config.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <Arduino.h>
+
+static inline bool _aborted(volatile bool* f1, volatile bool* f2) {
+    return (f1 && *f1) || (f2 && *f2);
+}
+
+bool sdioPreWait(const char* tag, uint32_t flags,
+                 volatile bool* abort_flag1, volatile bool* abort_flag2)
+{
+    // ── 1. Track-change settle (currently disabled — SDIO_TRACK_CHANGE_SETTLE_MS=0) ──
+    // Was 2000ms to drain UPnP NOTIFY bursts, but Sonos lib is pure SOAP-polling:
+    // no UPnP subscriptions, no WiFiServer, no NOTIFY events arrive at all.
+    // The 2000ms idle was causing C6 WiFi power-save → pkt_rxbuff overflow.
+    // Kept as a while-loop (not one-shot) so the window stays coherent if
+    // SDIO_TRACK_CHANGE_SETTLE_MS is re-enabled: last_track_change_ms is written
+    // by requestAlbumArt() on Core 1 a few ms after requestLyrics() spawns this
+    // task, so a while-loop correctly extends the wait if the timestamp is updated.
+    if (flags & SDIO_WAIT_TRACK_CHANGE) {
+        bool logged = false;
+        while (!_aborted(abort_flag1, abort_flag2)) {
+            if (last_track_change_ms == 0) break;
+            unsigned long elapsed = millis() - last_track_change_ms;
+            if (elapsed >= SDIO_TRACK_CHANGE_SETTLE_MS) break;
+            unsigned long remaining = SDIO_TRACK_CHANGE_SETTLE_MS - elapsed;
+            if (!logged) {
+                Serial.printf("[%s] Track-change settle: waiting %lums\n", tag, remaining);
+                logged = true;
+            }
+            vTaskDelay(pdMS_TO_TICKS(remaining < 50 ? remaining : 50));
+        }
+    }
+    if (_aborted(abort_flag1, abort_flag2)) return false;
+
+    // ── 2. HTTP-500 storm while-loop ──────────────────────────────────────────
+    // Sonos returns 500 during HLS source transitions.
+    // While-loop re-evaluates each 50ms so new 500s extend the window.
+    if (flags & SDIO_WAIT_STORM_GATE) {
+        unsigned long storm_start = millis();
+        bool logged = false;
+        bool storm_was_active = false;
+        while (true) {
+            if (_aborted(abort_flag1, abort_flag2)) return false;
+            if (last_transient_500_ms == 0) break;
+            if (millis() - last_transient_500_ms >= SDIO_STORM_COOLDOWN_MS) break;
+            if (millis() - storm_start > SDIO_STORM_SAFETY_CAP_MS) {
+                Serial.printf("[%s] 500-storm safety cap — proceeding\n", tag);
+                storm_was_active = true;
+                break;
+            }
+            if (!logged) {
+                Serial.printf("[%s] Sonos 500 storm: waiting for HLS transition...\n", tag);
+                logged = true;
+            }
+            storm_was_active = true;
+            vTaskDelay(pdMS_TO_TICKS(50));
+        }
+        if (_aborted(abort_flag1, abort_flag2)) return false;
+
+        // Post-storm settle (currently disabled — SDIO_POST_STORM_SETTLE_MS=0).
+        // Was 4000ms to wait for a 2nd UPnP NOTIFY wave, but Sonos library uses pure
+        // SOAP-polling (no UPnP subscriptions, no WiFiServer, no NOTIFY events).
+        // That 4000ms idle caused C6 WiFi power-save → pkt_rxbuff overflow at download start.
+        if (storm_was_active && SDIO_POST_STORM_SETTLE_MS > 0) {
+            Serial.printf("[%s] Post-storm settle: waiting %ums\n", tag, SDIO_POST_STORM_SETTLE_MS);
+            vTaskDelay(pdMS_TO_TICKS(SDIO_POST_STORM_SETTLE_MS));
+            if (_aborted(abort_flag1, abort_flag2)) return false;
+        }
+    }
+
+    // ── 3. General cooldown ───────────────────────────────────────────────────
+    // Minimum gap between any two network operations (HTTP or HTTPS).
+    // Even local HTTP generates SDIO traffic that can combine with SOAP/NOTIFY.
+    if (last_network_end_ms > 0) {
+        unsigned long elapsed = millis() - last_network_end_ms;
+        if (elapsed < SDIO_GENERAL_COOLDOWN_MS) {
+            vTaskDelay(pdMS_TO_TICKS(SDIO_GENERAL_COOLDOWN_MS - elapsed));
+        }
+    }
+    if (_aborted(abort_flag1, abort_flag2)) return false;
+
+    // ── 4. HTTPS residue cooldown (opt-in: SDIO_WAIT_HTTPS_COOLDOWN) ─────────────
+    // mbedTLS DMA buffers (~71KB) take ~3s to fully release after TLS session
+    // teardown. Only needed when the caller itself does HTTPS — applying it
+    // unconditionally to plain HTTP callers (sendSOAP, local Sonos getaa) caused
+    // 3s of SDIO idle → P4 SDIO DMA clock-gated → pkt_rxbuff :928 overflow.
+    if ((flags & SDIO_WAIT_HTTPS_COOLDOWN) && last_https_end_ms > 0) {
+        unsigned long elapsed = millis() - last_https_end_ms;
+        if (elapsed < SDIO_HTTPS_COOLDOWN_MS) {
+            Serial.printf("[%s] HTTPS cooldown: waiting %lums\n",
+                          tag, SDIO_HTTPS_COOLDOWN_MS - elapsed);
+            vTaskDelay(pdMS_TO_TICKS(SDIO_HTTPS_COOLDOWN_MS - elapsed));
+        }
+    }
+    if (_aborted(abort_flag1, abort_flag2)) return false;
+
+    // ── 5. Queue poll residue cooldown ────────────────────────────────────────
+    // updateQueue() returns ~20KB Browse response. Combined with a concurrent
+    // download it exhausts the SDIO RX buffer pool → pkt_rxbuff :928 crash.
+    if ((flags & SDIO_WAIT_QUEUE_POLL) && last_queue_fetch_time > 0) {
+        unsigned long elapsed = millis() - last_queue_fetch_time;
+        if (elapsed < SDIO_QUEUE_POLL_COOLDOWN_MS) {
+            Serial.printf("[%s] Queue poll cooldown: waiting %lums\n",
+                          tag, SDIO_QUEUE_POLL_COOLDOWN_MS - elapsed);
+            vTaskDelay(pdMS_TO_TICKS(SDIO_QUEUE_POLL_COOLDOWN_MS - elapsed));
+        }
+    }
+    if (_aborted(abort_flag1, abort_flag2)) return false;
+
+    // ── 6. Inter-download cooldown ────────────────────────────────────────────
+    // Back-to-back large HTTP downloads exhaust pkt_rxbuff: previous download's
+    // TCP FIN-ACK + new download's SYN-ACK arrive simultaneously → overflow.
+    // last_art_download_end_ms is set by art task AND clockBgTask after large downloads.
+    //
+    // HTTPS callers (SDIO_WAIT_HTTPS_COOLDOWN set) need SDIO_HTTPS_COOLDOWN_MS (3s):
+    // TLS handshake generates a burst of 2-4 incoming TCP segments (ServerHello +
+    // Certificate). If art's HTTP TCP residue hasn't fully drained, this burst
+    // overflows pkt_rxbuff → :928. 3s matches the system-wide TLS drain standard.
+    // HTTP callers (art task) need only SDIO_INTER_DOWNLOAD_MS (1s): HTTP SYN-ACK
+    // is a single segment; 1s is sufficient for prior FIN-ACK to drain.
+    if (last_art_download_end_ms > 0) {
+        unsigned long threshold = (flags & SDIO_WAIT_HTTPS_COOLDOWN)
+                                  ? SDIO_HTTPS_COOLDOWN_MS
+                                  : SDIO_INTER_DOWNLOAD_MS;
+        unsigned long elapsed = millis() - last_art_download_end_ms;
+        if (elapsed < threshold) {
+            Serial.printf("[%s] Inter-download cooldown: waiting %lums\n",
+                          tag, threshold - elapsed);
+            vTaskDelay(pdMS_TO_TICKS(threshold - elapsed));
+        }
+    }
+
+    return !_aborted(abort_flag1, abort_flag2);
+}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.3.0-nightly.85f511a"
+  "version": "1.3.0-nightly.b75ca67"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.5.0-nightly.12e5b76"
+  "version": "1.6.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.3.0-nightly.b75ca67"
+  "version": "1.5.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.5.0"
+  "version": "1.5.0-nightly.12e5b76"
 }

--- a/web-installer/manifest.json
+++ b/web-installer/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32-P4 Sonos Controller",
-  "version": "1.3.0-nightly.85f511a",
+  "version": "1.3.0-nightly.b75ca67",
   "new_install_prompt_erase": true,
   "builds": [
     {

--- a/web-installer/manifest.json
+++ b/web-installer/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32-P4 Sonos Controller",
-  "version": "1.3.0-nightly.b75ca67",
+  "version": "1.5.0",
   "new_install_prompt_erase": true,
   "builds": [
     {

--- a/web-installer/manifest.json
+++ b/web-installer/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32-P4 Sonos Controller",
-  "version": "1.5.0-nightly.12e5b76",
+  "version": "1.6.0",
   "new_install_prompt_erase": true,
   "builds": [
     {

--- a/web-installer/manifest.json
+++ b/web-installer/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32-P4 Sonos Controller",
-  "version": "1.5.0",
+  "version": "1.5.0-nightly.12e5b76",
   "new_install_prompt_erase": true,
   "builds": [
     {


### PR DESCRIPTION
# Changes — 2026-03-19

## SDIO / DMA
- `updateQueue` batch 50→10 — DMA floor 35→85 KB (primary crash fix)
- Queue poll interval 30s→60s
- `ART_MIN_DMA_PRE_BURST` reverted to 20000
- Art task: static 280 KB PSRAM buffer (no fragmentation)
- Art task: clear `art_download_in_progress` before DMA wait (prevents clock-gate)

## Dynamic Queue Window
- `updateQueue(startIndex)` — windowed fetch centred on current track (±5 tracks)
- Auto-triggers on every track skip → **Next Up** always populated
- Opening queue screen / Refresh button requests window asynchronously (no SOAP on UI thread)
- Status label shows `Tracks 4-13 of 47`

## Bug Fixes
- Mid-cycle guard `!isEmpty()` → `!= last_art_url` — was silently killing volume/transport/queue polling every cycle
- Queue list uses absolute `trackNumber` — correct highlight and play-on-tap for any window
