### PR TITLE
Wake clock screen when playback starts

### DIFF
--- a/src/screens/ui_clock_screen.cpp
+++ b/src/screens/ui_clock_screen.cpp
@@ -936,6 +936,29 @@ void exitClockScreen() {
 // Drives the clock state machine without blocking the main thread.
 // ============================================================================
 void checkClockTrigger() {
+
+      static bool clock_was_active = false;
+  static bool clock_saw_not_playing = false;
+
+  bool clock_active_now = (clock_state == CLOCK_ACTIVE);
+
+  if (clock_active_now && !clock_was_active) {
+    clock_saw_not_playing = !ui_playing;
+  }
+
+  if (clock_active_now) {
+    if (!ui_playing) {
+      clock_saw_not_playing = true;
+    } else if (clock_saw_not_playing) {
+      Serial.println("[CLOCK] Music started while clock active, exiting");
+      exitClockScreen();
+      clock_was_active = clock_active_now;
+      return;
+    }
+  }
+
+  clock_was_active = clock_active_now;
+
     switch (clock_state) {
 
         // ------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description
This fixes an issue where the clock screen stays visible after playback starts externally, for example from a phone or the Sonos app.

When the clock screen is active and playback changes from not playing to playing, the UI now exits the clock screen and returns to the main player display.

## Related Issue
N/A

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made
- Added clock wake logic inside `checkClockTrigger()`
- Tracks whether the clock screen has seen a non-playing state
- Exits the clock screen when playback starts while the clock is active

## Testing
Built successfully with PlatformIO and tested on device.

### Hardware Testing
- [x] Tested on GUITION JC4880P433C (ESP32-P4 + ESP32-C6)
- [ ] Tested on other hardware: _______________

### Functionality Testing
- [x] Playback control works (play/pause/skip)
- [x] No crashes during normal use
- [x] Device discovery works
- [x] Volume control works
- [x] Album art loads correctly
- [x] Tested for at least 30 minutes

### Edge Cases
- [ ] Source switching (music -> radio -> TV)
- [ ] WiFi reconnection
- [ ] Rapid track skipping
- [ ] Memory leak check (monitored free heap)

## Serial Logs