### PR TITLE
Fix speaker names with smart punctuation rendering as tofu

### DIFF
--- a/src/sonos_discovery.cpp
+++ b/src/sonos_discovery.cpp
@@ -363,7 +363,10 @@ void SonosController::getRoomName(SonosDevice* dev) {
         int start = xml.indexOf("<roomName>");
         int end = xml.indexOf("</roomName>");
         if (start > 0 && end > start) {
-            dev->roomName = xml.substring(start + 10, end);
+            // Decode XML entities (&apos;) and UTF-8 smart punctuation (e.g. U+2019
+            // curly apostrophe in "Raquel's Office") so they don't render as tofu in
+            // the ASCII-only Montserrat label font.
+            dev->roomName = decodeHTML(xml.substring(start + 10, end));
             Serial.printf("[SONOS]   Room name fetched successfully: '%s'\n", dev->roomName.c_str());
         } else {
             Serial.printf("[SONOS]   Failed to parse room name from XML for %s\n", dev->ip.toString().c_str());
@@ -451,10 +454,12 @@ bool SonosController::tryLoadCachedDevice() {
         return false;
     }
 
-    // Device is reachable - add it to the device list
+    // Device is reachable - add it to the device list.
+    // decodeHTML the cached name so legacy NVS values written before the discovery-side
+    // decode (with raw U+2019 / &apos; etc.) render cleanly on first boot after upgrade.
     deviceCount = 1;
     devices[0].ip = ip;
-    devices[0].roomName = cachedRoom;
+    devices[0].roomName = decodeHTML(cachedRoom);
     devices[0].rinconID = cachedRincon;
     devices[0].isPlaying = false;
     devices[0].volume = 50;


### PR DESCRIPTION
## Summary

Speaker room names containing smart punctuation (notably the iOS-default curly apostrophe `'` / U+2019, UTF-8 `E2 80 99`) render as a missing-glyph box ("tofu") on the Speakers list. The label font is `lv_font_montserrat_18`, which is built with ASCII-only coverage.

Fix: pipe `roomName` through the existing `SonosController::decodeHTML()` helper in both spots where `roomName` is assigned in `src/sonos_discovery.cpp`:

1. **SSDP-discovery path** (`getRoomName`, after extracting `<roomName>` from `device_description.xml`).
2. **Cached-load path** (`tryLoadCachedDevice`, when restoring the previously-selected device from NVS) — so users upgrading from an older build don't have to re-scan to clean a curly-quote-cached name.

`decodeHTML` already maps `\xE2\x80\x99 -> '`, `&apos; -> '`, plus all the other smart-quote/accent variants — it's the same helper already used dozens of times in `sonos_controller.cpp` for track titles, album names, station names, etc.

## Before / After

Before (raw U+2019 from the speaker reaches the ASCII font → tofu):

![Before](https://raw.githubusercontent.com/freeformz/SonosESP/pr-screenshots/before.jpg)

After (decoded to ASCII apostrophe → renders correctly):

![After](https://raw.githubusercontent.com/freeformz/SonosESP/pr-screenshots/after.png)

## Test plan

- [x] `pio run` — clean build, no new warnings on `src/sonos_discovery.cpp`
- [x] Flashed on a GUITION JC4880P433C — `Settings → Speakers` now shows "Raquel's Office" and "Milo's" with proper apostrophes (see screenshots above)
- [x] Standalone speakers and group members both render correctly (same `decodeHTML` path covers them via `getRoomName`)
- [x] Cache-restore path tested implicitly: the fast-boot path also runs `decodeHTML(cachedRoom)`, so a legacy NVS-cached name with a raw curly quote gets cleaned on first boot after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)