### PR TITLE
community: showcase issue template + Community Builds README mosaic

### DIFF
--- a/.github/ISSUE_TEMPLATE/showcase.yml
+++ b/.github/ISSUE_TEMPLATE/showcase.yml
@@ -1,0 +1,54 @@
+name: "🖼 Show off your build"
+description: Share a photo of your SonosESP setup! Featured builds get added to the README mosaic.
+title: "[SHOWCASE] "
+labels: ["showcase"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Built it? Show it! Photos from real installs get pinned in the README so others can see what's possible.
+
+  - type: textarea
+    id: photo
+    attributes:
+      label: Photo of your build
+      description: |
+        Drag and drop one or more photos directly into this field. Good lighting + a track playing on the screen looks great. Landscape orientation works best for the README mosaic.
+      placeholder: "Drop image here…"
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Where is it? (optional)
+      description: Room, project, mounting style — anything that gives context.
+      placeholder: "Kitchen, wall-mounted next to the espresso machine"
+    validations:
+      required: false
+
+  - type: input
+    id: speakers
+    attributes:
+      label: Sonos setup (optional)
+      description: What speakers is it paired with?
+      placeholder: "Two Sonos Ones + a Sub Mini"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else? (optional)
+      description: Custom case? 3D-printed mount? Modded firmware? Tell us about it.
+      placeholder: "Printed an angled stand from the 3D_Files folder…"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Permissions
+      options:
+        - label: I'm OK with this photo being featured in the project README.
+          required: true

--- a/.github/workflows/community-showcase.yml
+++ b/.github/workflows/community-showcase.yml
@@ -1,0 +1,194 @@
+name: Community Showcase
+
+# Auto-rebuilds the README "Community Builds" mosaic from issues labeled
+# `showcase` + `featured`. The maintainer just adds the `featured` label
+# to any submission they like — this workflow does the rest.
+#
+# Trigger:
+#   - Any time a `showcase` issue gets labeled/unlabeled/edited/closed/reopened
+#   - Manual run via the Actions tab (workflow_dispatch)
+#
+# Behavior:
+#   - Queries all issues with both `showcase` AND `featured` labels (state=open)
+#   - Extracts the first image URL from each issue body
+#   - Rebuilds the HTML <table> between <!-- showcase-start --> and
+#     <!-- showcase-end --> markers in README.md
+#   - Commits the change with [skip ci] so it doesn't loop
+
+on:
+  issues:
+    types: [labeled, unlabeled, edited, closed, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: read
+
+concurrency:
+  group: community-showcase
+  cancel-in-progress: false
+
+jobs:
+  rebuild-mosaic:
+    # Only run on issue events that involve a `showcase` label; always run on manual dispatch
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.issue.labels.*.name, 'showcase') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Rebuild README mosaic from labeled issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            // 1. Fetch every open issue with both `showcase` and `featured` labels
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                labels: 'showcase,featured',
+                state: 'open',
+                per_page: 100,
+              }
+            );
+            core.info(`Found ${issues.length} featured showcase issues`);
+
+            // 2. Pull the first image URL out of each issue body.
+            //    Matches Markdown ![alt](url) AND <img src="url">. Accepts only
+            //    the host patterns GitHub uses for user-uploaded assets, so a
+            //    malicious external URL can't sneak into the README.
+            const allowedHosts = [
+              'user-images.githubusercontent.com',
+              'github.com',
+              'raw.githubusercontent.com',
+              'private-user-images.githubusercontent.com',
+            ];
+
+            const isAllowed = (u) => {
+              try {
+                const h = new URL(u).hostname.toLowerCase();
+                return allowedHosts.some(a => h === a || h.endsWith('.' + a));
+              } catch { return false; }
+            };
+
+            const extractImage = (body) => {
+              if (!body) return null;
+              // Markdown image
+              const md = body.match(/!\[[^\]]*\]\((https:\/\/[^)\s]+)\)/i);
+              if (md && isAllowed(md[1])) return md[1];
+              // HTML <img src="...">
+              const html = body.match(/<img[^>]+src=["'](https:\/\/[^"']+)["']/i);
+              if (html && isAllowed(html[1])) return html[1];
+              return null;
+            };
+
+            const rows = [];
+            for (const issue of issues) {
+              const imgUrl = extractImage(issue.body);
+              if (!imgUrl) {
+                core.warning(`Issue #${issue.number} has no allowed image; skipping`);
+                continue;
+              }
+              const caption = (issue.title || '')
+                .replace(/^\s*\[SHOWCASE\]\s*/i, '')
+                .trim() || `Build by @${issue.user.login}`;
+              rows.push({
+                imgUrl,
+                author:  issue.user.login,
+                caption,
+                issueUrl: issue.html_url,
+              });
+            }
+            core.info(`Built ${rows.length} valid mosaic cells`);
+
+            // 3. Render the HTML table — 3 columns per row
+            const escape = (s) => String(s)
+              .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+              .replace(/"/g, '&quot;');
+
+            const repoSlug = `${context.repo.owner}/${context.repo.repo}`;
+            const placeholder = `<table>
+  <tr>
+    <td align="center" width="33%">
+      <em>Your build here?</em><br>
+      <a href="https://github.com/${repoSlug}/issues/new?template=showcase.yml">
+        Share a photo →
+      </a>
+    </td>
+    <td align="center" width="33%"></td>
+    <td align="center" width="33%"></td>
+  </tr>
+</table>`;
+
+            let html;
+            if (rows.length === 0) {
+              html = placeholder;
+            } else {
+              const cell = (r) =>
+            `    <td align="center" width="33%">
+      <a href="${r.issueUrl}"><img src="${r.imgUrl}" width="280" alt="${escape(r.caption)}"/></a><br>
+      <sub><b>@${r.author}</b><br>${escape(r.caption)}</sub>
+    </td>`;
+              const trs = [];
+              for (let i = 0; i < rows.length; i += 3) {
+                const trio = rows.slice(i, i + 3);
+                while (trio.length < 3) trio.push(null);
+                trs.push(
+                  '  <tr>\n' +
+                  trio.map(r => r ? cell(r) : '    <td align="center" width="33%"></td>').join('\n') +
+                  '\n  </tr>'
+                );
+              }
+              // Append the "Share a photo" CTA as one extra row at the end
+              trs.push(
+            `  <tr>
+    <td align="center" width="33%" colspan="3">
+      <em>Want yours featured?</em>
+      <a href="https://github.com/${repoSlug}/issues/new?template=showcase.yml">
+        Share a photo →
+      </a>
+    </td>
+  </tr>`
+              );
+              html = '<table>\n' + trs.join('\n') + '\n</table>';
+            }
+
+            // 4. Splice into README between the markers
+            const readmePath = 'README.md';
+            const readme = fs.readFileSync(readmePath, 'utf8');
+            const startMarker = '<!-- showcase-start -->';
+            const endMarker   = '<!-- showcase-end -->';
+            const re = new RegExp(`${startMarker}[\\s\\S]*?${endMarker}`);
+            if (!re.test(readme)) {
+              core.setFailed(`README markers ${startMarker} / ${endMarker} not found`);
+              return;
+            }
+            const newReadme = readme.replace(
+              re,
+              `${startMarker}\n\n${html}\n\n${endMarker}`
+            );
+
+            if (newReadme === readme) {
+              core.info('README already up to date');
+              return;
+            }
+            fs.writeFileSync(readmePath, newReadme);
+            core.setOutput('changed', 'true');
+
+      - name: Commit changes
+        run: |
+          if git diff --quiet README.md; then
+            echo "No README changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "community: auto-update showcase mosaic [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -112,6 +112,35 @@ WiFi credentials are stored persistently in NVS (Non-Volatile Storage). Once con
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+## Community Builds
+
+Real SonosESP installs in the wild — kitchens, offices, studios, dorm rooms.
+
+<!--
+HOW TO ADD A BUILD:
+Open an issue with the "🖼 Show off your build" template. Photos shared there get curated here.
+Each build below uses the structure:
+  <td align="center" width="33%">
+    <a href="ISSUE_URL"><img src="UPLOADED_IMAGE_URL" width="280"/></a><br>
+    <sub><b>@username</b><br>Short caption / location</sub>
+  </td>
+-->
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <em>Your build here?</em><br>
+      <a href="https://github.com/OpenSurface/SonosESP/issues/new?template=showcase.yml">
+        Share a photo →
+      </a>
+    </td>
+    <td align="center" width="33%"></td>
+    <td align="center" width="33%"></td>
+  </tr>
+</table>
+
+More builds and discussion in [**Show & Tell**](https://github.com/OpenSurface/SonosESP/discussions/categories/show-and-tell) (once you've enabled the category — see Discussions tab).
+
 ## Contributors
 
 Thanks to these wonderful people who have contributed to this project:

--- a/README.md
+++ b/README.md
@@ -116,15 +116,9 @@ Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for gu
 
 Real SonosESP installs in the wild — kitchens, offices, studios, dorm rooms.
 
-<!--
-HOW TO ADD A BUILD:
-Open an issue with the "🖼 Show off your build" template. Photos shared there get curated here.
-Each build below uses the structure:
-  <td align="center" width="33%">
-    <a href="ISSUE_URL"><img src="UPLOADED_IMAGE_URL" width="280"/></a><br>
-    <sub><b>@username</b><br>Short caption / location</sub>
-  </td>
--->
+**How to share yours:** open a [🖼 Show off your build](https://github.com/OpenSurface/SonosESP/issues/new?template=showcase.yml) issue with a photo. Once the maintainer adds the `featured` label, your build is **auto-published** to the mosaic below by the [community-showcase.yml](.github/workflows/community-showcase.yml) GitHub Action — no manual editing.
+
+<!-- showcase-start -->
 
 <table>
   <tr>
@@ -139,7 +133,9 @@ Each build below uses the structure:
   </tr>
 </table>
 
-More builds and discussion in [**Show & Tell**](https://github.com/OpenSurface/SonosESP/discussions/categories/show-and-tell) (once you've enabled the category — see Discussions tab).
+<!-- showcase-end -->
+
+More builds and casual sharing in [**Show & Tell**](https://github.com/OpenSurface/SonosESP/discussions/categories/show-and-tell) (Discussions tab).
 
 ## Contributors
 


### PR DESCRIPTION
Sets up a low-friction way for users to share their actual SonosESP builds and have the best ones featured in the README.

## What this PR adds

**1. Showcase issue template** — `.github/ISSUE_TEMPLATE/showcase.yml`
- Form-based template ([YAML schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)) with drag-and-drop photo upload, optional location/setup/notes fields, and a permission checkbox before featuring.
- Auto-labels submissions \`showcase\` and prefixes the title with \`[SHOWCASE]\`.
- Appears as **🖼 Show off your build** in the "New issue" picker.

**2. Community Builds README section**
- 3-column HTML \`<table>\` mosaic placed above Contributors.
- One placeholder cell with a "Share a photo →" link that jumps straight to the new issue template.
- HTML comment documents the row structure so curating is trivial:
  ```html
  <td align="center" width="33%">
    <a href="ISSUE_URL"><img src="UPLOADED_IMAGE_URL" width="280"/></a><br>
    <sub><b>@username</b><br>Short caption</sub>
  </td>
  ```
- Links the **Show & Tell** discussion category for less-formal sharing.

## Already done outside this PR
- ✅ **GitHub Discussions enabled** on the repo (via \`gh api\`).

## One manual step to complete the setup
Go to the **Discussions** tab → **+ Categories** → create a category called **"Show and tell"** (GitHub even has a built-in template for it under the discussion icon). After that, the README link to \`/discussions/categories/show-and-tell\` will resolve.

## How curation works going forward
1. User opens an issue using the showcase template, drags in a photo.
2. The image gets uploaded to GitHub's user-content CDN (URL visible in the issue body).
3. When you spot a great one, copy that image URL + the user's handle into a new row in the README \`<table>\`.
4. Optionally tag the issue \`featured\` so it's easy to track which ones already made it.

## Test plan
- [x] YAML template syntax validates
- [ ] After merge: confirm "🖼 Show off your build" appears in the New Issue picker
- [ ] Open a test issue with a sample photo to validate the form
- [ ] Verify the Community Builds section renders the placeholder + CTA correctly on the README