### PR TITLE
Multi-screen support: 4″ + 7″ (JD9165) from one codebase (#89)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Dependabot — keep CI actions and Python build deps current automatically.
+# (Adopted from the reference project's automated-maintenance approach; the
+#  GitHub-native equivalent of their Renovate setup.)
+version: 2
+updates:
+  # GitHub Actions used by the workflows (checkout, setup-python, cache,
+  # ccache-action, upload-artifact, gh-release, …). Grouped into one PR/week so
+  # action bumps (and Node-runtime deprecations) are handled in a single review.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # Python build dependencies (requirements.txt — platformio, esptool).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -95,14 +95,14 @@ jobs:
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'
       run: |
         pip install esptool
-        cd .pio/build/esp32-p4
+        cd .pio/build/esp32_4inch
         python -m esptool --chip esp32p4 merge_bin -o ../../../firmware-merged.bin --flash_mode qio --flash_size 16MB 0x0 bootloader.bin 0x8000 partitions.bin 0x10000 firmware.bin
         echo "Merged firmware binary created successfully"
 
     - name: Create release ZIP
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'
       run: |
-        cd .pio/build/esp32-p4
+        cd .pio/build/esp32_4inch
         zip -r ../../../sonos-controller-firmware-v${{ steps.get_version.outputs.VERSION }}.zip bootloader.bin partitions.bin firmware.bin
         echo "Created release ZIP with individual binaries"
 
@@ -115,9 +115,9 @@ jobs:
         files: |
           firmware-merged.bin
           sonos-controller-firmware-v${{ steps.get_version.outputs.VERSION }}.zip
-          .pio/build/esp32-p4/firmware.bin
-          .pio/build/esp32-p4/bootloader.bin
-          .pio/build/esp32-p4/partitions.bin
+          .pio/build/esp32_4inch/firmware.bin
+          .pio/build/esp32_4inch/bootloader.bin
+          .pio/build/esp32_4inch/partitions.bin
         draft: false
         prerelease: false
         generate_release_notes: true

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -66,6 +66,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'
@@ -87,7 +88,7 @@ jobs:
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'
       run: |
         python -m pip install --upgrade pip
-        pip install platformio
+        pip install -r requirements.txt
 
     - name: Clean build directory
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -66,7 +66,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,12 +17,14 @@ concurrency:
 jobs:
   auto-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
         submodules: recursive
+        fetch-depth: 1
 
     - name: Read version from version.json
       id: get_version
@@ -64,6 +66,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'
@@ -74,6 +77,12 @@ jobs:
         key: ${{ runner.os }}-pio-v3-${{ hashFiles('**/platformio.ini') }}
         restore-keys: |
           ${{ runner.os }}-pio-v3-
+
+    - name: Set up ccache
+      if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: ${{ runner.os }}-ccache-${{ hashFiles('**/platformio.ini') }}
 
     - name: Install PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'
@@ -89,6 +98,8 @@ jobs:
 
     - name: Build firmware
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true' && steps.check_release.outputs.EXISTS == 'false'
+      env:
+        USE_CCACHE: "1"
       run: pio run
 
     - name: Create merged firmware binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
@@ -73,7 +74,7 @@ jobs:
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       run: |
         python -m pip install --upgrade pip
-        pip install platformio
+        pip install -r requirements.txt
 
     - name: Build firmware
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
+    # Build every screen variant so a break in either is caught in CI.
+    # 4" is the shipping product; 7" is code-complete but not yet hardware-validated.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - env: esp32_4inch
+            screen: 4inch
+          - env: esp32_7inch
+            screen: 7inch
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -68,7 +79,7 @@ jobs:
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       uses: hendrikmuhs/ccache-action@v1
       with:
-        key: ${{ runner.os }}-ccache-${{ hashFiles('**/platformio.ini') }}
+        key: ${{ runner.os }}-ccache-${{ matrix.env }}-${{ hashFiles('**/platformio.ini') }}
 
     - name: Install PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
@@ -76,54 +87,68 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Build firmware
+    - name: Build firmware (${{ matrix.screen }})
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       env:
         USE_CCACHE: "1"
-      run: pio run
+      run: pio run -e ${{ matrix.env }}
 
-    - name: Copy binaries to web-installer
+    - name: Stage binaries (${{ matrix.screen }})
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       run: |
-        mkdir -p web-installer
-        cp .pio/build/esp32_4inch/bootloader.bin web-installer/
-        cp .pio/build/esp32_4inch/partitions.bin web-installer/
-        cp .pio/build/esp32_4inch/firmware.bin web-installer/
+        OUT=".pio/build/${{ matrix.env }}"
+        mkdir -p dist
+        cp "$OUT/bootloader.bin"  "dist/bootloader-${{ matrix.screen }}.bin"
+        cp "$OUT/partitions.bin"  "dist/partitions-${{ matrix.screen }}.bin"
+        cp "$OUT/firmware.bin"    "dist/firmware-${{ matrix.screen }}.bin"
+        # Legacy unsuffixed names — kept ~1 month for the deployed <=v1.8.4 4" fleet
+        # whose OTA matches the "firmware.bin" substring. Remove after transition.
+        if [ "${{ matrix.screen }}" = "4inch" ]; then
+          cp "$OUT/bootloader.bin" dist/bootloader.bin
+          cp "$OUT/partitions.bin" dist/partitions.bin
+          cp "$OUT/firmware.bin"   dist/firmware.bin
+        fi
+        ls -l dist/
 
-    - name: Upload firmware artifacts
+    - name: Upload firmware artifacts (${{ matrix.screen }})
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       uses: actions/upload-artifact@v7
       with:
-        name: firmware-binaries
-        path: |
-          .pio/build/esp32_4inch/bootloader.bin
-          .pio/build/esp32_4inch/partitions.bin
-          .pio/build/esp32_4inch/firmware.bin
+        name: firmware-${{ matrix.screen }}
+        path: dist/
         retention-days: 30
 
-    - name: Upload web-installer artifacts
-      if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
-      uses: actions/upload-artifact@v7
-      with:
-        name: web-installer
-        path: web-installer/
-        retention-days: 30
-
-    - name: Create Release Assets
+    - name: Create Release Assets (${{ matrix.screen }})
       if: github.event_name == 'release'
       run: |
-        cd .pio/build/esp32_4inch
-        zip -r ../../../sonos-controller-firmware.zip bootloader.bin partitions.bin firmware.bin
+        cd dist
+        zip -r "../sonos-controller-firmware-${{ matrix.screen }}.zip" \
+          "bootloader-${{ matrix.screen }}.bin" \
+          "partitions-${{ matrix.screen }}.bin" \
+          "firmware-${{ matrix.screen }}.bin"
 
-    - name: Upload Release Assets
+    - name: Upload Release Assets (${{ matrix.screen }})
       if: github.event_name == 'release'
       uses: softprops/action-gh-release@v2
       with:
         files: |
-          sonos-controller-firmware.zip
-          .pio/build/esp32_4inch/firmware.bin
-          .pio/build/esp32_4inch/bootloader.bin
-          .pio/build/esp32_4inch/partitions.bin
+          sonos-controller-firmware-${{ matrix.screen }}.zip
+          dist/firmware-${{ matrix.screen }}.bin
+          dist/bootloader-${{ matrix.screen }}.bin
+          dist/partitions-${{ matrix.screen }}.bin
         generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Legacy unsuffixed release assets for the deployed 4" fleet's OTA substring
+    # match. Remove ~1 month after the multi-screen release ships.
+    - name: Upload legacy 4" release assets
+      if: github.event_name == 'release' && matrix.screen == '4inch'
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          dist/firmware.bin
+          dist/bootloader.bin
+          dist/partitions.bin
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
         submodules: recursive
+        fetch-depth: 1
 
     - name: Read version from version.json
       id: get_version
@@ -50,6 +52,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
@@ -61,20 +64,22 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pio-v3-
 
+    - name: Set up ccache
+      if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: ${{ runner.os }}-ccache-${{ hashFiles('**/platformio.ini') }}
+
     - name: Install PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       run: |
         python -m pip install --upgrade pip
         pip install platformio
 
-    - name: Clean build directory
-      if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
-      run: |
-        rm -rf .pio
-        echo "Build directory cleaned"
-
     - name: Build firmware
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
+      env:
+        USE_CCACHE: "1"
       run: pio run
 
     - name: Copy binaries to web-installer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,9 +81,9 @@ jobs:
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       run: |
         mkdir -p web-installer
-        cp .pio/build/esp32-p4/bootloader.bin web-installer/
-        cp .pio/build/esp32-p4/partitions.bin web-installer/
-        cp .pio/build/esp32-p4/firmware.bin web-installer/
+        cp .pio/build/esp32_4inch/bootloader.bin web-installer/
+        cp .pio/build/esp32_4inch/partitions.bin web-installer/
+        cp .pio/build/esp32_4inch/firmware.bin web-installer/
 
     - name: Upload firmware artifacts
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
@@ -91,9 +91,9 @@ jobs:
       with:
         name: firmware-binaries
         path: |
-          .pio/build/esp32-p4/bootloader.bin
-          .pio/build/esp32-p4/partitions.bin
-          .pio/build/esp32-p4/firmware.bin
+          .pio/build/esp32_4inch/bootloader.bin
+          .pio/build/esp32_4inch/partitions.bin
+          .pio/build/esp32_4inch/firmware.bin
         retention-days: 30
 
     - name: Upload web-installer artifacts
@@ -107,7 +107,7 @@ jobs:
     - name: Create Release Assets
       if: github.event_name == 'release'
       run: |
-        cd .pio/build/esp32-p4
+        cd .pio/build/esp32_4inch
         zip -r ../../../sonos-controller-firmware.zip bootloader.bin partitions.bin firmware.bin
 
     - name: Upload Release Assets
@@ -116,9 +116,9 @@ jobs:
       with:
         files: |
           sonos-controller-firmware.zip
-          .pio/build/esp32-p4/firmware.bin
-          .pio/build/esp32-p4/bootloader.bin
-          .pio/build/esp32-p4/partitions.bin
+          .pio/build/esp32_4inch/firmware.bin
+          .pio/build/esp32_4inch/bootloader.bin
+          .pio/build/esp32_4inch/partitions.bin
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -65,6 +65,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
@@ -86,7 +87,7 @@ jobs:
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       run: |
         python -m pip install --upgrade pip
-        pip install platformio
+        pip install -r requirements.txt
 
     - name: Clean build directory
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -84,9 +84,9 @@ jobs:
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       run: |
         mkdir -p web-installer
-        cp .pio/build/esp32-p4/bootloader.bin web-installer/
-        cp .pio/build/esp32-p4/partitions.bin web-installer/
-        cp .pio/build/esp32-p4/firmware.bin web-installer/
+        cp .pio/build/esp32_4inch/bootloader.bin web-installer/
+        cp .pio/build/esp32_4inch/partitions.bin web-installer/
+        cp .pio/build/esp32_4inch/firmware.bin web-installer/
         ls -la web-installer/
 
     - name: Setup Pages

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -95,20 +95,23 @@ jobs:
         rm -rf .pio
         echo "Build directory cleaned"
 
-    - name: Build firmware
+    - name: Build firmware (both screen variants)
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       env:
         USE_CCACHE: "1"
-      run: pio run
+      run: pio run -e esp32_4inch -e esp32_7inch
 
     - name: Copy binaries to web-installer
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
       run: |
         mkdir -p web-installer
+        # bootloader + partitions are board-level (identical across SCREEN_SIZE);
+        # both manifests reference these shared names.
         cp .pio/build/esp32_4inch/bootloader.bin web-installer/
         cp .pio/build/esp32_4inch/partitions.bin web-installer/
-        # canonical 4" binary (used by manifest-4inch.json)
+        # canonical per-screen app binaries
         cp .pio/build/esp32_4inch/firmware.bin web-installer/firmware-4inch.bin
+        cp .pio/build/esp32_7inch/firmware.bin web-installer/firmware-7inch.bin
         # legacy alias (manifest.json) — kept during the ~1-month transition, then remove
         cp .pio/build/esp32_4inch/firmware.bin web-installer/firmware.bin
         ls -la web-installer/

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -107,7 +107,10 @@ jobs:
         mkdir -p web-installer
         cp .pio/build/esp32_4inch/bootloader.bin web-installer/
         cp .pio/build/esp32_4inch/partitions.bin web-installer/
-        cp .pio/build/esp32_4inch/firmware.bin web-installer/
+        # canonical 4" binary (used by manifest-4inch.json)
+        cp .pio/build/esp32_4inch/firmware.bin web-installer/firmware-4inch.bin
+        # legacy alias (manifest.json) — kept during the ~1-month transition, then remove
+        cp .pio/build/esp32_4inch/firmware.bin web-installer/firmware.bin
         ls -la web-installer/
 
     - name: Setup Pages

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -65,7 +65,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,16 @@ name: Deploy Web Installer
 on:
   push:
     branches: [ main ]
+    # Only redeploy when the firmware or the installer page actually changes —
+    # not on doc/workflow-only pushes (which would otherwise trigger a full
+    # firmware rebuild for nothing). Manual runs are always available below.
+    paths:
+      - 'version.json'
+      - 'web-installer/**'
+      - 'src/**'
+      - 'include/**'
+      - 'lib/**'
+      - 'platformio.ini'
   workflow_dispatch:
 
 permissions:
@@ -17,6 +27,7 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -26,6 +37,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+        fetch-depth: 1
 
     - name: Read version from version.json
       id: get_version
@@ -53,6 +65,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
@@ -63,6 +76,12 @@ jobs:
         key: ${{ runner.os }}-pio-v3-${{ hashFiles('**/platformio.ini') }}
         restore-keys: |
           ${{ runner.os }}-pio-v3-
+
+    - name: Set up ccache
+      if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: ${{ runner.os }}-ccache-${{ hashFiles('**/platformio.ini') }}
 
     - name: Install PlatformIO
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
@@ -78,6 +97,8 @@ jobs:
 
     - name: Build firmware
       if: steps.check_nightly.outputs.IS_NIGHTLY != 'true'
+      env:
+        USE_CCACHE: "1"
       run: pio run
 
     - name: Copy binaries to web-installer

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -55,6 +55,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_release.outputs.EXISTS == 'false'
@@ -76,7 +77,7 @@ jobs:
       if: steps.check_release.outputs.EXISTS == 'false'
       run: |
         python -m pip install --upgrade pip
-        pip install platformio
+        pip install -r requirements.txt
 
     - name: Clean build directory
       if: steps.check_release.outputs.EXISTS == 'false'

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -18,12 +18,14 @@ concurrency:
 jobs:
   nightly-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
         submodules: recursive
+        fetch-depth: 1
 
     - name: Validate version tag format
       run: |
@@ -53,6 +55,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_release.outputs.EXISTS == 'false'
@@ -63,6 +66,12 @@ jobs:
         key: ${{ runner.os }}-pio-v3-${{ hashFiles('**/platformio.ini') }}
         restore-keys: |
           ${{ runner.os }}-pio-v3-
+
+    - name: Set up ccache
+      if: steps.check_release.outputs.EXISTS == 'false'
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: ${{ runner.os }}-ccache-${{ hashFiles('**/platformio.ini') }}
 
     - name: Install PlatformIO
       if: steps.check_release.outputs.EXISTS == 'false'
@@ -78,6 +87,8 @@ jobs:
 
     - name: Build firmware
       if: steps.check_release.outputs.EXISTS == 'false'
+      env:
+        USE_CCACHE: "1"
       run: pio run
 
     - name: Create merged firmware binary

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -84,14 +84,14 @@ jobs:
       if: steps.check_release.outputs.EXISTS == 'false'
       run: |
         pip install esptool
-        cd .pio/build/esp32-p4
+        cd .pio/build/esp32_4inch
         python -m esptool --chip esp32p4 merge_bin -o ../../../firmware-merged.bin --flash_mode qio --flash_size 16MB 0x0 bootloader.bin 0x8000 partitions.bin 0x10000 firmware.bin
         echo "Merged firmware binary created successfully"
 
     - name: Create release ZIP
       if: steps.check_release.outputs.EXISTS == 'false'
       run: |
-        cd .pio/build/esp32-p4
+        cd .pio/build/esp32_4inch
         zip -r ../../../sonos-controller-nightly-v${{ inputs.version_tag }}.zip bootloader.bin partitions.bin firmware.bin
         echo "Created nightly release ZIP"
 
@@ -119,9 +119,9 @@ jobs:
         files: |
           firmware-merged.bin
           sonos-controller-nightly-v${{ inputs.version_tag }}.zip
-          .pio/build/esp32-p4/firmware.bin
-          .pio/build/esp32-p4/bootloader.bin
-          .pio/build/esp32-p4/partitions.bin
+          .pio/build/esp32_4inch/firmware.bin
+          .pio/build/esp32_4inch/bootloader.bin
+          .pio/build/esp32_4inch/partitions.bin
         draft: false
         prerelease: true
         generate_release_notes: false

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -55,7 +55,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-        cache: 'pip'
 
     - name: Cache PlatformIO
       if: steps.check_release.outputs.EXISTS == 'false'

--- a/bump_version.py
+++ b/bump_version.py
@@ -23,7 +23,15 @@ VERSION_FILES = {
         'type': 'json',
         'key': 'version'
     },
-    'web-installer/manifest.json': {
+    'web-installer/manifest.json': {           # legacy 4" alias (remove after transition)
+        'type': 'json',
+        'key': 'version'
+    },
+    'web-installer/manifest-4inch.json': {     # canonical 4"
+        'type': 'json',
+        'key': 'version'
+    },
+    'web-installer/manifest-7inch.json': {     # canonical 7" (placeholder until firmware exists)
         'type': 'json',
         'key': 'version'
     },

--- a/docs/MULTI_SCREEN_SUPPORT.md
+++ b/docs/MULTI_SCREEN_SUPPORT.md
@@ -182,6 +182,16 @@ The current UI uses absolute pixels for 800×480. The 7″ is 1024×600, so we m
 **Honest caveats:** fonts step between tiers (not continuous); some elements may need a manual
 nudge after scaling; pixel-perfect mockups need spot-checking on hardware.
 
+**Font status (7″).** The body-text tiers above use LVGL **built-in** Montserrat fonts and
+already step up on the 1024-wide panel (32/20/16 vs the 4″'s 24/16/14) — no generation needed.
+The **custom** icon/clock fonts (`lv_font_mdi_*`, `lv_font_weathericons_*`,
+`lv_font_montserrat_140`) are pre-generated `.c` files shared by both builds; the 7″ links and
+renders them at their native px (clear on 1024×600). Generating *larger* icon/clock variants is a
+**hardware-validation polish step** — it needs the physical panel to judge sizing, and the big
+clock digits can't be regenerated until `Montserrat-Medium.ttf` is added to the repo (only the
+MDI + FontAwesome TTFs ship in `node_modules`). Deliberately **not** fabricated blind, to avoid
+flash bloat and unvalidated assets.
+
 ### Alternatives considered (and why not)
 | Option | Verdict |
 |---|---|

--- a/docs/MULTI_SCREEN_SUPPORT.md
+++ b/docs/MULTI_SCREEN_SUPPORT.md
@@ -52,7 +52,7 @@ Nothing is variant-aware — this is greenfield.
 | Touch | GT911 | GT911 (different pins) |
 | Extra HW | — | **Ethernet** (future) |
 | `SCREEN_SIZE` flag | `4` | `7` |
-| Firmware asset | `firmware.bin` | `firmware-7inch.bin` |
+| Firmware asset | `firmware-4inch.bin` (+ legacy `firmware.bin` during transition) | `firmware-7inch.bin` |
 | Manifest | `manifest.json` | `manifest-7inch.json` |
 
 > The resolutions **differ** → the UI must adapt (see §6). This is the only substantial work; everything else is small plumbing.
@@ -76,7 +76,8 @@ src/
   screens/*.cpp           # use SX()/SY() instead of literal pixels
 web-installer/
   index.html              # screen-selector dropdown → per-variant manifest
-  manifest.json           # 4″ (keep name for backward-compat)
+  manifest-4inch.json     # 4″ → firmware-4inch.bin
+  manifest.json           # legacy 4″ alias during transition (see §7)
   manifest-7inch.json     # 7″
 assets/7inchScreensavers/ # optional, 7″ screensaver photos
 scripts/embed_photos.py   # optional, build-time photo embed
@@ -193,22 +194,44 @@ nudge after scaling; pixel-perfect mockups need spot-checking on hardware.
 
 ---
 
-## 7. OTA — variant-aware asset selection (trivial)
+## 7. OTA — variant-aware asset selection (trivial logic, careful rollout)
 
-OTA already works. The **only** change: each firmware fetches **its own** asset (otherwise a
-7″ would grab the 4″ `firmware.bin` → wrong panel → black screen).
+OTA already works. The **only** firmware change: each build fetches **its own** asset
+(otherwise a 7″ would grab the 4″ binary → wrong panel → black screen). Canonical names are
+**symmetric**: `firmware-4inch.bin` and `firmware-7inch.bin`.
 
 ```c
 #if SCREEN_SIZE == 7
   const char* WANT_ASSET = "firmware-7inch.bin";
 #else
-  const char* WANT_ASSET = "firmware.bin";   // 4″ keeps its name → deployed fleet unaffected
+  const char* WANT_ASSET = "firmware-4inch.bin";   // canonical 4" name going forward
 #endif
 // in checkForUpdates(): if (name.indexOf(WANT_ASSET) >= 0) download_url = ...
 ```
 
-That's it — ~3 lines. Keeping the 4″ asset named `firmware.bin` means the **already-deployed
-4″ units keep updating** with no transition needed.
+### ⚠️ Backward-compatibility — the deployed fleet (must not skip this)
+The **already-shipped v1.8.4 units search the substring `firmware.bin`**, and
+`"firmware-4inch.bin"` does **NOT** contain `"firmware.bin"`. So renaming the 4″ asset to
+`firmware-4inch.bin` without care would **silently cut OTA for the entire deployed 4″ fleet.**
+
+**Transition plan (publish BOTH names for the 4″ during migration):**
+
+| Release asset | Found by | Keep until |
+|---|---|---|
+| `firmware.bin` (legacy alias = the 4″ binary) | **old** units (≤ v1.8.4, search `firmware.bin`) | the fleet has moved to a build that searches `firmware-4inch.bin` |
+| `firmware-4inch.bin` (canonical) | **new** 4″ builds (search `firmware-4inch.bin`) | forever |
+| `firmware-7inch.bin` (canonical) | 7″ builds | forever |
+
+Rollout order:
+1. Ship a 4″ release that **publishes both** `firmware.bin` + `firmware-4inch.bin` (identical
+   binary) **and** switches the *firmware's* search string to `firmware-4inch.bin`.
+2. After a few cycles (fleet migrated) → **drop `firmware.bin`**; keep only the `-4inch`/`-7inch`
+   canonical pair.
+
+So: ~3 lines in firmware, plus CI publishing the legacy `firmware.bin` duplicate during the
+transition window. *(Note: the local PlatformIO build output is always
+`.pio/build/<env>/firmware.bin` — CI renames it to the release-asset name; "byte-identical"
+checks elsewhere in this doc refer to that build output, not the release asset.)*
 
 ---
 
@@ -219,7 +242,8 @@ auto-distinguish. So:
 
 - One **screen-selector dropdown** on `index.html` (4″ / 7″) that swaps the manifest the
   `<esp-web-install-button>` points at (the fork does exactly this — "Move screen selector to top").
-- `manifest.json` → `firmware.bin` (4″); `manifest-7inch.json` → `firmware-7inch.bin` (7″).
+- `manifest-4inch.json` → `firmware-4inch.bin`; `manifest-7inch.json` → `firmware-7inch.bin`.
+  (Keep `manifest.json` as a legacy alias of the 4″ during the transition — see §7.)
 - Show the selected board's specs (resolution/model) for confidence.
 
 ---
@@ -237,21 +261,25 @@ jobs:
       matrix:
         include:
           - env: esp32_4inch
-            asset: firmware.bin
+            asset: firmware-4inch.bin
           - env: esp32_7inch
             asset: firmware-7inch.bin
     steps:
       - run: pio run -e ${{ matrix.env }}
       - run: cp .pio/build/${{ matrix.env }}/firmware.bin ${{ matrix.asset }}
+      # transition: also publish the 4" under the legacy name so ≤v1.8.4 units keep updating
+      - if: matrix.env == 'esp32_4inch'
+        run: cp .pio/build/esp32_4inch/firmware.bin firmware.bin
       - uses: actions/upload-artifact@v7
-        with: { name: ${{ matrix.env }}, path: ${{ matrix.asset }} }
+        with: { name: ${{ matrix.env }}, path: "*.bin" }
 
   release:
     needs: build
     if: github.event_name == 'release'
     steps:
       - uses: actions/download-artifact@v7      # pulls every variant
-      - uses: softprops/action-gh-release@v2     # firmware.bin + firmware-7inch.bin + bootloader/partitions
+      - uses: softprops/action-gh-release@v2     # firmware-4inch.bin + firmware-7inch.bin
+        #                                          + legacy firmware.bin + bootloader/partitions
 ```
 
 - **Matrix** keeps the workflow DRY and builds variants in parallel.
@@ -267,7 +295,8 @@ jobs:
 ## 10. Versioning & release strategy
 
 - One version across all variants (`version.json` stays the single source of truth).
-- **4″ artifact name unchanged** (`firmware.bin`) → deployed units unaffected.
+- **4″ canonical asset is `firmware-4inch.bin`**, but a **legacy `firmware.bin` (same binary)
+  is published during the transition** so deployed ≤v1.8.4 units keep updating (see §7).
 - Cut the first 7″ build as a **nightly** so John / fork users validate before stable.
 - After 7″ is confirmed on hardware → promote to a stable release containing **both** assets.
 

--- a/docs/MULTI_SCREEN_SUPPORT.md
+++ b/docs/MULTI_SCREEN_SUPPORT.md
@@ -1,0 +1,321 @@
+# Multi-Screen / Multi-Variant Support — Plan
+
+> Tracking issue: **#89** (7″ screen support). Branch: `feat/multi-screen-support`.
+> Status: **PLAN** — no firmware changes yet. This document is the single source of truth
+> for how we add the 7″ panel (and future boards) without forking and without breaking the
+> 4″ fleet.
+
+---
+
+## 1. Goal
+
+Support multiple hardware variants (today: **4″ JC4880P433C**, **7″ JC1060P470C**; tomorrow:
+more) from **one codebase**, with:
+
+- one set of source/logic shared by all boards,
+- a clean web-installer experience (pick your screen → flash),
+- OTA that delivers the **correct** firmware per board,
+- a UI that adapts to any resolution **without a hand-written layout per screen**.
+
+### Why not just merge the existing fork?
+[`CoopsInChina/SonosESP`](https://github.com/CoopsInChina/SonosESP) already did the 7″ panel
+bring-up — **but it forked off our old `1.6.3`** (its version string is `1.6.3_DS_RC3`), so it is
+**missing every 1.7.x/1.8.x reliability fix** (CR-1, H-4/5/7, SDIO defences, #85 WiFi-save, …).
+Merging it would regress the project years. **We port its board-specific pieces onto current
+`main`, not the other way around.** One codebase = the 7″ never drifts behind again.
+
+---
+
+## 2. Current state (single-variant, hardcoded)
+
+| Layer | Today | File |
+|---|---|---|
+| Build | one env `[env:esp32-p4]` | `platformio.ini` |
+| Display dims/pins | fixed 800×480, ST7701 | `include/display_driver.h`, `include/config.h` |
+| UI layout | absolute pixels for 800×480 | `src/screens/*.cpp` |
+| CI/release | copies `.pio/build/esp32-p4/firmware.bin` | `.github/workflows/build.yml` |
+| Web installer | one `manifest.json` | `web-installer/` |
+| OTA | matches asset substring `firmware.bin` | `src/ui_handlers.cpp` (`checkForUpdates`) |
+
+Nothing is variant-aware — this is greenfield.
+
+---
+
+## 3. Variant matrix
+
+| | **4″ (current)** | **7″ (new)** |
+|---|---|---|
+| Board | GUITION JC4880P433C | GUITION JC1060P470C |
+| SoC | ESP32-P4 + C6 | ESP32-P4 + C6 |
+| Panel driver | **ST7701** (MIPI DSI) | **JD9165** (MIPI DSI) |
+| Resolution (landscape) | **800 × 480** | **1024 × 600** |
+| Touch | GT911 | GT911 (different pins) |
+| Extra HW | — | **Ethernet** (future) |
+| `SCREEN_SIZE` flag | `4` | `7` |
+| Firmware asset | `firmware.bin` | `firmware-7inch.bin` |
+| Manifest | `manifest.json` | `manifest-7inch.json` |
+
+> The resolutions **differ** → the UI must adapt (see §6). This is the only substantial work; everything else is small plumbing.
+
+---
+
+## 4. Repo organization
+
+```
+platformio.ini            # [env] base + [env:esp32_4inch] + [env:esp32_7inch]
+include/
+  config.h                # #if SCREEN_SIZE → dims, pins, clock-bg sizes
+  display_driver.h        # dims come from config.h; panel-agnostic API
+  ui_scale.h              # NEW: SX()/SY() scale macros + font-tier selection
+lib/
+  st7701_lcd/             # 4″ panel (exists)
+  jd9165_lcd/             # 7″ panel (PORT from fork)
+  gt911_lcd/pins_config.h # touch pins per SCREEN_SIZE (PORT from fork)
+src/
+  display_driver.cpp      # selects ST7701 vs JD9165 init by SCREEN_SIZE
+  screens/*.cpp           # use SX()/SY() instead of literal pixels
+web-installer/
+  index.html              # screen-selector dropdown → per-variant manifest
+  manifest.json           # 4″ (keep name for backward-compat)
+  manifest-7inch.json     # 7″
+assets/7inchScreensavers/ # optional, 7″ screensaver photos
+scripts/embed_photos.py   # optional, build-time photo embed
+docs/MULTI_SCREEN_SUPPORT.md  # this file
+```
+
+**Principle:** board-specific knowledge lives in exactly three places — `platformio.ini`
+(which env), `config.h` (dims/pins via `#if SCREEN_SIZE`), and `lib/*_lcd` (panel driver).
+Everything else (app logic, screens) is resolution-relative and board-agnostic.
+
+---
+
+## 5. Build system — `platformio.ini`
+
+Use a shared `[env]` base + a small per-variant section, per
+[PlatformIO `extends` docs](https://docs.platformio.org/en/stable/projectconf/sections/env/options/advanced/extends.html).
+
+> ⚠️ **Caveat (confirmed):** `build_flags` and `lib_deps` **do not auto-merge** across
+> `extends`/`[env]` — you must re-include the parent with interpolation
+> (`${env.build_flags}`). Plan for this so the 4″ flags don't silently drop.
+
+```ini
+[env]                       ; shared by all variants
+platform = .../55.03.38/platform-espressif32.zip
+board = esp32-p4
+framework = arduino
+board_upload.flash_size = 16MB
+board_build.partitions = default_16MB.csv
+board_build.psram_type = opi
+; ... all the common flash/psram/cpu settings ...
+build_flags =
+    -DBOARD_HAS_PSRAM
+    ; ... all the shared flags ...
+lib_deps =
+    lvgl/lvgl@^9.5.0
+    bblanchon/ArduinoJson@^7.4.3
+    bitbank2/PNGdec@^1.1.6
+    bitbank2/JPEGDEC@^1.8.4
+    tamctec/TAMC_GT911@^1.0.2
+
+[env:esp32_4inch]
+build_flags = ${env.build_flags} -DSCREEN_SIZE=4
+lib_ignore  = jd9165_lcd
+
+[env:esp32_7inch]
+build_flags = ${env.build_flags} -DSCREEN_SIZE=7
+lib_ignore  = st7701_lcd
+```
+
+`config.h` resolves the rest:
+
+```c
+#ifndef SCREEN_SIZE
+#define SCREEN_SIZE 4          // default 4″ if unset
+#endif
+#if SCREEN_SIZE == 7
+  #define DISPLAY_WIDTH  1024
+  #define DISPLAY_HEIGHT 600
+  #define DISPLAY_MODEL  "JD9165 7\" (1024x600)"
+#elif SCREEN_SIZE == 4
+  #define DISPLAY_WIDTH  800
+  #define DISPLAY_HEIGHT 480
+  #define DISPLAY_MODEL  "ST7701 4\" (800x480)"
+#else
+  #error "Unsupported SCREEN_SIZE (use 4 or 7)"
+#endif
+```
+
+> 🔒 **Guardrail:** after the refactor the **4″ binary must be byte-for-byte identical** to
+> 1.8.4 (same flags, same code path). Verify with a diff of the built `firmware.bin` before/after.
+
+---
+
+## 6. Responsive UI — the only sizeable work
+
+The current UI uses absolute pixels for 800×480. The 7″ is 1024×600, so we make the UI
+**resolution-relative once** instead of maintaining a layout per screen.
+
+### Chosen approach: scale-factor macros + font tiers (`include/ui_scale.h`)
+
+```c
+// Coordinates are authored in the 800×480 "design space" and scaled to the panel.
+#define SX(v) ((lv_coord_t)((v) * DISPLAY_WIDTH  / 800))
+#define SY(v) ((lv_coord_t)((v) * DISPLAY_HEIGHT / 480))
+// e.g. lv_obj_set_size(panel_art, SX(450), SY(480));
+
+// Fonts are discrete → pick a tier by width.
+#if DISPLAY_WIDTH >= 1024
+  #define FONT_TITLE &lv_font_montserrat_32
+  #define FONT_BODY  &lv_font_montserrat_20
+#else
+  #define FONT_TITLE &lv_font_montserrat_24
+  #define FONT_BODY  &lv_font_montserrat_16
+#endif
+```
+
+**Why this one:**
+- Keeps the existing absolute-positioning style — a *mechanical wrap*, not a rewrite.
+- On 4″, `SX/SY` with the 800/480 base = **identity → zero visual change** (protects the fleet).
+- Auto-adapts to any future resolution; coords computed once at screen build → **no runtime cost** (important: PPA/GPU is disabled, all rendering is software).
+
+**Honest caveats:** fonts step between tiers (not continuous); some elements may need a manual
+nudge after scaling; pixel-perfect mockups need spot-checking on hardware.
+
+### Alternatives considered (and why not)
+| Option | Verdict |
+|---|---|
+| **Flex/Grid (`lv_pct`)** | Truly responsive, cleanest long-term — but a full rewrite of every screen. Revisit later. |
+| **Transform-scale whole canvas** | ❌ Expensive in software (PPA off), needs touch-coord inverse-mapping, softens text. |
+| **Letterbox 800×480 in a centred box** | OK *stopgap* to ship "7″ beta" fast; wastes screen space. |
+
+> Adopt `SX()/SY()` **now** and the upcoming themes (#87) are born resolution-independent —
+> we never hand-write a per-size layout again.
+
+---
+
+## 7. OTA — variant-aware asset selection (trivial)
+
+OTA already works. The **only** change: each firmware fetches **its own** asset (otherwise a
+7″ would grab the 4″ `firmware.bin` → wrong panel → black screen).
+
+```c
+#if SCREEN_SIZE == 7
+  const char* WANT_ASSET = "firmware-7inch.bin";
+#else
+  const char* WANT_ASSET = "firmware.bin";   // 4″ keeps its name → deployed fleet unaffected
+#endif
+// in checkForUpdates(): if (name.indexOf(WANT_ASSET) >= 0) download_url = ...
+```
+
+That's it — ~3 lines. Keeping the 4″ asset named `firmware.bin` means the **already-deployed
+4″ units keep updating** with no transition needed.
+
+---
+
+## 8. Web installer
+
+`esp-web-tools` picks a build by `chipFamily`, but **both variants are ESP32-P4** → it can't
+auto-distinguish. So:
+
+- One **screen-selector dropdown** on `index.html` (4″ / 7″) that swaps the manifest the
+  `<esp-web-install-button>` points at (the fork does exactly this — "Move screen selector to top").
+- `manifest.json` → `firmware.bin` (4″); `manifest-7inch.json` → `firmware-7inch.bin` (7″).
+- Show the selected board's specs (resolution/model) for confidence.
+
+---
+
+## 9. CI / CD automation
+
+Today `build.yml` is hardwired to `.pio/build/esp32-p4/`. Move to a **matrix build →
+artifacts → single release job** ([GitHub Actions matrix strategy](https://runs-on.com/github-actions/the-matrix-strategy/),
+[multi-platform release pattern](https://dev.to/eugenebabichenko/automated-multi-platform-releases-with-github-actions-1abg)):
+
+```yaml
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - env: esp32_4inch
+            asset: firmware.bin
+          - env: esp32_7inch
+            asset: firmware-7inch.bin
+    steps:
+      - run: pio run -e ${{ matrix.env }}
+      - run: cp .pio/build/${{ matrix.env }}/firmware.bin ${{ matrix.asset }}
+      - uses: actions/upload-artifact@v7
+        with: { name: ${{ matrix.env }}, path: ${{ matrix.asset }} }
+
+  release:
+    needs: build
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/download-artifact@v7      # pulls every variant
+      - uses: softprops/action-gh-release@v2     # firmware.bin + firmware-7inch.bin + bootloader/partitions
+```
+
+- **Matrix** keeps the workflow DRY and builds variants in parallel.
+- A single **release job** depends on all matrix builds (`needs:`) and uploads **all**
+  per-variant assets to the GitHub release (so OTA §7 finds them).
+- `deploy-pages.yml`: build both, copy `firmware-4inch?.bin`/`firmware-7inch.bin` into
+  `web-installer/`, `sed` the version into both manifests. (The fork's `deploy-pages.yml` is a
+  good reference — it builds both envs and updates both manifests; we'll do it via matrix.)
+- Keep the **nightly skip** guard so nightly versions don't auto-release.
+
+---
+
+## 10. Versioning & release strategy
+
+- One version across all variants (`version.json` stays the single source of truth).
+- **4″ artifact name unchanged** (`firmware.bin`) → deployed units unaffected.
+- Cut the first 7″ build as a **nightly** so John / fork users validate before stable.
+- After 7″ is confirmed on hardware → promote to a stable release containing **both** assets.
+
+---
+
+## 11. Phased action plan
+
+| Phase | Work | Needs 7″ HW? | Risk |
+|---|---|---|---|
+| **0. Decisions** | get a 7″ unit; confirm OTA = auto-update; confirm scale-macro approach | — | — |
+| **1. Build scaffold** | base `[env]` + `esp32_4inch`/`esp32_7inch`; `config.h` `#if SCREEN_SIZE`; **verify 4″ byte-identical** | no | low |
+| **2. Panel bring-up** | port `jd9165_lcd` + `gt911` pins; `display_driver.cpp` panel select; light up 7″ + touch | **yes** | med (HW) |
+| **3. Responsive UI** | `ui_scale.h` (`SX/SY` + font tiers); convert screens, main player first; validate 4″ unchanged + 7″ fills | partial | med (broad but mechanical) |
+| **4. Distribution** | OTA variant pick (~3 lines); CI matrix + per-variant assets; `manifest-7inch.json` + selector | yes | low |
+| **5. Optional** | 7″ screensaver assets + `embed_photos.py` | yes | low |
+| **6. Future** | **Ethernet** for 7″ — needs a network abstraction; NOT in the fork | yes | high (separate effort) |
+
+**Phases 1 & 3 can start now, hardware-free**, shipping value to 4″ as a verified-identical
+refactor. **Phase 2 gates on owning a 7″ unit** — none of the panel work can be validated here.
+
+---
+
+## 12. Risks & guardrails
+
+- **4″ regression** from the build/UI refactor → byte-identical `firmware.bin` check at Phases 1 & 3.
+- **Cross-flash brick** (7″ pulling 4″ firmware) → variant-aware OTA (§7) + per-variant manifests.
+- **`extends` flag drop** → use `${env.build_flags}` interpolation; diff the resolved config.
+- **Panel bring-up** can only be done with the physical 7″ unit on the bench.
+- **Ethernet** touches the SDIO/WiFi crash-defence layer (all WiFi-specific) → keep it a
+  separate, later effort behind a clean network abstraction.
+
+---
+
+## 13. Open decisions (for the owner)
+
+1. Acquire a 7″ JC1060P470C? (hard dependency for Phases 2+)
+2. 7″ via OTA (auto-update, recommended) **or** web-install-only?
+3. Ship 7″ as **nightly-first** then stable? (recommended)
+4. Scale-macros now (recommended) vs letterbox beta first?
+5. Port the 7″ screensaver assets, or skip?
+
+---
+
+## 14. References
+
+- Fork (7″ bring-up, old base): https://github.com/CoopsInChina/SonosESP
+  - `lib/jd9165_lcd/`, `lib/gt911_lcd/pins_config.h`, `web-installer/manifest-7inch.json`,
+    `.github/workflows/deploy-pages.yml` (builds both envs), `scripts/embed_photos.py`
+- PlatformIO `extends` / shared `[env]`: https://docs.platformio.org/en/stable/projectconf/sections/env/options/advanced/extends.html
+- GitHub Actions matrix strategy: https://runs-on.com/github-actions/the-matrix-strategy/
+- Multi-platform release pattern: https://dev.to/eugenebabichenko/automated-multi-platform-releases-with-github-actions-1abg

--- a/include/config.h
+++ b/include/config.h
@@ -57,11 +57,37 @@
 #define MIN_BRIGHTNESS          5       // Minimum brightness allowed
 #define MAX_BRIGHTNESS          100     // Maximum brightness
 
-// Display dimensions (LVGL renders in landscape, driver rotates to portrait panel)
-#define DISPLAY_WIDTH           800     // LVGL width (landscape)
-#define DISPLAY_HEIGHT          480     // LVGL height (landscape)
-#define PANEL_WIDTH             480     // Physical panel width (portrait)
-#define PANEL_HEIGHT            800     // Physical panel height (portrait)
+// =============================================================================
+// SCREEN VARIANT  (build-time: -DSCREEN_SIZE=4 | 7 ; defaults to 4")
+// -----------------------------------------------------------------------------
+// To add a screen variant: add an env in platformio.ini with -DSCREEN_SIZE=N,
+// add a matching branch below, and port its panel driver under lib/. Keep the
+// UI resolution-relative via include/ui_scale.h so no per-size layout is needed.
+// See docs/MULTI_SCREEN_SUPPORT.md.
+// =============================================================================
+#ifndef SCREEN_SIZE
+#define SCREEN_SIZE 4                   // default to 4" if no build flag is set
+#endif
+
+#if SCREEN_SIZE == 4
+    // GUITION JC4880P433C — ST7701 MIPI DSI
+    #define DISPLAY_WIDTH       800     // LVGL width (landscape)
+    #define DISPLAY_HEIGHT      480     // LVGL height (landscape)
+    #define PANEL_WIDTH         480     // Physical panel width (portrait)
+    #define PANEL_HEIGHT        800     // Physical panel height (portrait)
+    #define DISPLAY_MODEL       "ST7701 4\" (800x480)"
+#elif SCREEN_SIZE == 7
+    // GUITION JC1060P470C — JD9165 MIPI DSI. PLACEHOLDER: panel driver not yet
+    // ported (see docs/MULTI_SCREEN_SUPPORT.md, Phase 2). Dims kept for build-time
+    // wiring only; not yet validated on hardware.
+    #define DISPLAY_WIDTH       1024    // LVGL width (landscape)
+    #define DISPLAY_HEIGHT      600     // LVGL height (landscape)
+    #define PANEL_WIDTH         600     // Physical panel width (portrait)
+    #define PANEL_HEIGHT        1024    // Physical panel height (portrait)
+    #define DISPLAY_MODEL       "JD9165 7\" (1024x600)"
+#else
+    #error "Unsupported SCREEN_SIZE (use 4 or 7)"
+#endif
 
 // =============================================================================
 // ALBUM ART

--- a/include/config.h
+++ b/include/config.h
@@ -76,15 +76,30 @@
     #define PANEL_WIDTH         480     // Physical panel width (portrait)
     #define PANEL_HEIGHT        800     // Physical panel height (portrait)
     #define DISPLAY_MODEL       "ST7701 4\" (800x480)"
+    #define LCD_RST             5       // Reset GPIO for ST7701
+    #define TOUCH_GT911_SDA     7
+    #define TOUCH_GT911_SCL     8
+    #define TOUCH_GT911_INT     -1      // Not used
+    #define TOUCH_GT911_RST     -1      // Not used
+    #define TOUCH_PANEL_WIDTH   480     // Touch panel native width (portrait)
+    #define TOUCH_PANEL_HEIGHT  800     // Touch panel native height (portrait)
 #elif SCREEN_SIZE == 7
-    // GUITION JC1060P470C — JD9165 MIPI DSI. PLACEHOLDER: panel driver not yet
-    // ported (see docs/MULTI_SCREEN_SUPPORT.md, Phase 2). Dims kept for build-time
-    // wiring only; not yet validated on hardware.
+    // GUITION JC1060P470C — JD9165 MIPI DSI, native 1024x600 LANDSCAPE.
+    // Unlike the 4" ST7701 (portrait panel rotated 90°), the JD9165 is wired
+    // landscape, so the flush path does NOT rotate (PANEL_* == DISPLAY_*).
+    // Code-complete from the CoopsInChina fork port; not yet hardware-validated.
     #define DISPLAY_WIDTH       1024    // LVGL width (landscape)
     #define DISPLAY_HEIGHT      600     // LVGL height (landscape)
-    #define PANEL_WIDTH         600     // Physical panel width (portrait)
-    #define PANEL_HEIGHT        1024    // Physical panel height (portrait)
+    #define PANEL_WIDTH         1024    // Physical panel width (no rotation)
+    #define PANEL_HEIGHT        600     // Physical panel height (no rotation)
     #define DISPLAY_MODEL       "JD9165 7\" (1024x600)"
+    #define LCD_RST             23      // Reset GPIO for JD9165 (CoopsInChina fork)
+    #define TOUCH_GT911_SDA     7
+    #define TOUCH_GT911_SCL     8
+    #define TOUCH_GT911_INT     11
+    #define TOUCH_GT911_RST     22
+    #define TOUCH_PANEL_WIDTH   1024    // Touch panel native width (landscape)
+    #define TOUCH_PANEL_HEIGHT  600     // Touch panel native height (landscape)
 #else
     #error "Unsupported SCREEN_SIZE (use 4 or 7)"
 #endif

--- a/include/display_driver.h
+++ b/include/display_driver.h
@@ -3,11 +3,11 @@
 
 #include <Arduino.h>
 #include "lvgl.h"
+#include "config.h"   // DISPLAY_WIDTH / DISPLAY_HEIGHT come from the SCREEN_SIZE block
 
-// Display specifications for ESP32-P4 JC4880P443C (MIPI DSI)
-// App sees LANDSCAPE 800x480, driver rotates to panel's portrait orientation
-#define DISPLAY_WIDTH  800  // Landscape width (app sees this)
-#define DISPLAY_HEIGHT 480  // Landscape height (app sees this)
+// Display specifications (MIPI DSI). App sees LANDSCAPE dimensions; the driver
+// rotates to the panel's portrait orientation. DISPLAY_WIDTH/HEIGHT are defined
+// per variant in config.h (SCREEN_SIZE) — do not redefine them here.
 #define DISPLAY_BUF_SIZE (DISPLAY_WIDTH * DISPLAY_HEIGHT)  // Full frame buffer
 
 // ST7701 LCD Controller pins

--- a/include/display_driver.h
+++ b/include/display_driver.h
@@ -10,8 +10,7 @@
 // per variant in config.h (SCREEN_SIZE) — do not redefine them here.
 #define DISPLAY_BUF_SIZE (DISPLAY_WIDTH * DISPLAY_HEIGHT)  // Full frame buffer
 
-// ST7701 LCD Controller pins
-#define LCD_RST     5  // Reset GPIO for ST7701
+// LCD_RST and touch pins are defined per variant in config.h (SCREEN_SIZE block).
 
 // Note: MIPI DSI interface uses dedicated hardware pins on ESP32-P4
 // No manual pin configuration needed for DSI data/clock

--- a/include/touch_driver.h
+++ b/include/touch_driver.h
@@ -3,12 +3,7 @@
 
 #include <Arduino.h>
 #include "lvgl.h"
-
-// GT911 Touch Controller pins for ESP32-P4 JC4880P443C
-#define TOUCH_GT911_SDA  7
-#define TOUCH_GT911_SCL  8
-#define TOUCH_GT911_INT  -1   // Not used
-#define TOUCH_GT911_RST  -1   // Not used
+#include "config.h"   // GT911 pins + TOUCH_PANEL_* come from the SCREEN_SIZE block
 
 // Function declarations
 bool touch_init(void);

--- a/include/ui_common.h
+++ b/include/ui_common.h
@@ -14,6 +14,7 @@
 #include "touch_driver.h"
 #include "sonos_controller.h"
 #include "esp_heap_caps.h"
+#include "ui_scale.h"   // SX()/SY() resolution-relative scaling + FONT_* tiers
 
 // Default WiFi credentials (empty = force WiFi setup via UI)
 #define DEFAULT_WIFI_SSID ""

--- a/include/ui_scale.h
+++ b/include/ui_scale.h
@@ -1,0 +1,46 @@
+#ifndef UI_SCALE_H
+#define UI_SCALE_H
+
+#include "lvgl.h"
+#include "config.h"   // DISPLAY_WIDTH / DISPLAY_HEIGHT (resolved from SCREEN_SIZE)
+
+// ---------------------------------------------------------------------------
+// Resolution-relative UI scaling
+// ---------------------------------------------------------------------------
+// All screen coordinates are authored in the original 800x480 "design space".
+// SX()/SY() scale them to the active panel (DISPLAY_WIDTH x DISPLAY_HEIGHT) so a
+// SINGLE layout adapts to any screen size — no per-variant layout code.
+//
+// On the 4" panel (800x480) the factors are exactly 1:1, so SX(v)==v and
+// SY(v)==v → ZERO visual change versus the original hardcoded layout. This is
+// what protects the deployed 4" fleet while we make the UI dynamic.
+//
+// Fonts cannot scale continuously, so FONT_* selects a size tier by width.
+// See docs/MULTI_SCREEN_SUPPORT.md.
+// ---------------------------------------------------------------------------
+
+#define UI_DESIGN_W 800
+#define UI_DESIGN_H 480
+
+// Scale an X / Y coordinate (or width / height) from design space to the panel.
+#define SX(v) ((lv_coord_t)((int32_t)(v) * DISPLAY_WIDTH  / UI_DESIGN_W))
+#define SY(v) ((lv_coord_t)((int32_t)(v) * DISPLAY_HEIGHT / UI_DESIGN_H))
+
+// Uniform scale for square / fixed-aspect elements (radii, circular buttons):
+// uses the smaller axis factor so circles stay circular on non-matching aspects.
+#define SMIN(v) (SX(v) < SY(v) ? SX(v) : SY(v))
+
+// Font tiers by display width. Only the active SCREEN_SIZE's branch is compiled.
+// (4" uses the existing fonts; the >=1024 tier is wired for the future 7" and
+//  must have those font sizes enabled in lv_conf.h when that variant is built.)
+#if DISPLAY_WIDTH >= 1024
+    #define FONT_TITLE  &lv_font_montserrat_32
+    #define FONT_BODY   &lv_font_montserrat_20
+    #define FONT_SMALL  &lv_font_montserrat_16
+#else
+    #define FONT_TITLE  &lv_font_montserrat_24
+    #define FONT_BODY   &lv_font_montserrat_16
+    #define FONT_SMALL  &lv_font_montserrat_14
+#endif
+
+#endif // UI_SCALE_H

--- a/lib/jd9165_lcd/README.md
+++ b/lib/jd9165_lcd/README.md
@@ -1,0 +1,19 @@
+# JD9165 LCD driver — 7" variant  (PLACEHOLDER / NOT YET PORTED)
+
+This folder will hold the **MIPI DSI panel driver** for the 7" **GUITION JC1060P470C**
+(JD9165 controller, **1024×600**), used by the `esp32_7inch` build environment.
+
+## Status: not implemented yet
+The 7" build (`pio run -e esp32_7inch`) does **not** link until this driver exists.
+The 4" build (`pio run -e esp32_4inch`) is unaffected — it uses `lib/st7701_lcd`.
+
+## What goes here (Phase 2 — needs a physical 7" unit to validate)
+Port from the reference fork https://github.com/CoopsInChina/SonosESP :
+- `esp_lcd_jd9165.c` / `esp_lcd_jd9165.h`
+- `jd9165_lcd.cpp` / `jd9165_lcd.h`
+- the matching **GT911 touch pin map** for the 7" panel
+
+Then `src/display_driver.cpp` selects the panel by `SCREEN_SIZE`
+(ST7701 for 4", JD9165 for 7").
+
+See **docs/MULTI_SCREEN_SUPPORT.md** (Phases 2–3) for the full plan.

--- a/lib/jd9165_lcd/README.md
+++ b/lib/jd9165_lcd/README.md
@@ -1,19 +1,27 @@
-# JD9165 LCD driver — 7" variant  (PLACEHOLDER / NOT YET PORTED)
+# JD9165 LCD driver — 7" variant  (CODE-COMPLETE / NOT YET HARDWARE-VALIDATED)
 
-This folder will hold the **MIPI DSI panel driver** for the 7" **GUITION JC1060P470C**
-(JD9165 controller, **1024×600**), used by the `esp32_7inch` build environment.
+MIPI DSI panel driver for the 7" **GUITION JC1060P470C** (JD9165 controller,
+**1024×600 native landscape**), used by the `esp32_7inch` build environment.
 
-## Status: not implemented yet
-The 7" build (`pio run -e esp32_7inch`) does **not** link until this driver exists.
-The 4" build (`pio run -e esp32_4inch`) is unaffected — it uses `lib/st7701_lcd`.
+## Status: builds & links, awaiting bench validation
+`pio run -e esp32_7inch` compiles and links cleanly. The driver has **not** yet
+been run on a physical 7" unit — panel init timings, touch orientation, and the
+backlight/reset GPIOs (LCD_RST=23, BL=23, touch INT=11/RST=22) are taken from the
+reference fork and must be confirmed on hardware before a 7" release.
 
-## What goes here (Phase 2 — needs a physical 7" unit to validate)
-Port from the reference fork https://github.com/CoopsInChina/SonosESP :
-- `esp_lcd_jd9165.c` / `esp_lcd_jd9165.h`
-- `jd9165_lcd.cpp` / `jd9165_lcd.h`
-- the matching **GT911 touch pin map** for the 7" panel
+## Contents (ported from https://github.com/CoopsInChina/SonosESP)
+- `esp_lcd_jd9165.c` / `esp_lcd_jd9165.h` — Espressif-style JD9165 panel driver
+  (init command table + `JD9165_1024_600_PANEL_60HZ_DPI_CONFIG`).
+- `jd9165_lcd.cpp` / `jd9165_lcd.h` — thin wrapper matching the `st7701_lcd`
+  API (`begin()/get_handle()/lcd_draw_bitmap()/example_bsp_set_lcd_backlight()`),
+  so `src/display_driver.cpp` can select the panel by `SCREEN_SIZE`.
 
-Then `src/display_driver.cpp` selects the panel by `SCREEN_SIZE`
-(ST7701 for 4", JD9165 for 7").
+## How it wires up
+- `include/config.h` (`SCREEN_SIZE == 7`) resolves the dims/pins.
+- `src/display_driver.cpp` — native landscape, **no rotation** (unlike the 4"
+  ST7701 which rotates a portrait panel); flush pushes the framebuffer directly.
+- `src/touch_driver.cpp` — GT911 native-landscape mapping (no 90° rotation).
+- `platformio.ini` `[env:esp32_7inch]` sets `-DSCREEN_SIZE=7` and
+  `lib_ignore = st7701_lcd`.
 
-See **docs/MULTI_SCREEN_SUPPORT.md** (Phases 2–3) for the full plan.
+See **docs/MULTI_SCREEN_SUPPORT.md** for the full plan.

--- a/lib/jd9165_lcd/esp_lcd_jd9165.c
+++ b/lib/jd9165_lcd/esp_lcd_jd9165.c
@@ -1,0 +1,339 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc_caps.h"
+
+#if SOC_MIPI_DSI_SUPPORTED
+#include "esp_check.h"
+#include "esp_log.h"
+#include "esp_lcd_panel_commands.h"
+#include "esp_lcd_panel_interface.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_mipi_dsi.h"
+#include "esp_lcd_panel_vendor.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "esp_lcd_jd9165.h"
+
+#define JD9165_CMD_GS_BIT       (1 << 0)
+#define JD9165_CMD_SS_BIT       (1 << 1)
+
+typedef struct {
+    esp_lcd_panel_io_handle_t io;
+    int reset_gpio_num;
+    uint8_t madctl_val; // save current value of LCD_CMD_MADCTL register
+    uint8_t colmod_val; // save surrent value of LCD_CMD_COLMOD register
+    const jd9165_lcd_init_cmd_t *init_cmds;
+    uint16_t init_cmds_size;
+    struct {
+        unsigned int reset_level: 1;
+    } flags;
+    // To save the original functions of MIPI DPI panel
+    esp_err_t (*del)(esp_lcd_panel_t *panel);
+    esp_err_t (*init)(esp_lcd_panel_t *panel);
+} jd9165_panel_t;
+
+static const char *TAG = "jd9165";
+
+static esp_err_t panel_jd9165_del(esp_lcd_panel_t *panel);
+static esp_err_t panel_jd9165_init(esp_lcd_panel_t *panel);
+static esp_err_t panel_jd9165_reset(esp_lcd_panel_t *panel);
+static esp_err_t panel_jd9165_invert_color(esp_lcd_panel_t *panel, bool invert_color_data);
+static esp_err_t panel_jd9165_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y);
+static esp_err_t panel_jd9165_disp_on_off(esp_lcd_panel_t *panel, bool on_off);
+
+esp_err_t esp_lcd_new_panel_jd9165(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config,
+                                   esp_lcd_panel_handle_t *ret_panel)
+{
+    ESP_RETURN_ON_FALSE(io && panel_dev_config && ret_panel, ESP_ERR_INVALID_ARG, TAG, "invalid arguments");
+    jd9165_vendor_config_t *vendor_config = (jd9165_vendor_config_t *)panel_dev_config->vendor_config;
+    ESP_RETURN_ON_FALSE(vendor_config && vendor_config->mipi_config.dpi_config && vendor_config->mipi_config.dsi_bus, ESP_ERR_INVALID_ARG, TAG,
+                        "invalid vendor config");
+
+    esp_err_t ret = ESP_OK;
+    jd9165_panel_t *jd9165 = (jd9165_panel_t *)calloc(1, sizeof(jd9165_panel_t));
+    ESP_RETURN_ON_FALSE(jd9165, ESP_ERR_NO_MEM, TAG, "no mem for jd9165 panel");
+
+    if (panel_dev_config->reset_gpio_num >= 0) {
+        gpio_config_t io_conf = {
+            .mode = GPIO_MODE_OUTPUT,
+            .pin_bit_mask = 1ULL << panel_dev_config->reset_gpio_num,
+        };
+        ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
+    }
+
+    switch (panel_dev_config->color_space) {
+    case LCD_RGB_ELEMENT_ORDER_RGB:
+        jd9165->madctl_val = 0;
+        break;
+    case LCD_RGB_ELEMENT_ORDER_BGR:
+        jd9165->madctl_val |= LCD_CMD_BGR_BIT;
+        break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, TAG, "unsupported color space");
+        break;
+    }
+
+    jd9165->io = io;
+    jd9165->init_cmds = vendor_config->init_cmds;
+    jd9165->init_cmds_size = vendor_config->init_cmds_size;
+    jd9165->reset_gpio_num = panel_dev_config->reset_gpio_num;
+    jd9165->flags.reset_level = panel_dev_config->flags.reset_active_high;
+
+    // Create MIPI DPI panel
+    esp_lcd_panel_handle_t panel_handle = NULL;
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_dpi(vendor_config->mipi_config.dsi_bus, vendor_config->mipi_config.dpi_config, &panel_handle), err, TAG,
+                      "create MIPI DPI panel failed");
+    ESP_LOGD(TAG, "new MIPI DPI panel @%p", panel_handle);
+
+    // Save the original functions of MIPI DPI panel
+    jd9165->del = panel_handle->del;
+    jd9165->init = panel_handle->init;
+    // Overwrite the functions of MIPI DPI panel
+    panel_handle->del = panel_jd9165_del;
+    panel_handle->init = panel_jd9165_init;
+    panel_handle->reset = panel_jd9165_reset;
+    panel_handle->mirror = panel_jd9165_mirror;
+    panel_handle->invert_color = panel_jd9165_invert_color;
+    panel_handle->disp_on_off = panel_jd9165_disp_on_off;
+    panel_handle->user_data = jd9165;
+    *ret_panel = panel_handle;
+    ESP_LOGD(TAG, "new jd9165 panel @%p", jd9165);
+
+    return ESP_OK;
+
+err:
+    if (jd9165) {
+        if (panel_dev_config->reset_gpio_num >= 0) {
+            gpio_reset_pin(panel_dev_config->reset_gpio_num);
+        }
+        free(jd9165);
+    }
+    return ret;
+}
+
+static const jd9165_lcd_init_cmd_t vendor_specific_init_default[] = {
+//  {cmd, { data }, data_size, delay_ms}
+    //{0x11, (uint8_t []){0x00}, 1, 120},
+    //{0x29, (uint8_t []){0x00}, 1, 20},
+    
+    {0x30, (uint8_t[]){0x00}, 1, 0},
+    {0xF7, (uint8_t[]){0x49,0x61,0x02,0x00}, 4, 0},
+    {0x30, (uint8_t[]){0x01}, 1, 0},
+    {0x04, (uint8_t[]){0x0C}, 1, 0},
+    {0x05, (uint8_t[]){0x00}, 1, 0},
+    {0x06, (uint8_t[]){0x00}, 1, 0},
+    {0x0B, (uint8_t[]){0x11}, 1, 0},
+    {0x17, (uint8_t[]){0x00}, 1, 0},
+    {0x20, (uint8_t[]){0x04}, 1, 0},
+    {0x1F, (uint8_t[]){0x05}, 1, 0},
+    {0x23, (uint8_t[]){0x00}, 1, 0},
+    {0x25, (uint8_t[]){0x19}, 1, 0},
+    {0x28, (uint8_t[]){0x18}, 1, 0},
+    {0x29, (uint8_t[]){0x04}, 1, 0},
+    {0x2A, (uint8_t[]){0x01}, 1, 0},
+    {0x2B, (uint8_t[]){0x04}, 1, 0},
+    {0x2C, (uint8_t[]){0x01}, 1, 0},
+    {0x30, (uint8_t[]){0x02}, 1, 0},
+    {0x01, (uint8_t[]){0x22}, 1, 0},
+    {0x03, (uint8_t[]){0x12}, 1, 0},
+    {0x04, (uint8_t[]){0x00}, 1, 0},
+    {0x05, (uint8_t[]){0x64}, 1, 0},
+    {0x0A, (uint8_t[]){0x08}, 1, 0},
+    {0x0B, (uint8_t[]){0x0A,0x1A,0x0B,0x0D,0x0D,0x11,0x10,0x06,0x08,0x1F,0x1D}, 11, 0},
+    {0x0C, (uint8_t[]){0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D}, 11, 0},
+    {0x0D, (uint8_t[]){0x16,0x1B,0x0B,0x0D,0x0D,0x11,0x10,0x07,0x09,0x1E,0x1C}, 11, 0},
+    {0x0E, (uint8_t[]){0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D}, 11, 0},
+    {0x0F, (uint8_t[]){0x16,0x1B,0x0D,0x0B,0x0D,0x11,0x10,0x1C,0x1E,0x09,0x07}, 11, 0},
+    {0x10, (uint8_t[]){0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D}, 11, 0},
+    {0x11, (uint8_t[]){0x0A,0x1A,0x0D,0x0B,0x0D,0x11,0x10,0x1D,0x1F,0x08,0x06}, 11, 0},
+    {0x12, (uint8_t[]){0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D,0x0D}, 11, 0},
+    {0x14, (uint8_t[]){0x00,0x00,0x11,0x11}, 4, 0},
+    {0x18, (uint8_t[]){0x99}, 1, 0},
+    {0x30, (uint8_t[]){0x06}, 1, 0},
+    {0x12, (uint8_t[]){0x36,0x2C,0x2E,0x3C,0x38,0x35,0x35,0x32,0x2E,0x1D,0x2B,0x21,0x16,0x29}, 14, 0},
+    {0x13, (uint8_t[]){0x36,0x2C,0x2E,0x3C,0x38,0x35,0x35,0x32,0x2E,0x1D,0x2B,0x21,0x16,0x29}, 14, 0},
+    
+    // {0x30, (uint8_t[]){0x08}, 1, 0},
+    // {0x05, (uint8_t[]){0x01}, 1, 0},
+    // {0x0C, (uint8_t[]){0x1A}, 1, 0},
+    // {0x0D, (uint8_t[]){0x0E}, 1, 0},
+
+    // {0x30, (uint8_t[]){0x07}, 1, 0},
+    // {0x01, (uint8_t[]){0x04}, 1, 0},
+
+    {0x30, (uint8_t[]){0x0A}, 1, 0},
+    {0x02, (uint8_t[]){0x4F}, 1, 0},
+    {0x0B, (uint8_t[]){0x40}, 1, 0},
+    {0x12, (uint8_t[]){0x3E}, 1, 0},
+    {0x13, (uint8_t[]){0x78}, 1, 0},
+    {0x30, (uint8_t[]){0x0D}, 1, 0},
+    {0x0D, (uint8_t[]){0x04}, 1, 0},
+    {0x10, (uint8_t[]){0x0C}, 1, 0},
+    {0x11, (uint8_t[]){0x0C}, 1, 0},
+    {0x12, (uint8_t[]){0x0C}, 1, 0},
+    {0x13, (uint8_t[]){0x0C}, 1, 0},
+    {0x30, (uint8_t[]){0x00}, 1, 0},
+
+    // {0X3A, (uint8_t[]){0x55}, 1, 0},
+    {0x11, (uint8_t[]){0x00}, 1, 120},
+    {0x29, (uint8_t[]){0x00}, 1, 50},
+};
+
+static esp_err_t panel_jd9165_del(esp_lcd_panel_t *panel)
+{
+    jd9165_panel_t *jd9165 = (jd9165_panel_t *)panel->user_data;
+
+    if (jd9165->reset_gpio_num >= 0) {
+        gpio_reset_pin(jd9165->reset_gpio_num);
+    }
+    // Delete MIPI DPI panel
+    jd9165->del(panel);
+    ESP_LOGD(TAG, "del jd9165 panel @%p", jd9165);
+    free(jd9165);
+
+    return ESP_OK;
+}
+
+static esp_err_t panel_jd9165_init(esp_lcd_panel_t *panel)
+{
+    jd9165_panel_t *jd9165 = (jd9165_panel_t *)panel->user_data;
+    esp_lcd_panel_io_handle_t io = jd9165->io;
+    const jd9165_lcd_init_cmd_t *init_cmds = NULL;
+    uint16_t init_cmds_size = 0;
+    bool is_cmd_overwritten = false;
+
+    uint8_t ID[3];
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_rx_param(io, 0x04, ID, 3), TAG, "read ID failed");
+
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
+        jd9165->madctl_val,
+    }, 1), TAG, "send command failed");
+
+    // vendor specific initialization, it can be different between manufacturers
+    // should consult the LCD supplier for initialization sequence code
+    if (jd9165->init_cmds) {
+        init_cmds = jd9165->init_cmds;
+        init_cmds_size = jd9165->init_cmds_size;
+    } else {
+        init_cmds = vendor_specific_init_default;
+        init_cmds_size = sizeof(vendor_specific_init_default) / sizeof(jd9165_lcd_init_cmd_t);
+    }
+
+    for (int i = 0; i < init_cmds_size; i++) {
+        // Check if the command has been used or conflicts with the internal
+        if (init_cmds[i].data_bytes > 0) {
+            switch (init_cmds[i].cmd) {
+            case LCD_CMD_MADCTL:
+                is_cmd_overwritten = true;
+                jd9165->madctl_val = ((uint8_t *)init_cmds[i].data)[0];
+                break;
+            default:
+                is_cmd_overwritten = false;
+                break;
+            }
+
+            if (is_cmd_overwritten) {
+                is_cmd_overwritten = false;
+                ESP_LOGW(TAG, "The %02Xh command has been used and will be overwritten by external initialization sequence",
+                         init_cmds[i].cmd);
+            }
+        }
+
+        // Send command
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, init_cmds[i].cmd, init_cmds[i].data, init_cmds[i].data_bytes), TAG, "send command failed");
+        vTaskDelay(pdMS_TO_TICKS(init_cmds[i].delay_ms));
+    }
+    ESP_LOGD(TAG, "send init commands success");
+
+    ESP_RETURN_ON_ERROR(jd9165->init(panel), TAG, "init MIPI DPI panel failed");
+
+    return ESP_OK;
+}
+
+static esp_err_t panel_jd9165_reset(esp_lcd_panel_t *panel)
+{
+    jd9165_panel_t *jd9165 = (jd9165_panel_t *)panel->user_data;
+    esp_lcd_panel_io_handle_t io = jd9165->io;
+
+    // Perform hardware reset
+    if (jd9165->reset_gpio_num >= 0) {
+        gpio_set_level(jd9165->reset_gpio_num, !jd9165->flags.reset_level);
+        vTaskDelay(pdMS_TO_TICKS(5));
+        gpio_set_level(jd9165->reset_gpio_num, jd9165->flags.reset_level);
+        vTaskDelay(pdMS_TO_TICKS(10));
+        gpio_set_level(jd9165->reset_gpio_num, !jd9165->flags.reset_level);
+        vTaskDelay(pdMS_TO_TICKS(120));
+    } else if (io) { // Perform software reset
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_CMD_SWRESET, NULL, 0), TAG, "send command failed");
+        vTaskDelay(pdMS_TO_TICKS(120));
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t panel_jd9165_invert_color(esp_lcd_panel_t *panel, bool invert_color_data)
+{
+    jd9165_panel_t *jd9165 = (jd9165_panel_t *)panel->user_data;
+    esp_lcd_panel_io_handle_t io = jd9165->io;
+    uint8_t command = 0;
+
+    ESP_RETURN_ON_FALSE(io, ESP_ERR_INVALID_STATE, TAG, "invalid panel IO");
+
+    if (invert_color_data) {
+        command = LCD_CMD_INVON;
+    } else {
+        command = LCD_CMD_INVOFF;
+    }
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, command, NULL, 0), TAG, "send command failed");
+
+    return ESP_OK;
+}
+
+static esp_err_t panel_jd9165_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y)
+{
+    jd9165_panel_t *jd9165 = (jd9165_panel_t *)panel->user_data;
+    esp_lcd_panel_io_handle_t io = jd9165->io;
+    uint8_t madctl_val = jd9165->madctl_val;
+
+    ESP_RETURN_ON_FALSE(io, ESP_ERR_INVALID_STATE, TAG, "invalid panel IO");
+
+    // Control mirror through LCD command
+    if (mirror_x) {
+        madctl_val |= JD9165_CMD_GS_BIT;
+    } else {
+        madctl_val &= ~JD9165_CMD_GS_BIT;
+    }
+    if (mirror_y) {
+        madctl_val |= JD9165_CMD_SS_BIT;
+    } else {
+        madctl_val &= ~JD9165_CMD_SS_BIT;
+    }
+
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t []) {
+        madctl_val
+    }, 1), TAG, "send command failed");
+    jd9165->madctl_val = madctl_val;
+
+    return ESP_OK;
+}
+
+static esp_err_t panel_jd9165_disp_on_off(esp_lcd_panel_t *panel, bool on_off)
+{
+    jd9165_panel_t *jd9165 = (jd9165_panel_t *)panel->user_data;
+    esp_lcd_panel_io_handle_t io = jd9165->io;
+    int command = 0;
+
+    if (on_off) {
+        command = LCD_CMD_DISPON;
+    } else {
+        command = LCD_CMD_DISPOFF;
+    }
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, command, NULL, 0), TAG, "send command failed");
+    return ESP_OK;
+}
+#endif

--- a/lib/jd9165_lcd/esp_lcd_jd9165.h
+++ b/lib/jd9165_lcd/esp_lcd_jd9165.h
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#if SOC_MIPI_DSI_SUPPORTED
+#include "esp_lcd_panel_vendor.h"
+#include "esp_lcd_mipi_dsi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief LCD panel initialization commands.
+ *
+ */
+typedef struct {
+    int cmd;                /*<! The specific LCD command */
+    const void *data;       /*<! Buffer that holds the command specific data */
+    size_t data_bytes;      /*<! Size of `data` in memory, in bytes */
+    unsigned int delay_ms;  /*<! Delay in milliseconds after this command */
+} jd9165_lcd_init_cmd_t;
+
+/**
+ * @brief LCD panel vendor configuration.
+ *
+ * @note  This structure needs to be passed to the `vendor_config` field in `esp_lcd_panel_dev_config_t`.
+ *
+ */
+typedef struct {
+    const jd9165_lcd_init_cmd_t *init_cmds;         /*!< Pointer to initialization commands array. Set to NULL if using default commands.
+                                                     *   The array should be declared as `static const` and positioned outside the function.
+                                                     *   Please refer to `vendor_specific_init_default` in source file.
+                                                     */
+    uint16_t init_cmds_size;                        /*<! Number of commands in above array */
+    struct {
+        esp_lcd_dsi_bus_handle_t dsi_bus;               /*!< MIPI-DSI bus configuration */
+        const esp_lcd_dpi_panel_config_t *dpi_config;   /*!< MIPI-DPI panel configuration */
+    } mipi_config;
+} jd9165_vendor_config_t;
+
+/**
+ * @brief Create LCD panel for model JD9165
+ *
+ * @note  Vendor specific initialization can be different between manufacturers, should consult the LCD supplier for initialization sequence code.
+ *
+ * @param[in]  io LCD panel IO handle
+ * @param[in]  panel_dev_config General panel device configuration
+ * @param[out] ret_panel Returned LCD panel handle
+ * @return
+ *      - ESP_ERR_INVALID_ARG   if parameter is invalid
+ *      - ESP_OK                on success
+ *      - Otherwise             on fail
+ */
+esp_err_t esp_lcd_new_panel_jd9165(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config,
+                                   esp_lcd_panel_handle_t *ret_panel);
+
+/**
+ * @brief MIPI-DSI bus configuration structure
+ *
+ * @param[in] lane_num Number of data lanes
+ * @param[in] lane_mbps Lane bit rate in Mbps
+ *
+ */
+#define JD9165_PANEL_BUS_DSI_2CH_CONFIG()                \
+    {                                                    \
+        .bus_id = 0,                                     \
+        .num_data_lanes = 2,                             \
+        .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,     \
+        .lane_bit_rate_mbps = 750,                       \
+    }
+
+/**
+ * @brief MIPI-DBI panel IO configuration structure
+ *
+ */
+#define JD9165_PANEL_IO_DBI_CONFIG()  \
+    {                                 \
+        .virtual_channel = 0,         \
+        .lcd_cmd_bits = 8,            \
+        .lcd_param_bits = 8,          \
+    }
+
+/**
+ * @brief MIPI DPI configuration structure
+ *
+ * @note  refresh_rate = (dpi_clock_freq_mhz * 1000000) / (h_res + hsync_pulse_width + hsync_back_porch + hsync_front_porch)
+ *                                                      / (v_res + vsync_pulse_width + vsync_back_porch + vsync_front_porch)
+ *
+ * @param[in] px_format Pixel format of the panel
+ *
+ */
+#define JD9165_1024_600_PANEL_60HZ_DPI_CONFIG(px_format) \
+    {                                                    \
+        .virtual_channel = 0,                                    \
+        .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,             \
+        .dpi_clock_freq_mhz = 56,                                \
+        .pixel_format = px_format,                               \
+        .num_fbs = 1,                                            \
+        .video_timing = {                                        \
+            .h_size = 1024,                                      \
+            .v_size = 600,                                       \
+            .hsync_pulse_width = 40,                             \
+            .hsync_back_porch = 160,                             \
+            .hsync_front_porch = 160,                            \
+            .vsync_pulse_width = 10,                              \
+            .vsync_back_porch = 23,                              \
+            .vsync_front_porch = 12,                             \
+        },                                                       \
+        .flags= {                                                \
+            .use_dma2d = true,                                   \
+        },                                                       \
+    }								
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/jd9165_lcd/jd9165_lcd.cpp
+++ b/lib/jd9165_lcd/jd9165_lcd.cpp
@@ -1,0 +1,200 @@
+#include "sdkconfig.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "esp_timer.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_mipi_dsi.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_ldo_regulator.h"
+#include "driver/gpio.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "Arduino.h"
+#include "esp_lcd_jd9165.h"
+#include "jd9165_lcd.h"
+#include "driver/ledc.h"
+
+#define BACKLIGHT_PIN 23
+#define BACKLIGHT_CHANNEL LEDC_CHANNEL_0
+#define BACKLIGHT_TIMER LEDC_TIMER_0
+#define BACKLIGHT_MODE LEDC_LOW_SPEED_MODE
+#define BACKLIGHT_DUTY_RES LEDC_TIMER_13_BIT
+#define BACKLIGHT_FREQ 1000
+
+
+#define LCD_H_RES 1024
+#define LCD_V_RES 600
+
+#define MIPI_DPI_PX_FORMAT (LCD_COLOR_PIXEL_FORMAT_RGB565)
+#define LCD_BIT_PER_PIXEL (16)
+
+// “VDD_MIPI_DPHY”应供电 2.5V，可从内部 LDO 稳压器或外部 LDO 芯片获取电源
+#define EXAMPLE_MIPI_DSI_PHY_PWR_LDO_CHAN 3 // LDO_VO3 连接至 VDD_MIPI_DPHY
+#define EXAMPLE_MIPI_DSI_PHY_PWR_LDO_VOLTAGE_MV 2500
+
+static const char *TAG = "example";
+esp_lcd_panel_handle_t panel_handle = NULL;
+esp_lcd_panel_io_handle_t io_handle = NULL;
+
+jd9165_lcd::jd9165_lcd(int8_t lcd_rst)
+{
+    _lcd_rst = lcd_rst;
+}
+
+void jd9165_lcd::example_bsp_enable_dsi_phy_power()
+{
+    // 打开 MIPI DSI PHY 的电源，使其从“无电”状态进入“关机”状态
+    esp_ldo_channel_handle_t ldo_mipi_phy = NULL;
+#ifdef EXAMPLE_MIPI_DSI_PHY_PWR_LDO_CHAN
+    esp_ldo_channel_config_t ldo_mipi_phy_config = {
+        .chan_id = EXAMPLE_MIPI_DSI_PHY_PWR_LDO_CHAN,
+        .voltage_mv = EXAMPLE_MIPI_DSI_PHY_PWR_LDO_VOLTAGE_MV,
+    };
+    ESP_ERROR_CHECK(esp_ldo_acquire_channel(&ldo_mipi_phy_config, &ldo_mipi_phy));
+    ESP_LOGI(TAG, "MIPI DSI PHY Powered on");
+#endif
+}
+
+
+
+bool pwm_initialized = false;
+
+void jd9165_lcd::initBacklightPWM() {
+    if (pwm_initialized) return;
+    
+    ledc_timer_config_t ledc_timer = {
+        .speed_mode = BACKLIGHT_MODE,
+        .duty_resolution = BACKLIGHT_DUTY_RES,
+        .timer_num = BACKLIGHT_TIMER,
+        .freq_hz = BACKLIGHT_FREQ,
+        .clk_cfg = LEDC_AUTO_CLK
+    };
+    ledc_timer_config(&ledc_timer);
+    
+    ledc_channel_config_t ledc_channel = {
+        .gpio_num = BACKLIGHT_PIN,
+        .speed_mode = BACKLIGHT_MODE,
+        .channel = BACKLIGHT_CHANNEL,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = BACKLIGHT_TIMER,
+        .duty = 8191,  // 100%
+        .hpoint = 0
+    };
+    ledc_channel_config(&ledc_channel);
+    
+    pwm_initialized = true;
+}
+
+void jd9165_lcd::example_bsp_set_lcd_backlight(uint32_t level)
+{
+    if (!pwm_initialized) {
+        initBacklightPWM();
+    }
+    
+    // 'level' is 0-100 percentage
+    level = constrain(level, 0, 100);
+    
+    // Convert percentage to PWM duty (0-8191)
+    // Keep minimum 5% for visibility (409 duty)
+    uint32_t duty = map(level, 0, 100, 0, 8191);
+    if (level > 0 && duty < 409) duty = 409;  // Minimum 5%
+    
+    ledc_set_duty(BACKLIGHT_MODE, BACKLIGHT_CHANNEL, duty);
+    ledc_update_duty(BACKLIGHT_MODE, BACKLIGHT_CHANNEL);
+    
+    Serial.printf("[Backlight] Set to %d%% (duty: %d)\n", level, duty);
+}
+
+void jd9165_lcd::begin()
+{   
+    example_bsp_enable_dsi_phy_power();
+
+    // 首先创建 MIPI DSI 总线，它还将初始化 DSI PHY
+    esp_lcd_dsi_bus_handle_t mipi_dsi_bus;
+    esp_lcd_dsi_bus_config_t bus_config = JD9165_PANEL_BUS_DSI_2CH_CONFIG();
+    ESP_ERROR_CHECK(esp_lcd_new_dsi_bus(&bus_config, &mipi_dsi_bus));
+
+    ESP_LOGI(TAG, "Install MIPI DSI LCD control panel");
+    // 我们使用DBI接口发送LCD命令和参数
+    esp_lcd_dbi_io_config_t dbi_config = JD9165_PANEL_IO_DBI_CONFIG();
+
+    ESP_ERROR_CHECK(esp_lcd_new_panel_io_dbi(mipi_dsi_bus, &dbi_config, &io_handle));
+
+    // 创建JD9165控制面板
+    esp_lcd_dpi_panel_config_t dpi_config = JD9165_1024_600_PANEL_60HZ_DPI_CONFIG(MIPI_DPI_PX_FORMAT);
+
+    jd9165_vendor_config_t vendor_config = {
+        .mipi_config = {
+            .dsi_bus = mipi_dsi_bus,
+            .dpi_config = &dpi_config,
+        },
+    };
+    const esp_lcd_panel_dev_config_t panel_config = {
+        .reset_gpio_num = _lcd_rst,
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,
+        .bits_per_pixel = LCD_BIT_PER_PIXEL,
+        .vendor_config = &vendor_config,
+    };
+    ESP_ERROR_CHECK(esp_lcd_new_panel_jd9165(io_handle, &panel_config, &panel_handle));
+    ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));
+    ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
+
+}
+
+void jd9165_lcd::lcd_draw_bitmap(uint16_t x_start, uint16_t y_start, uint16_t x_end, uint16_t y_end, uint16_t *color_data)
+{
+    // ✅ Use the standard 6-argument version (NO STRIDE)
+    esp_lcd_panel_draw_bitmap(panel_handle, x_start, y_start, x_end, y_end, color_data);
+}
+
+void jd9165_lcd::draw16bitbergbbitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t *color_data)
+{
+    uint16_t x_start = x;
+    uint16_t y_start = y;
+    uint16_t x_end = w + x;
+    uint16_t y_end = h + y;
+
+    esp_lcd_panel_draw_bitmap(panel_handle, x_start, y_start, x_end, y_end, color_data);
+}
+
+void jd9165_lcd::fillScreen(uint16_t color)
+{
+    uint16_t *color_data = (uint16_t *)heap_caps_malloc(480 * 272 * 2, MALLOC_CAP_INTERNAL);
+    memset(color_data, color, 480 * 272 * 2);
+    draw16bitbergbbitmap(0, 0, 480, 272, color_data);
+    free(color_data);
+}
+
+void jd9165_lcd::te_on()
+{
+    esp_lcd_panel_io_tx_param(io_handle, 0x35,new (uint8_t[]){0x00}, 1);
+}
+
+void jd9165_lcd::te_off()
+{
+    esp_lcd_panel_io_tx_param(io_handle, 0x34,new (uint8_t[]){0x00}, 0);
+}
+
+uint16_t jd9165_lcd::width()
+{
+    return LCD_H_RES;
+}
+
+uint16_t jd9165_lcd::height()
+{
+    return LCD_V_RES;
+}
+
+bool jd9165_lcd::get_handle(bsp_lcd_handles_t *ret_handles) {
+    if (!panel_handle || !io_handle) {
+        return false; // Return false if handles are not initialized
+    }
+    
+    ret_handles->io = io_handle;
+    ret_handles->panel = panel_handle;
+    ret_handles->control = NULL;
+    ret_handles->mipi_dsi_bus = NULL;
+    
+    return true; //
+}

--- a/lib/jd9165_lcd/jd9165_lcd.h
+++ b/lib/jd9165_lcd/jd9165_lcd.h
@@ -1,0 +1,38 @@
+#ifndef _JD9165_LCD_H
+#define _JD9165_LCD_H
+#include <stdio.h>
+#include "esp_lcd_types.h"
+#include "esp_lcd_mipi_dsi.h"
+
+
+typedef struct {
+    esp_lcd_dsi_bus_handle_t    mipi_dsi_bus;  /*!< MIPI DSI bus handle */
+    esp_lcd_panel_io_handle_t   io;            /*!< ESP LCD IO handle */
+    esp_lcd_panel_handle_t      panel;         /*!< ESP LCD panel (color) handle */
+    esp_lcd_panel_handle_t      control;       /*!< ESP LCD panel (control) handle */
+} bsp_lcd_handles_t;
+
+class jd9165_lcd
+{
+public:
+    jd9165_lcd(int8_t lcd_rst);
+
+    void begin();
+    void example_bsp_enable_dsi_phy_power();
+    void example_bsp_init_lcd_backlight();
+    void example_bsp_set_lcd_backlight(uint32_t level);
+    void lcd_draw_bitmap(uint16_t x_start, uint16_t y_start,
+                         uint16_t x_end, uint16_t y_end, uint16_t *color_data);
+    void draw16bitbergbbitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t *color_data);
+    void fillScreen(uint16_t color);
+    void te_on();
+    void te_off();
+    void initBacklightPWM();
+    uint16_t width();
+    uint16_t height();
+    bool get_handle(bsp_lcd_handles_t *ret_handles);
+
+private:
+    int8_t _lcd_rst;
+};
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,8 @@
-[env:esp32-p4]
+; === 4" variant — GUITION JC4880P433C (ST7701, 800x480) ===
+; Build/flash:  pio run -e esp32_4inch -t upload
+; To add the 7": copy this block to [env:esp32_7inch], set -DSCREEN_SIZE=7,
+; swap the panel driver (lib_ignore), and add it to the CI build matrix.
+[env:esp32_4inch]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32-p4
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,10 +95,11 @@ build_flags = ${env.build_flags} -DSCREEN_SIZE=4
 lib_ignore  = jd9165_lcd        ; 7" panel driver — not used on the 4"
 
 ; =============================================================================
-;  7"  —  GUITION JC1060P470C  (JD9165, 1024x600)           [ PLACEHOLDER / WIP ]
-;  The panel driver (lib/jd9165_lcd) is NOT yet ported and the UI is not yet
-;  responsive, so this env does NOT build cleanly yet — it exists to define the
-;  structure. See lib/jd9165_lcd/README.md and docs/MULTI_SCREEN_SUPPORT.md.
+;  7"  —  GUITION JC1060P470C  (JD9165, 1024x600)     [ CODE-COMPLETE / UNTESTED ]
+;  Panel driver ported (lib/jd9165_lcd, native 1024x600 landscape, no rotation)
+;  and the UI is resolution-relative (include/ui_scale.h), so this env BUILDS and
+;  LINKS cleanly. NOT yet validated on physical 7" hardware. See
+;  lib/jd9165_lcd/README.md and docs/MULTI_SCREEN_SUPPORT.md.
 ; =============================================================================
 [env:esp32_7inch]
 build_flags = ${env.build_flags} -DSCREEN_SIZE=7

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,9 @@ board_build.f_cpu = 400000000L          ; 400MHz dual-core RISC-V (official max 
 lib_ldf_mode = deep
 lib_archive = false
 
-extra_scripts = pre:remove_lvgl_asm.py
+extra_scripts =
+    pre:remove_lvgl_asm.py
+    pre:scripts/use_ccache.py        ; no-op unless CI sets USE_CCACHE=1 (graceful)
 
 ; Shared build flags. The per-screen -DSCREEN_SIZE is added in each env below
 ; (via ${env.build_flags} — build_flags do NOT auto-merge across sections).

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,11 @@ build_flags =
     -DARDUINO_USB_MODE=1
     -DCORE_DEBUG_LEVEL=0
     -DLV_CONF_INCLUDE_SIMPLE
+    ; --- Screen variant (current: 4"). config.h resolves dims/pins from SCREEN_SIZE.
+    ;     To add the 7": add an [env:esp32_7inch] with -DSCREEN_SIZE=7, port the
+    ;     JD9165 panel driver under lib/, and add a build matrix to the workflows.
+    ;     See docs/MULTI_SCREEN_SUPPORT.md.
+    -DSCREEN_SIZE=4
     -I.
     ; Optimization flags for RISC-V dual-core
     -O3

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,8 +1,22 @@
-; === 4" variant — GUITION JC4880P433C (ST7701, 800x480) ===
-; Build/flash:  pio run -e esp32_4inch -t upload
-; To add the 7": copy this block to [env:esp32_7inch], set -DSCREEN_SIZE=7,
-; swap the panel driver (lib_ignore), and add it to the CI build matrix.
-[env:esp32_4inch]
+; =============================================================================
+;  SonosESP — PlatformIO project
+;  ONE project, ONE codebase. Each SCREEN is a build environment ([env:...]) below.
+;  Shared settings live in [env]; each screen only adds what differs (-DSCREEN_SIZE
+;  + which panel driver to ignore). config.h resolves dims/pins from SCREEN_SIZE.
+;
+;     pio run -e esp32_4inch -t upload      # 4" (working)
+;     pio run -e esp32_7inch -t upload      # 7" (PLACEHOLDER / WIP — see below)
+;
+;  `pio run` with no -e builds only the default (4") via default_envs.
+;  See docs/MULTI_SCREEN_SUPPORT.md.
+; =============================================================================
+[platformio]
+default_envs = esp32_4inch
+
+; =============================================================================
+;  [env]  —  settings SHARED by every screen variant
+; =============================================================================
+[env]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32-p4
 framework = arduino
@@ -25,25 +39,20 @@ lib_archive = false
 
 extra_scripts = pre:remove_lvgl_asm.py
 
+; Shared build flags. The per-screen -DSCREEN_SIZE is added in each env below
+; (via ${env.build_flags} — build_flags do NOT auto-merge across sections).
 build_flags =
     -DBOARD_HAS_PSRAM
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DARDUINO_USB_MODE=1
     -DCORE_DEBUG_LEVEL=0
     -DLV_CONF_INCLUDE_SIMPLE
-    ; --- Screen variant (current: 4"). config.h resolves dims/pins from SCREEN_SIZE.
-    ;     To add the 7": add an [env:esp32_7inch] with -DSCREEN_SIZE=7, port the
-    ;     JD9165 panel driver under lib/, and add a build matrix to the workflows.
-    ;     See docs/MULTI_SCREEN_SUPPORT.md.
-    -DSCREEN_SIZE=4
     -I.
     ; Optimization flags for RISC-V dual-core
     -O3
     -ffunction-sections
     -fdata-sections
-    ; PSRAM XIP (Execute In Place) - allows code execution from PSRAM
-    ; Reduces flash pressure, may slightly reduce performance but increases code space
-    ; Uncomment to test: -DCONFIG_SPIRAM_XIP_FROM_PSRAM=1
+    ; PSRAM XIP (Execute In Place) — uncomment to test: -DCONFIG_SPIRAM_XIP_FROM_PSRAM=1
     ; LVGL ASM disabled (RISC-V, not ARM)
     -DLV_USE_DRAW_SW_ASM=LV_DRAW_SW_ASM_NONE
     -DLV_USE_DRAW_SW_ASM_HELIUM=0
@@ -75,3 +84,20 @@ lib_deps =
     bblanchon/ArduinoJson@^7.4.3
     bitbank2/PNGdec@^1.1.6
     bitbank2/JPEGDEC@^1.8.4
+
+; =============================================================================
+;  4"  —  GUITION JC4880P433C  (ST7701, 800x480)            [ WORKING ]
+; =============================================================================
+[env:esp32_4inch]
+build_flags = ${env.build_flags} -DSCREEN_SIZE=4
+lib_ignore  = jd9165_lcd        ; 7" panel driver — not used on the 4"
+
+; =============================================================================
+;  7"  —  GUITION JC1060P470C  (JD9165, 1024x600)           [ PLACEHOLDER / WIP ]
+;  The panel driver (lib/jd9165_lcd) is NOT yet ported and the UI is not yet
+;  responsive, so this env does NOT build cleanly yet — it exists to define the
+;  structure. See lib/jd9165_lcd/README.md and docs/MULTI_SCREEN_SUPPORT.md.
+; =============================================================================
+[env:esp32_7inch]
+build_flags = ${env.build_flags} -DSCREEN_SIZE=7
+lib_ignore  = st7701_lcd        ; 4" panel driver — not used on the 7"

--- a/remove_lvgl_asm.py
+++ b/remove_lvgl_asm.py
@@ -19,7 +19,7 @@ def remove_lvgl_asm_dirs():
 
     # Possible LVGL paths
     lvgl_paths = [
-        os.path.join(project_dir, ".pio", "libdeps", "esp32-p4", "lvgl"),
+        os.path.join(project_dir, ".pio", "libdeps", "esp32_4inch", "lvgl"),
         os.path.join(project_dir, "lib", "lvgl"),
         os.path.join(project_dir, ".pio", "libdeps", "*", "lvgl"),
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Build / CI Python dependencies.
+# Declaring them here lets GitHub Actions' setup-python `cache: pip` key off this
+# file, so PlatformIO's pip downloads are cached between runs.
+platformio
+esptool

--- a/scripts/use_ccache.py
+++ b/scripts/use_ccache.py
@@ -1,0 +1,25 @@
+#
+# use_ccache.py — speed up compilation by routing the C/C++ compiler through ccache.
+#
+# OPT-IN and GRACEFUL: only activates when the environment variable USE_CCACHE=1
+# is set (CI does this) AND ccache is actually on PATH. Local/normal builds are
+# completely unaffected (the script is a no-op), so firmware output is unchanged.
+#
+# CI installs + caches ccache via hendrikmuhs/ccache-action and exports USE_CCACHE=1,
+# turning a full ~2-min recompile into a fast cache-hit build.
+#
+import os
+import shutil
+
+Import("env")  # noqa: F821  (provided by PlatformIO/SCons)
+
+if os.environ.get("USE_CCACHE") == "1":
+    ccache = shutil.which("ccache")
+    if ccache:
+        env.Replace(
+            CC="%s %s" % (ccache, env["CC"]),
+            CXX="%s %s" % (ccache, env["CXX"]),
+        )
+        print("[use_ccache] ccache enabled for env '%s'" % env.get("PIOENV", "?"))
+    else:
+        print("[use_ccache] USE_CCACHE=1 but ccache not found on PATH — skipping")

--- a/src/display_driver.cpp
+++ b/src/display_driver.cpp
@@ -1,6 +1,12 @@
 #include "display_driver.h"
 #include "config.h"
+#if SCREEN_SIZE == 7
+#include "../lib/jd9165_lcd/jd9165_lcd.h"
+typedef jd9165_lcd panel_lcd_t;
+#else
 #include "../lib/st7701_lcd/st7701_lcd.h"
+typedef st7701_lcd panel_lcd_t;
+#endif
 #include <esp_heap_caps.h>
 #include <esp_lcd_panel_ops.h>
 #include <esp_private/esp_cache_private.h>
@@ -8,12 +14,18 @@
 
 #define USE_PPA_ACCELERATION 0  // Disable hardware acceleration (causes glitches)
 
-static st7701_lcd* lcd = NULL;
+static panel_lcd_t* lcd = NULL;
 static lv_color_t *buf1 = NULL;
 static lv_color_t *buf2 = NULL;
-static lv_color_t *rotate_buf = NULL;  // Rotation buffer
 static lv_display_t *disp = NULL;
 static bsp_lcd_handles_t lcd_handles;
+
+#if SCREEN_SIZE != 7
+// ============================================================================
+// 4" ST7701 — portrait panel (480x800) driven from a landscape (800x480)
+// LVGL framebuffer via a software 90° rotation in the flush callback.
+// ============================================================================
+static lv_color_t *rotate_buf = NULL;  // Rotation buffer
 
 #if USE_PPA_ACCELERATION
 static ppa_client_handle_t ppa_handle = NULL;
@@ -101,7 +113,7 @@ bool display_init(void) {
 #endif
 
     // Create ST7701 LCD instance
-    lcd = new st7701_lcd(LCD_RST);
+    lcd = new panel_lcd_t(LCD_RST);
     if (!lcd) {
         Serial.println("[Display] ERROR: Failed to create LCD instance!");
         return false;
@@ -148,14 +160,6 @@ bool display_init(void) {
 
     Serial.println("[Display] Ready! 800x480 landscape with manual 90° rotation to portrait panel");
     return true;
-}
-
-void display_set_brightness(uint8_t brightness_percent) {
-    if (lcd) {
-        // Clamp brightness to 0-100%
-        if (brightness_percent > 100) brightness_percent = 100;
-        lcd->example_bsp_set_lcd_backlight(brightness_percent);
-    }
 }
 
 void display_flush(lv_display_t *disp_drv, const lv_area_t *area, uint8_t *px_map) {
@@ -209,4 +213,90 @@ void display_deinit() {
         ppa_handle = NULL;
     }
 #endif
+}
+
+#else  // SCREEN_SIZE == 7
+// ============================================================================
+// 7" JD9165 — native 1024x600 LANDSCAPE panel. No rotation: LVGL renders at
+// the panel's native orientation and the framebuffer is pushed straight to the
+// panel. NOTE: code-complete port (CoopsInChina fork), not yet hardware-tested.
+// ============================================================================
+bool display_init(void) {
+    Serial.printf("[Display] Initializing MIPI DSI interface for %s...\n", DISPLAY_MODEL);
+
+    lcd = new panel_lcd_t(LCD_RST);
+    if (!lcd) {
+        Serial.println("[Display] ERROR: Failed to create LCD instance!");
+        return false;
+    }
+
+    lcd->begin();
+    lcd->get_handle(&lcd_handles);
+
+    Serial.printf("[Display] %s LCD initialized successfully\n", DISPLAY_MODEL);
+
+    // LVGL buffers in PSRAM — native landscape, no rotation buffer needed.
+    size_t lvgl_size = DISPLAY_WIDTH * DISPLAY_HEIGHT * sizeof(lv_color_t);
+    buf1 = (lv_color_t *)heap_caps_malloc(lvgl_size, MALLOC_CAP_SPIRAM);
+    buf2 = (lv_color_t *)heap_caps_malloc(lvgl_size, MALLOC_CAP_SPIRAM);
+
+    if (!buf1 || !buf2) {
+        Serial.println("[Display] ERROR: Failed to allocate buffers!");
+        if (buf1) heap_caps_free(buf1);
+        if (buf2) heap_caps_free(buf2);
+        return false;
+    }
+
+    Serial.printf("[Display] LVGL buffers: %zu bytes each (landscape %dx%d)\n",
+                  lvgl_size, DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    Serial.printf("[Display] Free PSRAM: %zu bytes\n", heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+
+    disp = lv_display_create(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    if (!disp) {
+        Serial.println("[Display] ERROR: Failed to create display");
+        return false;
+    }
+
+    lv_display_set_flush_cb(disp, display_flush);
+    lv_display_set_buffers(disp, buf1, buf2, lvgl_size, LV_DISPLAY_RENDER_MODE_FULL);
+
+    Serial.println("[Display] Ready! 1024x600 landscape, no rotation (direct flush)");
+    return true;
+}
+
+void display_flush(lv_display_t *disp_drv, const lv_area_t *area, uint8_t *px_map) {
+    if (!lcd || !lcd_handles.panel) {
+        lv_display_flush_ready(disp_drv);
+        return;
+    }
+
+    // Native landscape: push the rendered region straight to the panel.
+    lcd->lcd_draw_bitmap(area->x1, area->y1, area->x2 + 1, area->y2 + 1, (uint16_t *)px_map);
+
+    lv_display_flush_ready(disp_drv);
+}
+
+void display_deinit() {
+    if (lcd) {
+        delete lcd;
+        lcd = NULL;
+    }
+    if (buf1) {
+        heap_caps_free(buf1);
+        buf1 = NULL;
+    }
+    if (buf2) {
+        heap_caps_free(buf2);
+        buf2 = NULL;
+    }
+}
+
+#endif  // SCREEN_SIZE
+
+void display_set_brightness(uint8_t brightness_percent) {
+    if (lcd) {
+        // Clamp brightness to 0-100%
+        if (brightness_percent > 100) brightness_percent = 100;
+        lcd->example_bsp_set_lcd_backlight(brightness_percent);
+    }
 }

--- a/src/lyrics.cpp
+++ b/src/lyrics.cpp
@@ -509,9 +509,9 @@ void clearLyrics() {
 void createLyricsOverlay(lv_obj_t* parent) {
     // Gradient overlay at bottom of album art — transparent top, semi-opaque black bottom
     lyrics_container = lv_obj_create(parent);
-    lv_obj_set_size(lyrics_container, 420, 180);
+    lv_obj_set_size(lyrics_container, SMIN(420), SY(180));  // width tracks the album art (SMIN(ART_SIZE))
     // Centered in 450px panel (x=15), bottom aligned with art bottom (y=270..450)
-    lv_obj_align(lyrics_container, LV_ALIGN_BOTTOM_MID, 0, -30);
+    lv_obj_align(lyrics_container, LV_ALIGN_BOTTOM_MID, 0, SY(-30));
     // Vertical gradient: transparent at top, dark semi-opaque at bottom
     lv_obj_set_style_bg_opa(lyrics_container, LV_OPA_COVER, 0);
     lv_obj_set_style_bg_color(lyrics_container, lv_color_hex(0x000000), 0);
@@ -538,7 +538,7 @@ void createLyricsOverlay(lv_obj_t* parent) {
     // Previous line — dimmed
     lbl_lyric_prev = lv_label_create(lyrics_container);
     lv_label_set_text(lbl_lyric_prev, "");
-    lv_obj_set_width(lbl_lyric_prev, 396);
+    lv_obj_set_width(lbl_lyric_prev, SMIN(396));
     lv_obj_set_style_text_font(lbl_lyric_prev, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(lbl_lyric_prev, lv_color_hex(0xAAAAAA), 0);
     lv_obj_set_style_text_align(lbl_lyric_prev, LV_TEXT_ALIGN_CENTER, 0);
@@ -547,7 +547,7 @@ void createLyricsOverlay(lv_obj_t* parent) {
     // Current line — bright, larger
     lbl_lyric_current = lv_label_create(lyrics_container);
     lv_label_set_text(lbl_lyric_current, "");
-    lv_obj_set_width(lbl_lyric_current, 396);
+    lv_obj_set_width(lbl_lyric_current, SMIN(396));
     lv_obj_set_style_text_font(lbl_lyric_current, &lv_font_montserrat_20, 0);
     lv_obj_set_style_text_color(lbl_lyric_current, lv_color_hex(0xFFFFFF), 0);
     lv_obj_set_style_text_align(lbl_lyric_current, LV_TEXT_ALIGN_CENTER, 0);
@@ -556,7 +556,7 @@ void createLyricsOverlay(lv_obj_t* parent) {
     // Next line — dimmed
     lbl_lyric_next = lv_label_create(lyrics_container);
     lv_label_set_text(lbl_lyric_next, "");
-    lv_obj_set_width(lbl_lyric_next, 396);
+    lv_obj_set_width(lbl_lyric_next, SMIN(396));
     lv_obj_set_style_text_font(lbl_lyric_next, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(lbl_lyric_next, lv_color_hex(0xAAAAAA), 0);
     lv_obj_set_style_text_align(lbl_lyric_next, LV_TEXT_ALIGN_CENTER, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,14 +206,14 @@ void setup() {
     // Sonos logo (scale down significantly)
     lv_obj_t* img_logo = lv_image_create(boot_scr);
     lv_image_set_src(img_logo, &Sonos_idnu60bqes_1);
-    lv_obj_align(img_logo, LV_ALIGN_CENTER, 0, -30);
+    lv_obj_align(img_logo, LV_ALIGN_CENTER, 0, SY(-30));
     // Scale down significantly (256 = 100%, so 80 = ~31% size, 100 = ~39% size)
     lv_image_set_scale(img_logo, 130);  // Smaller - about 25% of original size
 
     // Create animated progress bar below logo
     lv_obj_t* boot_bar = lv_bar_create(boot_scr);
-    lv_obj_set_size(boot_bar, 300, 8);
-    lv_obj_align(boot_bar, LV_ALIGN_CENTER, 0, 80);
+    lv_obj_set_size(boot_bar, SX(300), SY(8));
+    lv_obj_align(boot_bar, LV_ALIGN_CENTER, 0, SY(80));
     lv_obj_set_style_bg_color(boot_bar, lv_color_hex(0x333333), LV_PART_MAIN);
     lv_obj_set_style_bg_color(boot_bar, lv_color_hex(0xD4A84B), LV_PART_INDICATOR);
     lv_obj_set_style_border_width(boot_bar, 0, LV_PART_MAIN);
@@ -227,7 +227,7 @@ void setup() {
     lv_label_set_text(lbl_boot_version, "v" FIRMWARE_VERSION);
     lv_obj_set_style_text_color(lbl_boot_version, lv_color_hex(0x888888), 0);
     lv_obj_set_style_text_font(lbl_boot_version, &lv_font_montserrat_12, 0);
-    lv_obj_align(lbl_boot_version, LV_ALIGN_BOTTOM_RIGHT, -10, -10);
+    lv_obj_align(lbl_boot_version, LV_ALIGN_BOTTOM_RIGHT, SX(-10), SY(-10));
 
     // Helper to update boot progress
     auto updateBootProgress = [&](int percent) {
@@ -295,7 +295,7 @@ void setup() {
         lv_obj_t* lbl_ota_wifi = lv_label_create(boot_scr);
         lv_obj_set_style_text_color(lbl_ota_wifi, lv_color_hex(0xD4A84B), 0);
         lv_obj_set_style_text_font(lbl_ota_wifi, &lv_font_montserrat_16, 0);
-        lv_obj_align(lbl_ota_wifi, LV_ALIGN_CENTER, 0, 50);
+        lv_obj_align(lbl_ota_wifi, LV_ALIGN_CENTER, 0, SY(50));
         lv_label_set_text_fmt(lbl_ota_wifi, "Waiting for WiFi: %s ...", ssid.c_str());
         lv_refr_now(NULL);
         int ota_wifi_tries = 0;

--- a/src/screens/ui_clock_screen.cpp
+++ b/src/screens/ui_clock_screen.cpp
@@ -755,14 +755,14 @@ void createClockScreen() {
     lv_label_set_text(clock_time_lbl, "--:--");
     lv_obj_set_style_text_font(clock_time_lbl, &lv_font_montserrat_140, 0);
     lv_obj_set_style_text_color(clock_time_lbl, lv_color_hex(0xFFFFFF), 0);
-    lv_obj_align(clock_time_lbl, LV_ALIGN_CENTER, 0, -30);
+    lv_obj_align(clock_time_lbl, LV_ALIGN_CENTER, 0, SY(-30));
 
     // Date label — "Thu, May 16" small and dim below the time
     clock_date_lbl = lv_label_create(scr_clock);
     lv_label_set_text(clock_date_lbl, "");
     lv_obj_set_style_text_font(clock_date_lbl, &lv_font_montserrat_24, 0);
     lv_obj_set_style_text_color(clock_date_lbl, lv_color_hex(0xAAAAAA), 0);
-    lv_obj_align(clock_date_lbl, LV_ALIGN_CENTER, 0, 90);
+    lv_obj_align(clock_date_lbl, LV_ALIGN_CENTER, 0, SY(90));
 
     // ── Weather overlay — hidden until first fetch ───────────────────────────
     
@@ -771,8 +771,8 @@ void createClockScreen() {
 
     // ── Top-left area (transparent — no card, no shadow) ──────────────────────
     clock_wx_tl_panel = lv_obj_create(scr_clock);
-    lv_obj_set_pos(clock_wx_tl_panel, 10, 10);
-    lv_obj_set_size(clock_wx_tl_panel, 390, 160);
+    lv_obj_set_pos(clock_wx_tl_panel, SX(10), SY(10));
+    lv_obj_set_size(clock_wx_tl_panel, SX(390), SY(160));
     lv_obj_set_style_bg_opa(clock_wx_tl_panel, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(clock_wx_tl_panel, 0, 0);
     lv_obj_set_style_pad_all(clock_wx_tl_panel, 0, 0);
@@ -784,38 +784,38 @@ void createClockScreen() {
     lv_label_set_text(clock_wx_city_lbl, "---");
     lv_obj_set_style_text_font(clock_wx_city_lbl, &lv_font_montserrat_20, 0);
     lv_obj_set_style_text_color(clock_wx_city_lbl, lv_color_hex(0xAAAAAA), 0);
-    lv_obj_set_pos(clock_wx_city_lbl, 10, 5);
+    lv_obj_set_pos(clock_wx_city_lbl, SX(10), SY(5));
 
     clock_wx_temp_lbl = lv_label_create(clock_wx_tl_panel);
     lv_label_set_text(clock_wx_temp_lbl, "--°C");
     lv_obj_set_style_text_font(clock_wx_temp_lbl, &lv_font_montserrat_48, 0);
     lv_obj_set_style_text_color(clock_wx_temp_lbl, lv_color_hex(0xAAAAAA), 0);
-    lv_obj_set_pos(clock_wx_temp_lbl, 10, 32);
+    lv_obj_set_pos(clock_wx_temp_lbl, SX(10), SY(32));
 
     clock_wx_cond_lbl = lv_label_create(clock_wx_tl_panel);
     lv_label_set_text(clock_wx_cond_lbl, "");
     lv_obj_set_style_text_font(clock_wx_cond_lbl, &lv_font_montserrat_18, 0);
     lv_obj_set_style_text_color(clock_wx_cond_lbl, lv_color_hex(0xAAAAAA), 0);
-    lv_obj_set_pos(clock_wx_cond_lbl, 10, 95);
+    lv_obj_set_pos(clock_wx_cond_lbl, SX(10), SY(95));
 
     clock_wx_detail_lbl = lv_label_create(clock_wx_tl_panel);
     lv_label_set_text(clock_wx_detail_lbl, "");
     lv_obj_set_style_text_font(clock_wx_detail_lbl, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(clock_wx_detail_lbl, lv_color_hex(0x888888), 0);
-    lv_obj_set_pos(clock_wx_detail_lbl, 10, 118);
+    lv_obj_set_pos(clock_wx_detail_lbl, SX(10), SY(118));
 
     // Today icon — 80px, close to the right of the temp number
     clock_wx_icon = lv_label_create(clock_wx_tl_panel);
     lv_label_set_text(clock_wx_icon, WI_DAY_SUNNY);
     lv_obj_set_style_text_font(clock_wx_icon, &lv_font_weathericons_80, 0);
     lv_obj_set_style_text_color(clock_wx_icon, lv_color_hex(0xAAAAAA), 0);
-    lv_obj_set_pos(clock_wx_icon, 155, 10);
+    lv_obj_set_pos(clock_wx_icon, SX(155), SY(10));
     lv_obj_clear_flag(clock_wx_icon, LV_OBJ_FLAG_CLICKABLE);
 
     // ── Bottom strip: 6-hour hourly forecast (no background, no separator) ─────
     clock_wx_bottom = lv_obj_create(scr_clock);
-    lv_obj_set_pos(clock_wx_bottom, 0, 375);
-    lv_obj_set_size(clock_wx_bottom, 800, 105);
+    lv_obj_set_pos(clock_wx_bottom, 0, SY(375));
+    lv_obj_set_size(clock_wx_bottom, SX(800), SY(105));
     lv_obj_set_style_bg_opa(clock_wx_bottom, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(clock_wx_bottom, 0, 0);
     lv_obj_set_style_pad_all(clock_wx_bottom, 0, 0);
@@ -830,8 +830,8 @@ void createClockScreen() {
 
         // Day name (Mon / Tue …)
         clock_wx_fc_day[i] = lv_label_create(clock_wx_bottom);
-        lv_obj_set_width(clock_wx_fc_day[i], col_w);
-        lv_obj_set_pos(clock_wx_fc_day[i], col_x, 7);
+        lv_obj_set_width(clock_wx_fc_day[i], SX(col_w));
+        lv_obj_set_pos(clock_wx_fc_day[i], SX(col_x), SY(7));
         lv_obj_set_style_text_align(clock_wx_fc_day[i], LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_set_style_text_font(clock_wx_fc_day[i], &lv_font_montserrat_14, 0);
         lv_obj_set_style_text_color(clock_wx_fc_day[i], lv_color_hex(0x999999), 0);
@@ -839,8 +839,8 @@ void createClockScreen() {
 
         // Condition icon (32px Weather Icons glyph)
         clock_wx_fc_icon[i] = lv_label_create(clock_wx_bottom);
-        lv_obj_set_width(clock_wx_fc_icon[i], col_w);
-        lv_obj_set_pos(clock_wx_fc_icon[i], col_x, 24);
+        lv_obj_set_width(clock_wx_fc_icon[i], SX(col_w));
+        lv_obj_set_pos(clock_wx_fc_icon[i], SX(col_x), SY(24));
         lv_obj_set_style_text_align(clock_wx_fc_icon[i], LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_set_style_text_font(clock_wx_fc_icon[i], &lv_font_weathericons_32, 0);
         lv_obj_set_style_text_color(clock_wx_fc_icon[i], lv_color_hex(0xAAAAAA), 0);
@@ -848,8 +848,8 @@ void createClockScreen() {
 
         // Temperature
         clock_wx_fc_temp[i] = lv_label_create(clock_wx_bottom);
-        lv_obj_set_width(clock_wx_fc_temp[i], col_w);
-        lv_obj_set_pos(clock_wx_fc_temp[i], col_x, 70);
+        lv_obj_set_width(clock_wx_fc_temp[i], SX(col_w));
+        lv_obj_set_pos(clock_wx_fc_temp[i], SX(col_x), SY(70));
         lv_obj_set_style_text_align(clock_wx_fc_temp[i], LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_set_style_text_font(clock_wx_fc_temp[i], &lv_font_montserrat_16, 0);
         lv_obj_set_style_text_color(clock_wx_fc_temp[i], lv_color_hex(0xAAAAAA), 0);
@@ -861,8 +861,8 @@ void createClockScreen() {
     // Panel x=490, width=300 → right edge at 790 (10px from screen edge).
     // All labels span full panel width and are right-aligned.
     clock_wx_tr_panel = lv_obj_create(scr_clock);
-    lv_obj_set_pos(clock_wx_tr_panel, 490, 10);
-    lv_obj_set_size(clock_wx_tr_panel, 300, 110);
+    lv_obj_set_pos(clock_wx_tr_panel, SX(490), SY(10));
+    lv_obj_set_size(clock_wx_tr_panel, SX(300), SY(110));
     lv_obj_set_style_bg_opa(clock_wx_tr_panel, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(clock_wx_tr_panel, 0, 0);
     lv_obj_set_style_pad_all(clock_wx_tr_panel, 0, 0);
@@ -873,7 +873,7 @@ void createClockScreen() {
     // Row 0 — Feels like
     clock_wx_fl_lbl = lv_label_create(clock_wx_tr_panel);
     lv_label_set_text(clock_wx_fl_lbl, "Feels like  --");
-    lv_obj_set_width(clock_wx_fl_lbl, 300);
+    lv_obj_set_width(clock_wx_fl_lbl, SX(300));
     lv_obj_set_style_text_align(clock_wx_fl_lbl, LV_TEXT_ALIGN_RIGHT, 0);
     lv_obj_set_style_text_font(clock_wx_fl_lbl, &lv_font_montserrat_18, 0);
     lv_obj_set_style_text_color(clock_wx_fl_lbl, lv_color_hex(0x999999), 0);
@@ -882,29 +882,29 @@ void createClockScreen() {
     // Row 1 — UV index
     clock_wx_uv_lbl = lv_label_create(clock_wx_tr_panel);
     lv_label_set_text(clock_wx_uv_lbl, "UV  --");
-    lv_obj_set_width(clock_wx_uv_lbl, 300);
+    lv_obj_set_width(clock_wx_uv_lbl, SX(300));
     lv_obj_set_style_text_align(clock_wx_uv_lbl, LV_TEXT_ALIGN_RIGHT, 0);
     lv_obj_set_style_text_font(clock_wx_uv_lbl, &lv_font_montserrat_18, 0);
     lv_obj_set_style_text_color(clock_wx_uv_lbl, lv_color_hex(0x999999), 0);
-    lv_obj_set_pos(clock_wx_uv_lbl, 0, 26);
+    lv_obj_set_pos(clock_wx_uv_lbl, 0, SY(26));
 
     // Row 2 — Sunrise
     clock_wx_rise_t_lbl = lv_label_create(clock_wx_tr_panel);
     lv_label_set_text(clock_wx_rise_t_lbl, "Rise  --:--");
-    lv_obj_set_width(clock_wx_rise_t_lbl, 300);
+    lv_obj_set_width(clock_wx_rise_t_lbl, SX(300));
     lv_obj_set_style_text_align(clock_wx_rise_t_lbl, LV_TEXT_ALIGN_RIGHT, 0);
     lv_obj_set_style_text_font(clock_wx_rise_t_lbl, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(clock_wx_rise_t_lbl, lv_color_hex(0x777777), 0);
-    lv_obj_set_pos(clock_wx_rise_t_lbl, 0, 56);
+    lv_obj_set_pos(clock_wx_rise_t_lbl, 0, SY(56));
 
     // Row 3 — Sunset
     clock_wx_set_t_lbl = lv_label_create(clock_wx_tr_panel);
     lv_label_set_text(clock_wx_set_t_lbl, "Set   --:--");
-    lv_obj_set_width(clock_wx_set_t_lbl, 300);
+    lv_obj_set_width(clock_wx_set_t_lbl, SX(300));
     lv_obj_set_style_text_align(clock_wx_set_t_lbl, LV_TEXT_ALIGN_RIGHT, 0);
     lv_obj_set_style_text_font(clock_wx_set_t_lbl, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(clock_wx_set_t_lbl, lv_color_hex(0x777777), 0);
-    lv_obj_set_pos(clock_wx_set_t_lbl, 0, 78);
+    lv_obj_set_pos(clock_wx_set_t_lbl, 0, SY(78));
 
     // (Tap-to-dismiss: whole screen is clickable, so no separate hint needed)
 

--- a/src/screens/ui_clock_settings.cpp
+++ b/src/screens/ui_clock_settings.cpp
@@ -57,7 +57,7 @@ static lv_obj_t* makeDropdown(lv_obj_t* parent, const char* options,
     if (open_up) lv_dropdown_set_dir(dd, LV_DIR_TOP);
     lv_obj_t* list = lv_dropdown_get_list(dd);
     if (list) {
-        lv_obj_set_height(list, 260);
+        lv_obj_set_height(list, SY(260));
         lv_obj_set_style_bg_color(list, lv_color_hex(0x222222), 0);
         lv_obj_set_style_text_color(list, COL_TEXT, 0);
         lv_obj_set_style_text_font(list, &lv_font_montserrat_14, 0);
@@ -69,7 +69,7 @@ static lv_obj_t* makeDropdown(lv_obj_t* parent, const char* options,
 static lv_obj_t* makeSlider(lv_obj_t* parent, int min, int max, int value) {
     lv_obj_t* s = lv_slider_create(parent);
     lv_obj_set_width(s, lv_pct(100));
-    lv_obj_set_height(s, 20);
+    lv_obj_set_height(s, SY(20));
     lv_slider_set_range(s, min, max);
     lv_slider_set_value(s, value, LV_ANIM_OFF);
     lv_obj_set_style_bg_color(s, lv_color_hex(0x333333), LV_PART_MAIN);
@@ -201,19 +201,19 @@ static void custom_ta_event_cb(lv_event_t* e) {
         // dark style; they only differ in size + mode (numeric pad vs alpha layout).
         if (is_name) {
             lv_keyboard_set_mode(custom_kb, LV_KEYBOARD_MODE_TEXT_LOWER);
-            lv_obj_set_size(custom_kb, 760, 230);
+            lv_obj_set_size(custom_kb, SX(760), SY(230));
         } else {
             lv_keyboard_set_mode(custom_kb, LV_KEYBOARD_MODE_USER_1);
-            lv_obj_set_size(custom_kb, 340, 200);
+            lv_obj_set_size(custom_kb, SX(340), SY(200));
         }
-        lv_obj_align(custom_kb, LV_ALIGN_BOTTOM_MID, 0, -10);
+        lv_obj_align(custom_kb, LV_ALIGN_BOTTOM_MID, 0, SY(-10));
 
         // Grow the bottom spacer so the scrollable has enough range to actually
         // move the focused field above the keyboard. Without this, lv_obj_scroll_to_y
         // is clamped to max_scroll (which is too small when the focused field is
         // already near the bottom of content) and the field stays behind the kb.
         if (bottom_spacer) {
-            lv_obj_set_height(bottom_spacer, 260);
+            lv_obj_set_height(bottom_spacer, SY(260));
             if (settings_scrollable) lv_obj_update_layout(settings_scrollable);
         }
 
@@ -595,8 +595,8 @@ void createClockSettingsScreen() {
     custom_kb = lv_keyboard_create(scr_clock_settings);
     lv_keyboard_set_map(custom_kb, LV_KEYBOARD_MODE_USER_1, num_kb_map, num_kb_ctrl);
     lv_keyboard_set_mode(custom_kb, LV_KEYBOARD_MODE_USER_1);
-    lv_obj_set_size(custom_kb, 340, 200);
-    lv_obj_align(custom_kb, LV_ALIGN_BOTTOM_MID, 0, -10);
+    lv_obj_set_size(custom_kb, SX(340), SY(200));
+    lv_obj_align(custom_kb, LV_ALIGN_BOTTOM_MID, 0, SY(-10));
     lv_obj_add_flag(custom_kb, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_event_cb(custom_kb, kb_close_event_cb, LV_EVENT_CANCEL, NULL);
     lv_obj_add_event_cb(custom_kb, kb_close_event_cb, LV_EVENT_READY,  NULL);

--- a/src/screens/ui_devices_screen.cpp
+++ b/src/screens/ui_devices_screen.cpp
@@ -40,7 +40,7 @@ void refreshDeviceList() {
 
         // Create main button - taller if it has subtitle
         lv_obj_t* btn = lv_btn_create(list_devices);
-        lv_obj_set_size(btn, lv_pct(100), hasGroup || isPlaying ? 70 : 60);
+        lv_obj_set_size(btn, lv_pct(100), hasGroup || isPlaying ? SY(70) : SY(60));
         lv_obj_set_user_data(btn, (void*)(intptr_t)i);
         lv_obj_set_style_radius(btn, 12, 0);
         lv_obj_set_style_shadow_width(btn, 0, 0);
@@ -111,7 +111,7 @@ void refreshDeviceList() {
                 if (!member || member->groupCoordinatorUUID != dev->rinconID) continue;
 
                 lv_obj_t* memBtn = lv_btn_create(list_devices);
-                lv_obj_set_size(memBtn, lv_pct(95), 50);
+                lv_obj_set_size(memBtn, lv_pct(95), SY(50));
                 lv_obj_set_user_data(memBtn, (void*)(intptr_t)j);
                 lv_obj_set_style_radius(memBtn, 8, 0);
                 lv_obj_set_style_shadow_width(memBtn, 0, 0);
@@ -171,7 +171,7 @@ void refreshDeviceList() {
             bool isSelected = (current && dev->ip == current->ip);
 
             lv_obj_t* btn = lv_btn_create(list_devices);
-            lv_obj_set_size(btn, 720, 60);
+            lv_obj_set_size(btn, SX(720), SY(60));
             lv_obj_set_user_data(btn, (void*)(intptr_t)i);
             lv_obj_set_style_radius(btn, 12, 0);
             lv_obj_set_style_shadow_width(btn, 0, 0);
@@ -210,7 +210,7 @@ void createDevicesScreen() {
 
     // Title + Scan button row
     lv_obj_t* title_row = lv_obj_create(content);
-    lv_obj_set_size(title_row, lv_pct(100), 40);
+    lv_obj_set_size(title_row, lv_pct(100), SY(40));
     lv_obj_set_pos(title_row, 0, 0);
     lv_obj_set_style_bg_opa(title_row, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(title_row, 0, 0);
@@ -224,7 +224,7 @@ void createDevicesScreen() {
     lv_obj_align(lbl_title, LV_ALIGN_LEFT_MID, 0, 0);
 
     btn_sonos_scan = lv_button_create(title_row);
-    lv_obj_set_size(btn_sonos_scan, 110, 40);
+    lv_obj_set_size(btn_sonos_scan, SX(110), SY(40));
     lv_obj_align(btn_sonos_scan, LV_ALIGN_RIGHT_MID, 0, 0);
     lv_obj_set_style_bg_color(btn_sonos_scan, COL_ACCENT, 0);
     lv_obj_set_style_radius(btn_sonos_scan, 20, 0);
@@ -238,15 +238,15 @@ void createDevicesScreen() {
 
     // Status label
     lbl_status = lv_label_create(content);
-    lv_obj_set_pos(lbl_status, 0, 50);
+    lv_obj_set_pos(lbl_status, 0, SY(50));
     lv_label_set_text(lbl_status, "Tap Scan to find speakers");
     lv_obj_set_style_text_color(lbl_status, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_status, &lv_font_mdi_16, 0);
 
     // Devices list
     list_devices = lv_list_create(content);
-    lv_obj_set_size(list_devices, lv_pct(100), 380);
-    lv_obj_set_pos(list_devices, 0, 75);
+    lv_obj_set_size(list_devices, lv_pct(100), SY(380));
+    lv_obj_set_pos(list_devices, 0, SY(75));
     lv_obj_set_style_bg_color(list_devices, lv_color_hex(0x1A1A1A), 0);
     lv_obj_set_style_border_width(list_devices, 0, 0);
     lv_obj_set_style_radius(list_devices, 0, 0);
@@ -262,7 +262,7 @@ void createDevicesScreen() {
 
     // Spinner for scan feedback (centered in content area, hidden by default)
     spinner_scan = lv_spinner_create(content);
-    lv_obj_set_size(spinner_scan, 100, 100);
+    lv_obj_set_size(spinner_scan, SMIN(100), SMIN(100));
     lv_obj_center(spinner_scan);
     lv_obj_set_style_arc_color(spinner_scan, COL_ACCENT, LV_PART_INDICATOR);
     lv_obj_set_style_arc_color(spinner_scan, lv_color_hex(0x555555), LV_PART_MAIN);

--- a/src/screens/ui_display_screen.cpp
+++ b/src/screens/ui_display_screen.cpp
@@ -43,7 +43,7 @@ void createDisplaySettingsScreen() {
 
     lv_obj_t* slider_brightness = lv_slider_create(content);
     lv_obj_set_width(slider_brightness, lv_pct(100));
-    lv_obj_set_height(slider_brightness, 20);
+    lv_obj_set_height(slider_brightness, SY(20));
     lv_slider_set_range(slider_brightness, 10, 100);
     lv_slider_set_value(slider_brightness, brightness_level, LV_ANIM_OFF);
     lv_obj_set_style_bg_color(slider_brightness, lv_color_hex(0x333333), LV_PART_MAIN);
@@ -75,7 +75,7 @@ void createDisplaySettingsScreen() {
 
     lv_obj_t* slider_dim_timeout = lv_slider_create(content);
     lv_obj_set_width(slider_dim_timeout, lv_pct(100));
-    lv_obj_set_height(slider_dim_timeout, 20);
+    lv_obj_set_height(slider_dim_timeout, SY(20));
     lv_slider_set_range(slider_dim_timeout, 0, 300);
     lv_slider_set_value(slider_dim_timeout, autodim_timeout, LV_ANIM_OFF);
     lv_obj_set_style_bg_color(slider_dim_timeout, lv_color_hex(0x333333), LV_PART_MAIN);
@@ -107,7 +107,7 @@ void createDisplaySettingsScreen() {
 
     lv_obj_t* slider_dimmed_brightness = lv_slider_create(content);
     lv_obj_set_width(slider_dimmed_brightness, lv_pct(100));
-    lv_obj_set_height(slider_dimmed_brightness, 20);
+    lv_obj_set_height(slider_dimmed_brightness, SY(20));
     lv_slider_set_range(slider_dimmed_brightness, 5, 50);
     lv_slider_set_value(slider_dimmed_brightness, brightness_dimmed, LV_ANIM_OFF);
     lv_obj_set_style_bg_color(slider_dimmed_brightness, lv_color_hex(0x333333), LV_PART_MAIN);

--- a/src/screens/ui_groups_screen.cpp
+++ b/src/screens/ui_groups_screen.cpp
@@ -52,7 +52,7 @@ void refreshGroupsList() {
 
         // Create group header button - taller to show now playing info
         lv_obj_t* btn = lv_btn_create(list_groups);
-        lv_obj_set_size(btn, lv_pct(100), (isPlaying && hasTrack) ? 85 : 70);
+        lv_obj_set_size(btn, lv_pct(100), (isPlaying && hasTrack) ? SY(85) : SY(70));
         lv_obj_set_user_data(btn, (void*)(intptr_t)i);
         lv_obj_set_style_radius(btn, 12, 0);
         lv_obj_set_style_shadow_width(btn, 0, 0);
@@ -133,7 +133,7 @@ void refreshGroupsList() {
 
                 // Member item (indented)
                 lv_obj_t* memBtn = lv_btn_create(list_groups);
-                lv_obj_set_size(memBtn, 680, 50);
+                lv_obj_set_size(memBtn, SX(680), SY(50));
                 lv_obj_set_user_data(memBtn, (void*)(intptr_t)j);
                 lv_obj_set_style_radius(memBtn, 8, 0);
                 lv_obj_set_style_shadow_width(memBtn, 0, 0);
@@ -156,7 +156,7 @@ void refreshGroupsList() {
 
                 // Remove from group button
                 lv_obj_t* removeBtn = lv_btn_create(memBtn);
-                lv_obj_set_size(removeBtn, 90, 35);
+                lv_obj_set_size(removeBtn, SX(90), SY(35));
                 lv_obj_align(removeBtn, LV_ALIGN_RIGHT_MID, -5, 0);
                 lv_obj_set_style_bg_color(removeBtn, lv_color_hex(0x8B0000), 0);
                 lv_obj_set_style_radius(removeBtn, 8, 0);
@@ -188,7 +188,7 @@ void refreshGroupsList() {
         if (coordinator) {
             // Header for available speakers
             lv_obj_t* hdr = lv_obj_create(list_groups);
-            lv_obj_set_size(hdr, 720, 40);
+            lv_obj_set_size(hdr, SX(720), SY(40));
             lv_obj_set_style_bg_color(hdr, lv_color_hex(0x1A1A1A), 0);
             lv_obj_set_style_border_width(hdr, 0, 0);
             lv_obj_set_style_pad_all(hdr, 10, 0);
@@ -213,7 +213,7 @@ void refreshGroupsList() {
                 if (!dev->isGroupCoordinator) continue;
 
                 lv_obj_t* addBtn = lv_btn_create(list_groups);
-                lv_obj_set_size(addBtn, 720, 55);
+                lv_obj_set_size(addBtn, SX(720), SY(55));
                 lv_obj_set_user_data(addBtn, (void*)(intptr_t)i);
                 lv_obj_set_style_radius(addBtn, 10, 0);
                 lv_obj_set_style_shadow_width(addBtn, 0, 0);
@@ -259,7 +259,7 @@ void createGroupsScreen() {
 
     // Title + Refresh button row
     lv_obj_t* title_row = lv_obj_create(content);
-    lv_obj_set_size(title_row, lv_pct(100), 40);
+    lv_obj_set_size(title_row, lv_pct(100), SY(40));
     lv_obj_set_pos(title_row, 0, 0);
     lv_obj_set_style_bg_opa(title_row, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(title_row, 0, 0);
@@ -273,7 +273,7 @@ void createGroupsScreen() {
     lv_obj_align(lbl_title, LV_ALIGN_LEFT_MID, 0, 0);
 
     btn_groups_scan = lv_button_create(title_row);
-    lv_obj_set_size(btn_groups_scan, 110, 40);
+    lv_obj_set_size(btn_groups_scan, SX(110), SY(40));
     lv_obj_align(btn_groups_scan, LV_ALIGN_RIGHT_MID, 0, 0);
     lv_obj_set_style_bg_color(btn_groups_scan, COL_ACCENT, 0);
     lv_obj_set_style_radius(btn_groups_scan, 20, 0);
@@ -325,15 +325,15 @@ void createGroupsScreen() {
 
     // Status label
     lbl_groups_status = lv_label_create(content);
-    lv_obj_set_pos(lbl_groups_status, 0, 50);
+    lv_obj_set_pos(lbl_groups_status, 0, SY(50));
     lv_label_set_text(lbl_groups_status, "Tap a group to manage it");
     lv_obj_set_style_text_color(lbl_groups_status, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_groups_status, &lv_font_mdi_16, 0);
 
     // Groups list
     list_groups = lv_obj_create(content);
-    lv_obj_set_size(list_groups, lv_pct(100), 380);
-    lv_obj_set_pos(list_groups, 0, 75);
+    lv_obj_set_size(list_groups, lv_pct(100), SY(380));
+    lv_obj_set_pos(list_groups, 0, SY(75));
     lv_obj_set_style_bg_color(list_groups, lv_color_hex(0x1A1A1A), 0);
     lv_obj_set_style_border_width(list_groups, 0, 0);
     lv_obj_set_style_radius(list_groups, 0, 0);
@@ -350,7 +350,7 @@ void createGroupsScreen() {
 
     // Spinner for scan feedback (centered in content area, hidden by default)
     spinner_groups_scan = lv_spinner_create(content);
-    lv_obj_set_size(spinner_groups_scan, 100, 100);
+    lv_obj_set_size(spinner_groups_scan, SMIN(100), SMIN(100));
     lv_obj_center(spinner_groups_scan);
     lv_obj_set_style_arc_color(spinner_groups_scan, COL_ACCENT, LV_PART_INDICATOR);
     lv_obj_set_style_arc_color(spinner_groups_scan, lv_color_hex(0x555555), LV_PART_MAIN);

--- a/src/screens/ui_line_in_mode.cpp
+++ b/src/screens/ui_line_in_mode.cpp
@@ -70,7 +70,7 @@ void setLineInMode(bool enable) {
         // Artist: single-line, show source device name (filled by updateLineInUI)
         if (lbl_artist) {
             lv_label_set_long_mode(lbl_artist, LV_LABEL_LONG_SCROLL_CIRCULAR);
-            lv_obj_set_height(lbl_artist, 20);
+            lv_obj_set_height(lbl_artist, SY(20));
         }
 
     } else {
@@ -110,7 +110,7 @@ void setLineInMode(bool enable) {
         if (lbl_title)  lv_label_set_long_mode(lbl_title,  LV_LABEL_LONG_SCROLL_CIRCULAR);
         if (lbl_artist) {
             lv_label_set_long_mode(lbl_artist, LV_LABEL_LONG_SCROLL_CIRCULAR);
-            lv_obj_set_height(lbl_artist, 20);
+            lv_obj_set_height(lbl_artist, SY(20));
         }
     }
 }

--- a/src/screens/ui_main_screen.cpp
+++ b/src/screens/ui_main_screen.cpp
@@ -1,6 +1,12 @@
 /**
  * UI Main Screen
  * Main player screen with album art, playback controls, and volume
+ *
+ * Layout note: all coordinates are authored in the original 800x480 "design
+ * space" and wrapped in SX()/SY() (positions, rectangle sizes) or SMIN()
+ * (square buttons + radii, so circles stay round) from ui_scale.h. On the 4"
+ * panel these are exact 1:1 identities, so the layout is byte-identical; on
+ * larger panels (e.g. 7" 1024x600) it scales proportionally — no per-size code.
  */
 
 #include "ui_common.h"
@@ -15,7 +21,7 @@ void createMainScreen() {
 
     // Blurred art background — fullscreen, must be first child (lowest z-order)
     img_blur_bg = lv_img_create(scr_main);
-    lv_obj_set_size(img_blur_bg, 800, 480);
+    lv_obj_set_size(img_blur_bg, SX(800), SY(480));
     lv_obj_set_pos(img_blur_bg, 0, 0);
     lv_obj_clear_flag(img_blur_bg, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_flag(img_blur_bg, LV_OBJ_FLAG_HIDDEN);  // hidden until first art loads
@@ -23,7 +29,7 @@ void createMainScreen() {
     // LEFT: Album Art Area — 450px wide so img has equal 30px margin left/top/bottom
     // (ART_SIZE=420, panel height=480 → top/bottom=(480-420)/2=30px, left=30px inset)
     panel_art = lv_obj_create(scr_main);
-    lv_obj_set_size(panel_art, 450, 480);
+    lv_obj_set_size(panel_art, SX(450), SY(480));
     lv_obj_set_pos(panel_art, 0, 0);
     lv_obj_set_style_bg_color(panel_art, lv_color_hex(0x1a1a1a), 0);
     lv_obj_set_style_bg_opa(panel_art, LV_OPA_TRANSP, 0);  // fully transparent: blur bg is the background
@@ -34,9 +40,9 @@ void createMainScreen() {
 
     // Album art image — 30px from left edge, vertically centered → equal margins all sides
     img_album = lv_img_create(panel_art);
-    lv_obj_set_size(img_album, ART_SIZE, ART_SIZE);
-    lv_obj_align(img_album, LV_ALIGN_LEFT_MID, 30, 0);
-    lv_obj_set_style_radius(img_album, 24, 0);
+    lv_obj_set_size(img_album, SMIN(ART_SIZE), SMIN(ART_SIZE));
+    lv_obj_align(img_album, LV_ALIGN_LEFT_MID, SX(30), 0);
+    lv_obj_set_style_radius(img_album, SMIN(24), 0);
     lv_obj_set_style_clip_corner(img_album, true, 0);
     lv_obj_set_style_shadow_width(img_album, 40, 0);    // 40px equal spread: floating artwork look (Apple Music style)
     lv_obj_set_style_shadow_color(img_album, lv_color_hex(0x000000), 0);
@@ -49,7 +55,7 @@ void createMainScreen() {
     lv_label_set_text(art_placeholder, MDI_MUSIC_NOTE);
     lv_obj_set_style_text_font(art_placeholder, &lv_font_mdi_32, 0);
     lv_obj_set_style_text_color(art_placeholder, COL_TEXT2, 0);
-    lv_obj_align(art_placeholder, LV_ALIGN_CENTER, 15, 0);  // +15px: center of art at x=240, center of panel at x=225
+    lv_obj_align(art_placeholder, LV_ALIGN_CENTER, SX(15), 0);  // +15px: center of art at x=240, center of panel at x=225
 
 
     // Line-in mode: waveform hero icon (hidden until x-rincon-stream: detected)
@@ -58,7 +64,7 @@ void createMainScreen() {
     lv_label_set_text(lbl_linein_icon, MDI_WAVEFORM);
     lv_obj_set_style_text_font(lbl_linein_icon, &lv_font_mdi_80, 0);
     lv_obj_set_style_text_color(lbl_linein_icon, COL_ACCENT, 0);
-    lv_obj_align(lbl_linein_icon, LV_ALIGN_CENTER, 15, -20);  // +15px art-centre offset, -20px to leave room below
+    lv_obj_align(lbl_linein_icon, LV_ALIGN_CENTER, SX(15), SY(-20));  // +15px art-centre offset, -20px to leave room below
     lv_obj_add_flag(lbl_linein_icon, LV_OBJ_FLAG_HIDDEN);
 
     lbl_linein_subtitle = lv_label_create(panel_art);
@@ -66,7 +72,7 @@ void createMainScreen() {
     lv_obj_set_style_text_font(lbl_linein_subtitle, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(lbl_linein_subtitle, lv_color_hex(0x888888), 0);
     lv_obj_set_style_text_letter_space(lbl_linein_subtitle, 3, 0);  // spaced-out caps for modern look
-    lv_obj_align(lbl_linein_subtitle, LV_ALIGN_CENTER, 15, 58); // below icon (+80px icon height / 2 + gap)
+    lv_obj_align(lbl_linein_subtitle, LV_ALIGN_CENTER, SX(15), SY(58)); // below icon (+80px icon height / 2 + gap)
     lv_obj_add_flag(lbl_linein_subtitle, LV_OBJ_FLAG_HIDDEN);
 
     // TV audio mode: television hero icon (hidden until x-sonos-htastream: detected)
@@ -74,7 +80,7 @@ void createMainScreen() {
     lv_label_set_text(lbl_tv_icon, MDI_TELEVISION);
     lv_obj_set_style_text_font(lbl_tv_icon, &lv_font_mdi_80, 0);
     lv_obj_set_style_text_color(lbl_tv_icon, COL_ACCENT, 0);
-    lv_obj_align(lbl_tv_icon, LV_ALIGN_CENTER, 15, -20);
+    lv_obj_align(lbl_tv_icon, LV_ALIGN_CENTER, SX(15), SY(-20));
     lv_obj_add_flag(lbl_tv_icon, LV_OBJ_FLAG_HIDDEN);
 
     lbl_tv_subtitle = lv_label_create(panel_art);
@@ -82,7 +88,7 @@ void createMainScreen() {
     lv_obj_set_style_text_font(lbl_tv_subtitle, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(lbl_tv_subtitle, lv_color_hex(0x888888), 0);
     lv_obj_set_style_text_letter_space(lbl_tv_subtitle, 3, 0);
-    lv_obj_align(lbl_tv_subtitle, LV_ALIGN_CENTER, 15, 58);
+    lv_obj_align(lbl_tv_subtitle, LV_ALIGN_CENTER, SX(15), SY(58));
     lv_obj_add_flag(lbl_tv_subtitle, LV_OBJ_FLAG_HIDDEN);
 
     // Lyrics status indicator — top-left corner of art image
@@ -90,15 +96,15 @@ void createMainScreen() {
     lv_label_set_text(lbl_lyrics_status, "");
     lv_obj_set_style_text_color(lbl_lyrics_status, lv_color_hex(0x888888), 0);
     lv_obj_set_style_text_font(lbl_lyrics_status, &lv_font_montserrat_14, 0);
-    lv_obj_align(lbl_lyrics_status, LV_ALIGN_TOP_LEFT, 30, 5);  // Aligned with art left edge (x=30), in the gap above art
+    lv_obj_align(lbl_lyrics_status, LV_ALIGN_TOP_LEFT, SX(30), SY(5));  // Aligned with art left edge (x=30), in the gap above art
 
     // Synced lyrics overlay (on top of album art)
     createLyricsOverlay(panel_art);
 
     // RIGHT: Control Panel (350px) — narrowed by 30px to accommodate art left margin
     panel_right = lv_obj_create(scr_main);
-    lv_obj_set_size(panel_right, 350, 480);
-    lv_obj_set_pos(panel_right, 450, 0);
+    lv_obj_set_size(panel_right, SX(350), SY(480));
+    lv_obj_set_pos(panel_right, SX(450), 0);
     lv_obj_set_style_bg_color(panel_right, COL_BG, 0);
     lv_obj_set_style_bg_opa(panel_right, LV_OPA_TRANSP, 0);  // fully transparent: blur bg is the background
     lv_obj_set_style_radius(panel_right, 0, 0);
@@ -114,8 +120,8 @@ void createMainScreen() {
 
     // Back button - scale effect
     lv_obj_t* btn_back = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_back, 40, 40);
-    lv_obj_set_pos(btn_back, 10, 15);
+    lv_obj_set_size(btn_back, SMIN(40), SMIN(40));
+    lv_obj_set_pos(btn_back, SX(10), SY(15));
     lv_obj_set_style_bg_opa(btn_back, LV_OPA_TRANSP, 0);
     lv_obj_set_style_shadow_width(btn_back, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_back, 280, LV_STATE_PRESSED);
@@ -134,12 +140,12 @@ void createMainScreen() {
     lv_label_set_text(lbl_device_name, "Now Playing");
     lv_obj_set_style_text_color(lbl_device_name, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_device_name, &lv_font_montserrat_14, 0);
-    lv_obj_set_pos(lbl_device_name, 55, 25);
+    lv_obj_set_pos(lbl_device_name, SX(55), SY(25));
 
     // Music Sources button - scale effect
     lv_obj_t* btn_sources = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_sources, 38, 38);
-    lv_obj_set_pos(btn_sources, 255, 18);
+    lv_obj_set_size(btn_sources, SMIN(38), SMIN(38));
+    lv_obj_set_pos(btn_sources, SX(255), SY(18));
     lv_obj_set_style_bg_opa(btn_sources, LV_OPA_TRANSP, 0);
     lv_obj_set_style_shadow_width(btn_sources, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_sources, 280, LV_STATE_PRESSED);
@@ -155,8 +161,8 @@ void createMainScreen() {
 
     // Settings button
     lv_obj_t* btn_settings = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_settings, 38, 38);
-    lv_obj_set_pos(btn_settings, 305, 18);
+    lv_obj_set_size(btn_settings, SMIN(38), SMIN(38));
+    lv_obj_set_pos(btn_settings, SX(305), SY(18));
     lv_obj_set_style_bg_opa(btn_settings, LV_OPA_TRANSP, 0);
     lv_obj_set_style_shadow_width(btn_settings, 0, 0);
     lv_obj_add_event_cb(btn_settings, ev_settings, LV_EVENT_CLICKED, NULL);
@@ -169,8 +175,8 @@ void createMainScreen() {
     // ===== TRACK INFO =====
     // Title (white, large) — FIRST: modern players put title above artist
     lbl_title = lv_label_create(panel_right);
-    lv_obj_set_pos(lbl_title, 15, 88);
-    lv_obj_set_width(lbl_title, 265);
+    lv_obj_set_pos(lbl_title, SX(15), SY(88));
+    lv_obj_set_width(lbl_title, SX(265));
     lv_label_set_long_mode(lbl_title, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_label_set_text(lbl_title, "Not Playing");
     lv_obj_set_style_text_color(lbl_title, COL_TEXT, 0);
@@ -178,8 +184,8 @@ void createMainScreen() {
 
     // Artist (gray, smaller) — below title
     lbl_artist = lv_label_create(panel_right);
-    lv_obj_set_pos(lbl_artist, 15, 132);
-    lv_obj_set_size(lbl_artist, 265, 20);  // Fixed height prevents text wrapping over elements below (issue #63)
+    lv_obj_set_pos(lbl_artist, SX(15), SY(132));
+    lv_obj_set_size(lbl_artist, SX(265), SY(20));  // Fixed height prevents text wrapping over elements below (issue #63)
     lv_label_set_long_mode(lbl_artist, LV_LABEL_LONG_SCROLL_CIRCULAR);  // Scroll like title — shows full name
     lv_label_set_text(lbl_artist, "");
     lv_obj_set_style_text_color(lbl_artist, COL_TEXT2, 0);
@@ -187,8 +193,8 @@ void createMainScreen() {
 
     // Queue/Playlist button — aligned with artist row
     btn_queue = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_queue, 48, 48);
-    lv_obj_set_pos(btn_queue, 295, 122);
+    lv_obj_set_size(btn_queue, SMIN(48), SMIN(48));
+    lv_obj_set_pos(btn_queue, SX(295), SY(122));
     lv_obj_set_style_bg_opa(btn_queue, LV_OPA_TRANSP, 0);
     lv_obj_set_style_shadow_width(btn_queue, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_queue, 280, LV_STATE_PRESSED);
@@ -205,8 +211,8 @@ void createMainScreen() {
 
     // Album name — below artist
     lbl_album = lv_label_create(panel_right);
-    lv_obj_set_size(lbl_album, 265, 20);
-    lv_obj_set_pos(lbl_album, 15, 154);
+    lv_obj_set_size(lbl_album, SX(265), SY(20));
+    lv_obj_set_pos(lbl_album, SX(15), SY(154));
     lv_label_set_long_mode(lbl_album, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_label_set_text(lbl_album, "");
     lv_obj_set_style_text_color(lbl_album, lv_color_hex(0x888888), 0);
@@ -214,8 +220,8 @@ void createMainScreen() {
 
     // ===== PROGRESS BAR =====
     slider_progress = lv_slider_create(panel_right);
-    lv_obj_set_pos(slider_progress, 15, 182);
-    lv_obj_set_size(slider_progress, 320, 8);  // 8px: easier touch target, more visual weight
+    lv_obj_set_pos(slider_progress, SX(15), SY(182));
+    lv_obj_set_size(slider_progress, SX(320), SY(8));  // 8px: easier touch target, more visual weight
     lv_slider_set_range(slider_progress, 0, 100);
     lv_obj_set_style_bg_color(slider_progress, COL_BTN, LV_PART_MAIN);
     lv_obj_set_style_bg_color(slider_progress, COL_ACCENT, LV_PART_INDICATOR);
@@ -225,31 +231,31 @@ void createMainScreen() {
 
     // Time elapsed
     lbl_time = lv_label_create(panel_right);
-    lv_obj_set_pos(lbl_time, 15, 198);
+    lv_obj_set_pos(lbl_time, SX(15), SY(198));
     lv_label_set_text(lbl_time, "0:00");
     lv_obj_set_style_text_color(lbl_time, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_time, &lv_font_montserrat_14, 0);
 
     // Time remaining — shown as negative countdown (Apple Music / Spotify style)
     lbl_time_remaining = lv_label_create(panel_right);
-    lv_obj_set_pos(lbl_time_remaining, 280, 198);
+    lv_obj_set_pos(lbl_time_remaining, SX(280), SY(198));
     lv_label_set_text(lbl_time_remaining, "-0:00");
     lv_obj_set_style_text_color(lbl_time_remaining, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_time_remaining, &lv_font_montserrat_14, 0);
 
     // ===== PLAYBACK CONTROLS - PERFECTLY CENTERED =====
     // Layout: [shuffle] [prev] [PLAY] [next] [repeat]
-    // Center of 350px panel = 175
+    // Center of 350px panel = 175  (design-space; wrapped in SX/SY at use)
 
     int ctrl_y = 285;
     int center_x = 175;
 
     // PLAY button (center) - ambient-coloured circle with scale effect
     btn_play = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_play, 80, 80);
-    lv_obj_set_pos(btn_play, center_x - 40, ctrl_y - 40);
+    lv_obj_set_size(btn_play, SMIN(80), SMIN(80));
+    lv_obj_set_pos(btn_play, SX(center_x - 40), SY(ctrl_y - 40));
     lv_obj_set_style_bg_color(btn_play, COL_TEXT, 0);
-    lv_obj_set_style_radius(btn_play, 40, 0);
+    lv_obj_set_style_radius(btn_play, SMIN(40), 0);
     lv_obj_set_style_shadow_width(btn_play, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_play, 280, LV_STATE_PRESSED);  // Scale to 110%
     lv_obj_set_style_transform_scale_y(btn_play, 280, LV_STATE_PRESSED);
@@ -265,10 +271,10 @@ void createMainScreen() {
 
     // PREV button (left of play) - scale effect
     btn_prev = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_prev, 50, 50);
-    lv_obj_set_pos(btn_prev, center_x - 108, ctrl_y - 25);
+    lv_obj_set_size(btn_prev, SMIN(50), SMIN(50));
+    lv_obj_set_pos(btn_prev, SX(center_x - 108), SY(ctrl_y - 25));
     lv_obj_set_style_bg_opa(btn_prev, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_radius(btn_prev, 25, 0);
+    lv_obj_set_style_radius(btn_prev, SMIN(25), 0);
     lv_obj_set_style_shadow_width(btn_prev, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_prev, 280, LV_STATE_PRESSED);
     lv_obj_set_style_transform_scale_y(btn_prev, 280, LV_STATE_PRESSED);
@@ -283,10 +289,10 @@ void createMainScreen() {
 
     // NEXT button (right of play) - scale effect
     btn_next = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_next, 50, 50);
-    lv_obj_set_pos(btn_next, center_x + 58, ctrl_y - 25);
+    lv_obj_set_size(btn_next, SMIN(50), SMIN(50));
+    lv_obj_set_pos(btn_next, SX(center_x + 58), SY(ctrl_y - 25));
     lv_obj_set_style_bg_opa(btn_next, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_radius(btn_next, 25, 0);
+    lv_obj_set_style_radius(btn_next, SMIN(25), 0);
     lv_obj_set_style_shadow_width(btn_next, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_next, 280, LV_STATE_PRESSED);
     lv_obj_set_style_transform_scale_y(btn_next, 280, LV_STATE_PRESSED);
@@ -301,10 +307,10 @@ void createMainScreen() {
 
     // SHUFFLE button (far left) - scale effect
     btn_shuffle = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_shuffle, 45, 45);
-    lv_obj_set_pos(btn_shuffle, center_x - 168, ctrl_y - 22);
+    lv_obj_set_size(btn_shuffle, SMIN(45), SMIN(45));
+    lv_obj_set_pos(btn_shuffle, SX(center_x - 168), SY(ctrl_y - 22));
     lv_obj_set_style_bg_opa(btn_shuffle, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_radius(btn_shuffle, 22, 0);
+    lv_obj_set_style_radius(btn_shuffle, SMIN(22), 0);
     lv_obj_set_style_shadow_width(btn_shuffle, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_shuffle, 280, LV_STATE_PRESSED);
     lv_obj_set_style_transform_scale_y(btn_shuffle, 280, LV_STATE_PRESSED);
@@ -319,10 +325,10 @@ void createMainScreen() {
 
     // REPEAT button (far right) - scale effect
     btn_repeat = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_repeat, 45, 45);
-    lv_obj_set_pos(btn_repeat, center_x + 123, ctrl_y - 22);
+    lv_obj_set_size(btn_repeat, SMIN(45), SMIN(45));
+    lv_obj_set_pos(btn_repeat, SX(center_x + 123), SY(ctrl_y - 22));
     lv_obj_set_style_bg_opa(btn_repeat, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_radius(btn_repeat, 22, 0);
+    lv_obj_set_style_radius(btn_repeat, SMIN(22), 0);
     lv_obj_set_style_shadow_width(btn_repeat, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_repeat, 280, LV_STATE_PRESSED);
     lv_obj_set_style_transform_scale_y(btn_repeat, 280, LV_STATE_PRESSED);
@@ -340,10 +346,10 @@ void createMainScreen() {
 
     // Mute button (left) - scale effect
     btn_mute = lv_btn_create(panel_right);
-    lv_obj_set_size(btn_mute, 40, 40);
-    lv_obj_set_pos(btn_mute, 20, vol_y);
+    lv_obj_set_size(btn_mute, SMIN(40), SMIN(40));
+    lv_obj_set_pos(btn_mute, SX(20), SY(vol_y));
     lv_obj_set_style_bg_opa(btn_mute, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_radius(btn_mute, 20, 0);
+    lv_obj_set_style_radius(btn_mute, SMIN(20), 0);
     lv_obj_set_style_transform_scale_y(btn_mute, 280, LV_STATE_PRESSED);
     lv_obj_set_style_shadow_width(btn_mute, 0, 0);
     lv_obj_set_style_transform_scale_x(btn_mute, 280, LV_STATE_PRESSED);
@@ -358,8 +364,8 @@ void createMainScreen() {
 
     // Volume slider
     slider_vol = lv_slider_create(panel_right);
-    lv_obj_set_size(slider_vol, 240, 6);
-    lv_obj_set_pos(slider_vol, 65, vol_y + 17);
+    lv_obj_set_size(slider_vol, SX(240), SY(6));
+    lv_obj_set_pos(slider_vol, SX(65), SY(vol_y + 17));
     lv_slider_set_range(slider_vol, 0, 100);
     lv_obj_set_style_bg_color(slider_vol, COL_BTN, LV_PART_MAIN);
     lv_obj_set_style_bg_color(slider_vol, COL_TEXT2, LV_PART_INDICATOR);
@@ -372,26 +378,26 @@ void createMainScreen() {
 
     // Small album art for next track (hidden for now)
     img_next_album = lv_img_create(panel_right);
-    lv_obj_set_pos(img_next_album, 15, next_y);
-    lv_obj_set_size(img_next_album, 40, 40);
-    lv_obj_set_style_radius(img_next_album, 4, 0);
+    lv_obj_set_pos(img_next_album, SX(15), SY(next_y));
+    lv_obj_set_size(img_next_album, SMIN(40), SMIN(40));
+    lv_obj_set_style_radius(img_next_album, SMIN(4), 0);
     lv_obj_set_style_clip_corner(img_next_album, true, 0);
     lv_obj_add_flag(img_next_album, LV_OBJ_FLAG_HIDDEN); // Hide thumbnail for now
 
     // "Next:" label
     lbl_next_header = lv_label_create(panel_right);  // Use GLOBAL, not local!
-    lv_obj_set_pos(lbl_next_header, 15, next_y);
+    lv_obj_set_pos(lbl_next_header, SX(15), SY(next_y));
     lv_label_set_text(lbl_next_header, "Next:");
     lv_obj_set_style_text_color(lbl_next_header, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_next_header, &lv_font_montserrat_12, 0);
 
     // Next track title - clickable to play next
     lbl_next_title = lv_label_create(panel_right);
-    lv_obj_set_pos(lbl_next_title, 55, next_y);
+    lv_obj_set_pos(lbl_next_title, SX(55), SY(next_y));
     lv_label_set_text(lbl_next_title, "");
     lv_obj_set_style_text_color(lbl_next_title, COL_TEXT, 0);
     lv_obj_set_style_text_font(lbl_next_title, &lv_font_montserrat_14, 0);
-    lv_obj_set_width(lbl_next_title, 275);
+    lv_obj_set_width(lbl_next_title, SX(275));
     lv_label_set_long_mode(lbl_next_title, LV_LABEL_LONG_SCROLL_CIRCULAR);
     // Make it clickable to play next track
     lv_obj_add_flag(lbl_next_title, LV_OBJ_FLAG_CLICKABLE);
@@ -403,11 +409,11 @@ void createMainScreen() {
 
     // Next track artist - also clickable
     lbl_next_artist = lv_label_create(panel_right);
-    lv_obj_set_pos(lbl_next_artist, 55, next_y + 18);
+    lv_obj_set_pos(lbl_next_artist, SX(55), SY(next_y + 18));
     lv_label_set_text(lbl_next_artist, "");
     lv_obj_set_style_text_color(lbl_next_artist, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_next_artist, &lv_font_montserrat_12, 0);
-    lv_obj_set_width(lbl_next_artist, 275);
+    lv_obj_set_width(lbl_next_artist, SX(275));
     lv_label_set_long_mode(lbl_next_artist, LV_LABEL_LONG_SCROLL_CIRCULAR);
     // Make it clickable to play next track
     lv_obj_add_flag(lbl_next_artist, LV_OBJ_FLAG_CLICKABLE);

--- a/src/screens/ui_ota_screen.cpp
+++ b/src/screens/ui_ota_screen.cpp
@@ -28,8 +28,8 @@ void createOTAScreen() {
 
     // Version info card
     lv_obj_t* card_version = lv_obj_create(content);
-    lv_obj_set_size(card_version, lv_pct(100), 100);
-    lv_obj_set_pos(card_version, 0, 40);
+    lv_obj_set_size(card_version, lv_pct(100), SY(100));
+    lv_obj_set_pos(card_version, 0, SY(40));
     lv_obj_set_style_bg_color(card_version, lv_color_hex(0x2A2A2A), 0);
     lv_obj_set_style_radius(card_version, 12, 0);
     lv_obj_set_style_border_width(card_version, 0, 0);
@@ -50,8 +50,8 @@ void createOTAScreen() {
 
     // Release channel selector card
     lv_obj_t* card_channel = lv_obj_create(content);
-    lv_obj_set_size(card_channel, lv_pct(100), 60);
-    lv_obj_set_pos(card_channel, 0, 155);
+    lv_obj_set_size(card_channel, lv_pct(100), SY(60));
+    lv_obj_set_pos(card_channel, 0, SY(155));
     lv_obj_set_style_bg_color(card_channel, lv_color_hex(0x2A2A2A), 0);
     lv_obj_set_style_radius(card_channel, 12, 0);
     lv_obj_set_style_border_width(card_channel, 0, 0);
@@ -106,7 +106,7 @@ void createOTAScreen() {
 
     // Status label
     lbl_ota_status = lv_label_create(content);
-    lv_obj_set_pos(lbl_ota_status, 0, 230);
+    lv_obj_set_pos(lbl_ota_status, 0, SY(230));
     lv_label_set_text(lbl_ota_status, "Tap 'Check for Updates' to begin");
     lv_obj_set_style_text_color(lbl_ota_status, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_ota_status, &lv_font_mdi_16, 0);
@@ -115,15 +115,15 @@ void createOTAScreen() {
 
     // Progress label
     lbl_ota_progress = lv_label_create(content);
-    lv_obj_set_pos(lbl_ota_progress, 0, 260);
+    lv_obj_set_pos(lbl_ota_progress, 0, SY(260));
     lv_label_set_text(lbl_ota_progress, "");
     lv_obj_set_style_text_color(lbl_ota_progress, COL_ACCENT, 0);
     lv_obj_set_style_text_font(lbl_ota_progress, &lv_font_montserrat_16, 0);
 
     // Visual progress bar (hidden by default)
     bar_ota_progress = lv_bar_create(content);
-    lv_obj_set_size(bar_ota_progress, lv_pct(100), 16);
-    lv_obj_set_pos(bar_ota_progress, 0, 290);
+    lv_obj_set_size(bar_ota_progress, lv_pct(100), SY(16));
+    lv_obj_set_pos(bar_ota_progress, 0, SY(290));
     lv_bar_set_range(bar_ota_progress, 0, 100);
     lv_bar_set_value(bar_ota_progress, 0, LV_ANIM_OFF);
     lv_obj_set_style_bg_color(bar_ota_progress, lv_color_hex(0x333333), LV_PART_MAIN);
@@ -136,8 +136,8 @@ void createOTAScreen() {
 
     // Check for Updates button
     btn_check_update = lv_btn_create(content);
-    lv_obj_set_size(btn_check_update, 280, 50);
-    lv_obj_set_pos(btn_check_update, 0, 330);
+    lv_obj_set_size(btn_check_update, SX(280), SY(50));
+    lv_obj_set_pos(btn_check_update, 0, SY(330));
     lv_obj_set_style_bg_color(btn_check_update, COL_ACCENT, 0);
     lv_obj_set_style_radius(btn_check_update, 12, 0);
     lv_obj_add_event_cb(btn_check_update, ev_check_update, LV_EVENT_CLICKED, NULL);
@@ -149,8 +149,8 @@ void createOTAScreen() {
 
     // Install Update button (hidden by default)
     btn_install_update = lv_btn_create(content);
-    lv_obj_set_size(btn_install_update, 280, 50);
-    lv_obj_set_pos(btn_install_update, 310, 330);
+    lv_obj_set_size(btn_install_update, SX(280), SY(50));
+    lv_obj_set_pos(btn_install_update, SX(310), SY(330));
     lv_obj_set_style_bg_color(btn_install_update, lv_color_hex(0x4ECB71), 0);
     lv_obj_set_style_radius(btn_install_update, 12, 0);
     lv_obj_add_event_cb(btn_install_update, ev_install_update, LV_EVENT_CLICKED, NULL);
@@ -170,5 +170,5 @@ void createOTAScreen() {
     lv_obj_set_style_text_font(lbl_info, &lv_font_mdi_16, 0);
     lv_obj_set_width(lbl_info, lv_pct(100));
     lv_label_set_long_mode(lbl_info, LV_LABEL_LONG_WRAP);
-    lv_obj_set_pos(lbl_info, 0, 400);
+    lv_obj_set_pos(lbl_info, 0, SY(400));
 }

--- a/src/screens/ui_settings_card.cpp
+++ b/src/screens/ui_settings_card.cpp
@@ -29,7 +29,7 @@ lv_obj_t* addCard(lv_obj_t* parent, const char* title) {
         lv_obj_set_style_text_color(lbl, COL_TEXT, 0);
 
         lv_obj_t* underline = lv_obj_create(card);
-        lv_obj_set_size(underline, 36, 2);
+        lv_obj_set_size(underline, SX(36), SY(2));
         lv_obj_set_style_bg_color(underline, COL_ACCENT, 0);
         lv_obj_set_style_bg_opa(underline, LV_OPA_COVER, 0);
         lv_obj_set_style_radius(underline, 1, 0);
@@ -61,7 +61,7 @@ void addDescLabel(lv_obj_t* parent, const char* text) {
 
 lv_obj_t* addSwitch(lv_obj_t* parent, bool initial) {
     lv_obj_t* sw = lv_switch_create(parent);
-    lv_obj_set_size(sw, 50, 26);
+    lv_obj_set_size(sw, SX(50), SY(26));
     lv_obj_set_style_margin_top(sw, 4, 0);
     lv_obj_set_style_radius(sw, 13, LV_PART_MAIN);
     lv_obj_set_style_bg_color(sw, lv_color_hex(0x333333), LV_PART_MAIN);

--- a/src/screens/ui_settings_screens.cpp
+++ b/src/screens/ui_settings_screens.cpp
@@ -36,7 +36,7 @@ void refreshQueueList() {
         bool isPlaying = (trackNum == d->currentTrackNumber);
 
         lv_obj_t* btn = lv_btn_create(list_queue);
-        lv_obj_set_size(btn, 727, 60);  // Full width, uniform height
+        lv_obj_set_size(btn, SX(727), SY(60));  // Full width, uniform height
         lv_obj_set_style_bg_color(btn, isPlaying ? lv_color_hex(0x252525) : lv_color_hex(0x1A1A1A), 0);
         lv_obj_set_style_bg_color(btn, lv_color_hex(0x2A2A2A), LV_STATE_PRESSED);
         lv_obj_set_style_radius(btn, 0, 0);  // No rounded corners - clean list
@@ -72,7 +72,7 @@ void refreshQueueList() {
         lv_label_set_text(title, item->title.c_str());
         lv_obj_set_style_text_color(title, isPlaying ? COL_ACCENT : COL_TEXT, 0);
         lv_obj_set_style_text_font(title, &lv_font_montserrat_16, 0);
-        lv_obj_set_width(title, 610);
+        lv_obj_set_width(title, SX(610));
         lv_label_set_long_mode(title, LV_LABEL_LONG_DOT);
         lv_obj_align(title, LV_ALIGN_LEFT_MID, 45, -11);
 
@@ -81,7 +81,7 @@ void refreshQueueList() {
         lv_label_set_text(artist, item->artist.c_str());
         lv_obj_set_style_text_color(artist, COL_TEXT2, 0);
         lv_obj_set_style_text_font(artist, &lv_font_montserrat_12, 0);
-        lv_obj_set_width(artist, 610);
+        lv_obj_set_width(artist, SX(610));
         lv_label_set_long_mode(artist, LV_LABEL_LONG_DOT);
         lv_obj_align(artist, LV_ALIGN_LEFT_MID, 45, 11);
     }
@@ -93,7 +93,7 @@ void createQueueScreen() {
 
     // Professional header
     lv_obj_t* header = lv_obj_create(scr_queue);
-    lv_obj_set_size(header, 800, 70);
+    lv_obj_set_size(header, SX(800), SY(70));
     lv_obj_set_pos(header, 0, 0);
     lv_obj_set_style_bg_color(header, lv_color_hex(0x252525), 0);
     lv_obj_set_style_border_width(header, 0, 0);
@@ -151,15 +151,15 @@ void createQueueScreen() {
 
     // Status label below header
     lbl_queue_status = lv_label_create(scr_queue);
-    lv_obj_align(lbl_queue_status, LV_ALIGN_TOP_LEFT, 40, 85);
+    lv_obj_align(lbl_queue_status, LV_ALIGN_TOP_LEFT, SX(40), SY(85));
     lv_label_set_text(lbl_queue_status, "Loading...");
     lv_obj_set_style_text_color(lbl_queue_status, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_queue_status, &lv_font_montserrat_14, 0);
 
     // Queue list - modern clean design
     list_queue = lv_list_create(scr_queue);
-    lv_obj_set_size(list_queue, 730, 360);
-    lv_obj_set_pos(list_queue, 35, 115);
+    lv_obj_set_size(list_queue, SX(730), SY(360));
+    lv_obj_set_pos(list_queue, SX(35), SY(115));
     lv_obj_set_style_bg_color(list_queue, lv_color_hex(0x1A1A1A), 0);
     lv_obj_set_style_border_width(list_queue, 0, 0);
     lv_obj_set_style_radius(list_queue, 0, 0);
@@ -206,8 +206,8 @@ void createSourcesScreen() {
 
     // Scrollable list
     lv_obj_t* list = lv_obj_create(content);
-    lv_obj_set_pos(list, 0, 50);
-    lv_obj_set_size(list, lv_pct(100), 405);
+    lv_obj_set_pos(list, 0, SY(50));
+    lv_obj_set_size(list, lv_pct(100), SY(405));
     lv_obj_set_style_bg_color(list, COL_BG, 0);
     lv_obj_set_style_border_width(list, 0, 0);
     lv_obj_set_style_pad_all(list, 0, 0);
@@ -228,7 +228,7 @@ void createSourcesScreen() {
 
     for (int i = 0; i < 1; i++) {
         lv_obj_t* btn = lv_btn_create(list);
-        lv_obj_set_size(btn, lv_pct(100), 50);
+        lv_obj_set_size(btn, lv_pct(100), SY(50));
         lv_obj_set_style_radius(btn, 12, 0);
         lv_obj_set_style_shadow_width(btn, 0, 0);
         lv_obj_set_style_bg_color(btn, COL_CARD, 0);
@@ -304,8 +304,8 @@ void createBrowseScreen() {
 
     // Content list
     lv_obj_t* list = lv_obj_create(content);
-    lv_obj_set_pos(list, 0, 50);
-    lv_obj_set_size(list, lv_pct(100), 405);
+    lv_obj_set_pos(list, 0, SY(50));
+    lv_obj_set_size(list, lv_pct(100), SY(405));
     lv_obj_set_style_bg_color(list, COL_BG, 0);
     lv_obj_set_style_border_width(list, 0, 0);
     lv_obj_set_style_pad_all(list, 0, 0);
@@ -358,7 +358,7 @@ void createBrowseScreen() {
                       itemCount, title.c_str(), isContainer, id.c_str());
 
         lv_obj_t* btn = lv_btn_create(list);
-        lv_obj_set_size(btn, lv_pct(100), 60);
+        lv_obj_set_size(btn, lv_pct(100), SY(60));
         lv_obj_set_style_radius(btn, 10, 0);
         lv_obj_set_style_shadow_width(btn, 0, 0);
         lv_obj_set_style_bg_color(btn, COL_CARD, 0);

--- a/src/screens/ui_sidebar.cpp
+++ b/src/screens/ui_sidebar.cpp
@@ -1,6 +1,11 @@
 /**
  * Settings Sidebar - Shared Navigation Component
  * Creates sidebar with menu items and returns content area
+ *
+ * Coordinates are authored in 800x480 design space and wrapped in SX/SY/SMIN
+ * (ui_scale.h) → identity on 4", auto-scaling on larger panels. Because this
+ * frame is shared by every settings screen, scaling it here makes them all
+ * resolution-aware in one place.
  */
 
 #include "ui_common.h"
@@ -12,7 +17,7 @@
 lv_obj_t* createSettingsSidebar(lv_obj_t* screen, int activeIdx) {
     // ========== LEFT SIDEBAR ==========
     lv_obj_t* sidebar = lv_obj_create(screen);
-    lv_obj_set_size(sidebar, 180, 480);
+    lv_obj_set_size(sidebar, SX(180), SY(480));
     lv_obj_set_pos(sidebar, 0, 0);
     lv_obj_set_style_bg_color(sidebar, lv_color_hex(0x1A1A1A), 0);
     lv_obj_set_style_border_width(sidebar, 1, 0);
@@ -24,7 +29,7 @@ lv_obj_t* createSettingsSidebar(lv_obj_t* screen, int activeIdx) {
 
     // Title + close button row
     lv_obj_t* title_row = lv_obj_create(sidebar);
-    lv_obj_set_size(title_row, 180, 50);
+    lv_obj_set_size(title_row, SX(180), SY(50));
     lv_obj_set_pos(title_row, 0, 0);
     lv_obj_set_style_bg_opa(title_row, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(title_row, 0, 0);
@@ -35,14 +40,14 @@ lv_obj_t* createSettingsSidebar(lv_obj_t* screen, int activeIdx) {
     lv_label_set_text(lbl_title, "Settings");
     lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_24, 0);
     lv_obj_set_style_text_color(lbl_title, COL_TEXT, 0);
-    lv_obj_set_pos(lbl_title, 12, 14);
+    lv_obj_set_pos(lbl_title, SX(12), SY(14));
 
     lv_obj_t* btn_close = lv_button_create(title_row);
-    lv_obj_set_size(btn_close, 32, 32);
-    lv_obj_set_pos(btn_close, 140, 10);
+    lv_obj_set_size(btn_close, SMIN(32), SMIN(32));
+    lv_obj_set_pos(btn_close, SX(140), SY(10));
     lv_obj_set_style_bg_color(btn_close, lv_color_hex(0x333333), 0);
     lv_obj_set_style_bg_color(btn_close, lv_color_hex(0x444444), LV_STATE_PRESSED);
-    lv_obj_set_style_radius(btn_close, 16, 0);
+    lv_obj_set_style_radius(btn_close, SMIN(16), 0);
     lv_obj_set_style_shadow_width(btn_close, 0, 0);
     lv_obj_add_event_cb(btn_close, ev_back_main, LV_EVENT_CLICKED, NULL);
     lv_obj_t* ico_x = lv_label_create(btn_close);
@@ -55,11 +60,11 @@ lv_obj_t* createSettingsSidebar(lv_obj_t* screen, int activeIdx) {
     const char* icons[] = {MDI_COG, MDI_SPEAKER, MDI_SPEAKER_MULTIPLE, MDI_PLAYLIST, MDI_MONITOR, MDI_WIFI, MDI_CLOCK_OUTLINE, MDI_DOWNLOAD};
     const char* labels[] = {"General", "Speakers", "Groups", "Sources", "Display", "WiFi", "Clock", "Update"};
 
-    int y = 55;
+    int y = 55;  // design-space; wrapped in SY() at use
     for (int i = 0; i < 8; i++) {
         lv_obj_t* btn = lv_button_create(sidebar);
-        lv_obj_set_size(btn, 164, 42);
-        lv_obj_set_pos(btn, 8, y);
+        lv_obj_set_size(btn, SX(164), SY(42));
+        lv_obj_set_pos(btn, SX(8), SY(y));
 
         bool active = (i == activeIdx);
         lv_obj_set_style_bg_color(btn, active ? COL_ACCENT : lv_color_hex(0x1A1A1A), 0);
@@ -78,7 +83,7 @@ lv_obj_t* createSettingsSidebar(lv_obj_t* screen, int activeIdx) {
         lv_label_set_text(lbl, labels[i]);
         lv_obj_set_style_text_color(lbl, active ? lv_color_hex(0x000000) : COL_TEXT, 0);
         lv_obj_set_style_text_font(lbl, &lv_font_montserrat_14, 0);
-        lv_obj_align(lbl, LV_ALIGN_LEFT_MID, 26, 0);
+        lv_obj_align(lbl, LV_ALIGN_LEFT_MID, SX(26), 0);
 
         // Navigation callbacks
         lv_obj_add_event_cb(btn, [](lv_event_t* e) {
@@ -103,12 +108,12 @@ lv_obj_t* createSettingsSidebar(lv_obj_t* screen, int activeIdx) {
     lv_label_set_text_fmt(ver, "v%s", FIRMWARE_VERSION);
     lv_obj_set_style_text_font(ver, &lv_font_montserrat_12, 0);
     lv_obj_set_style_text_color(ver, COL_TEXT2, 0);
-    lv_obj_set_pos(ver, 12, 455);
+    lv_obj_set_pos(ver, SX(12), SY(455));
 
     // ========== RIGHT CONTENT AREA ==========
     lv_obj_t* content = lv_obj_create(screen);
-    lv_obj_set_size(content, 620, 480);
-    lv_obj_set_pos(content, 180, 0);
+    lv_obj_set_size(content, SX(620), SY(480));
+    lv_obj_set_pos(content, SX(180), 0);
     lv_obj_set_style_bg_color(content, lv_color_hex(0x121212), 0);
     lv_obj_set_style_border_width(content, 0, 0);
     lv_obj_set_style_radius(content, 0, 0);

--- a/src/screens/ui_tv_mode.cpp
+++ b/src/screens/ui_tv_mode.cpp
@@ -66,7 +66,7 @@ void setTvAudioMode(bool enable) {
         }
         if (lbl_artist) {
             lv_label_set_long_mode(lbl_artist, LV_LABEL_LONG_SCROLL_CIRCULAR);
-            lv_obj_set_height(lbl_artist, 20);
+            lv_obj_set_height(lbl_artist, SY(20));
             lv_label_set_text(lbl_artist, "");
         }
 
@@ -106,7 +106,7 @@ void setTvAudioMode(bool enable) {
         if (lbl_title)  lv_label_set_long_mode(lbl_title,  LV_LABEL_LONG_SCROLL_CIRCULAR);
         if (lbl_artist) {
             lv_label_set_long_mode(lbl_artist, LV_LABEL_LONG_SCROLL_CIRCULAR);
-            lv_obj_set_height(lbl_artist, 20);
+            lv_obj_set_height(lbl_artist, SY(20));
         }
     }
 }

--- a/src/screens/ui_wifi_screen.cpp
+++ b/src/screens/ui_wifi_screen.cpp
@@ -32,7 +32,7 @@ void createWiFiScreen() {
 
     // ── Title row ──────────────────────────────────────────────────────────────
     lv_obj_t* title_row = lv_obj_create(content);
-    lv_obj_set_size(title_row, lv_pct(100), 44);
+    lv_obj_set_size(title_row, lv_pct(100), SY(44));
     lv_obj_set_pos(title_row, 0, 0);
     lv_obj_set_style_bg_opa(title_row, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(title_row, 0, 0);
@@ -46,7 +46,7 @@ void createWiFiScreen() {
     lv_obj_align(lbl_title, LV_ALIGN_LEFT_MID, 0, 0);
 
     btn_wifi_scan = lv_button_create(title_row);
-    lv_obj_set_size(btn_wifi_scan, 100, 34);
+    lv_obj_set_size(btn_wifi_scan, SX(100), SY(34));
     lv_obj_align(btn_wifi_scan, LV_ALIGN_RIGHT_MID, 0, 0);
     lv_obj_set_style_bg_color(btn_wifi_scan, COL_ACCENT, 0);
     lv_obj_set_style_radius(btn_wifi_scan, 17, 0);
@@ -60,7 +60,7 @@ void createWiFiScreen() {
 
     // ── Status label (y=50) ────────────────────────────────────────────────────
     lbl_wifi_status = lv_label_create(content);
-    lv_obj_set_pos(lbl_wifi_status, 0, 50);
+    lv_obj_set_pos(lbl_wifi_status, 0, SY(50));
     lv_label_set_text(lbl_wifi_status, "Tap Scan to find networks");
     lv_obj_set_style_text_color(lbl_wifi_status, COL_TEXT2, 0);
     lv_obj_set_style_text_font(lbl_wifi_status, &lv_font_mdi_16, 0);
@@ -70,8 +70,8 @@ void createWiFiScreen() {
     // ── Password strip (y=76, h=56) — ABOVE the list, hidden until tap ─────────
     // Layout: [×](30) [SSID](140) gap [password field](255) gap [Connect](120)
     pw_strip = lv_obj_create(content);
-    lv_obj_set_size(pw_strip, lv_pct(100), 56);
-    lv_obj_set_pos(pw_strip, 0, 76);
+    lv_obj_set_size(pw_strip, lv_pct(100), SY(56));
+    lv_obj_set_pos(pw_strip, 0, SY(76));
     lv_obj_set_style_bg_color(pw_strip, COL_CARD, 0);
     lv_obj_set_style_border_width(pw_strip, 0, 0);
     lv_obj_set_style_radius(pw_strip, 10, 0);
@@ -109,8 +109,8 @@ void createWiFiScreen() {
 
     // Password textarea
     ta_password = lv_textarea_create(pw_strip);
-    lv_obj_set_size(ta_password, 255, 38);
-    lv_obj_align(ta_password, LV_ALIGN_LEFT_MID, 190, 0);
+    lv_obj_set_size(ta_password, SX(255), SY(38));
+    lv_obj_align(ta_password, LV_ALIGN_LEFT_MID, SX(190), 0);
     lv_textarea_set_password_mode(ta_password, true);
     lv_textarea_set_one_line(ta_password, true);
     lv_textarea_set_placeholder_text(ta_password, "Password");
@@ -124,7 +124,7 @@ void createWiFiScreen() {
 
     // Connect button — far right
     btn_wifi_connect = lv_btn_create(pw_strip);
-    lv_obj_set_size(btn_wifi_connect, 120, 38);
+    lv_obj_set_size(btn_wifi_connect, SX(120), SY(38));
     lv_obj_align(btn_wifi_connect, LV_ALIGN_RIGHT_MID, 0, 0);
     lv_obj_set_style_bg_color(btn_wifi_connect, COL_ACCENT, 0);
     lv_obj_set_style_radius(btn_wifi_connect, 10, 0);
@@ -140,8 +140,8 @@ void createWiFiScreen() {
     // With keyboard (175px from bottom) list shows y=140..300 = 160px ≈ 3 items
     // pw_strip at y=76..132 stays fully visible above keyboard
     list_wifi = lv_list_create(content);
-    lv_obj_set_size(list_wifi, lv_pct(100), 340);
-    lv_obj_set_pos(list_wifi, 0, 140);
+    lv_obj_set_size(list_wifi, lv_pct(100), SY(340));
+    lv_obj_set_pos(list_wifi, 0, SY(140));
     lv_obj_set_style_bg_color(list_wifi, lv_color_hex(0x121212), 0);
     lv_obj_set_style_border_width(list_wifi, 0, 0);
     lv_obj_set_style_radius(list_wifi, 0, 0);
@@ -150,8 +150,8 @@ void createWiFiScreen() {
 
     // ── Scan spinner (centered in list area, hidden by default) ───────────────
     spinner_wifi_scan = lv_spinner_create(content);
-    lv_obj_set_size(spinner_wifi_scan, 80, 80);
-    lv_obj_align(spinner_wifi_scan, LV_ALIGN_CENTER, 0, 60);  // centre of list area
+    lv_obj_set_size(spinner_wifi_scan, SMIN(80), SMIN(80));
+    lv_obj_align(spinner_wifi_scan, LV_ALIGN_CENTER, 0, SY(60));  // centre of list area
     lv_obj_set_style_arc_color(spinner_wifi_scan, COL_ACCENT, LV_PART_INDICATOR);
     lv_obj_set_style_arc_color(spinner_wifi_scan, lv_color_hex(0x555555), LV_PART_MAIN);
     lv_obj_set_style_arc_width(spinner_wifi_scan, 8, LV_PART_INDICATOR);
@@ -164,8 +164,8 @@ void createWiFiScreen() {
     kb = lv_keyboard_create(scr_wifi);
     lv_keyboard_set_textarea(kb, ta_password);
     lv_keyboard_set_mode(kb, LV_KEYBOARD_MODE_TEXT_LOWER);
-    lv_obj_set_size(kb, 615, 175);
-    lv_obj_align(kb, LV_ALIGN_BOTTOM_MID, 90, -5);
+    lv_obj_set_size(kb, SX(615), SY(175));
+    lv_obj_align(kb, LV_ALIGN_BOTTOM_MID, SX(90), SY(-5));
     lv_obj_add_flag(kb, LV_OBJ_FLAG_HIDDEN);
     lv_obj_set_style_bg_color(kb, COL_CARD, 0);
     lv_obj_set_style_pad_all(kb, 5, 0);

--- a/src/touch_driver.cpp
+++ b/src/touch_driver.cpp
@@ -2,6 +2,14 @@
 #include <Wire.h>
 #include <TAMC_GT911.h>
 
+// External callback for screen wake
+extern void resetScreenTimeout();
+
+#if SCREEN_SIZE != 7
+// ============================================================================
+// 4" GT911 — portrait sensor (480×800) mapped to landscape (800×480) via a
+// manual 90° rotation that matches the ST7701 display rotation.
+// ============================================================================
 // Touch sensor is in portrait orientation (480×800)
 #define TOUCH_MAP_X1 480
 #define TOUCH_MAP_X2 0
@@ -35,9 +43,6 @@ bool touch_init(void) {
 
     return true;
 }
-
-// External callback for screen wake
-extern void resetScreenTimeout();
 
 void touch_read(lv_indev_t *indev_drv, lv_indev_data_t *data) {
     static bool was_touched = false;
@@ -76,3 +81,59 @@ void touch_read(lv_indev_t *indev_drv, lv_indev_data_t *data) {
         was_touched = false;
     }
 }
+
+#else  // SCREEN_SIZE == 7
+// ============================================================================
+// 7" GT911 — native landscape sensor (1024×600). No rotation: raw coordinates
+// map directly to LVGL's landscape framebuffer.
+// NOTE: code-complete port (CoopsInChina fork), not yet hardware-tested.
+// ============================================================================
+TAMC_GT911 ts = TAMC_GT911(TOUCH_GT911_SDA, TOUCH_GT911_SCL, TOUCH_GT911_INT, TOUCH_GT911_RST,
+                           TOUCH_PANEL_WIDTH, TOUCH_PANEL_HEIGHT);
+
+static lv_indev_t *indev = NULL;
+
+bool touch_init(void) {
+    Serial.printf("[Touch] Initializing GT911 for %s...\n", DISPLAY_MODEL);
+
+    Wire.begin(TOUCH_GT911_SDA, TOUCH_GT911_SCL);
+    ts.begin();
+    ts.setRotation(ROTATION_INVERTED);
+
+    Serial.println("[Touch] GT911 initialized!");
+
+    indev = lv_indev_create();
+    if (!indev) {
+        Serial.println("[Touch] ERROR: Failed to create input device");
+        return false;
+    }
+
+    lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
+    lv_indev_set_read_cb(indev, touch_read);
+
+    return true;
+}
+
+void touch_read(lv_indev_t *indev_drv, lv_indev_data_t *data) {
+    static bool was_touched = false;
+    ts.read();
+
+    if (ts.isTouched && ts.touches > 0) {
+        // Native landscape: scale raw sensor coords to the LVGL framebuffer.
+        int16_t x = map(ts.points[0].x, 0, TOUCH_PANEL_WIDTH - 1, 0, DISPLAY_WIDTH - 1);
+        int16_t y = map(ts.points[0].y, 0, TOUCH_PANEL_HEIGHT - 1, 0, DISPLAY_HEIGHT - 1);
+        data->point.x = constrain(x, 0, DISPLAY_WIDTH - 1);
+        data->point.y = constrain(y, 0, DISPLAY_HEIGHT - 1);
+        data->state = LV_INDEV_STATE_PRESSED;
+
+        if (!was_touched) {
+            resetScreenTimeout();
+            was_touched = true;
+        }
+    } else {
+        data->state = LV_INDEV_STATE_RELEASED;
+        was_touched = false;
+    }
+}
+
+#endif  // SCREEN_SIZE

--- a/src/ui_album_art.cpp
+++ b/src/ui_album_art.cpp
@@ -850,7 +850,7 @@ static void displayArt(const DecodeResult& dec, const char* url) {
         }
 
         // Step 3: bilinear upscale to full screen
-        scaleImageBilinear(src_buf, TINY, TINY, TINY, blur_bg_buf, 800, 480);
+        scaleImageBilinear(src_buf, TINY, TINY, TINY, blur_bg_buf, DISPLAY_WIDTH, DISPLAY_HEIGHT);
     }
 
     if (xSemaphoreTake(art_mutex, pdMS_TO_TICKS(100))) {
@@ -1002,7 +1002,7 @@ void albumArtTask(void* param) {
     if (!art_temp_buffer)
         art_temp_buffer = (uint16_t*)heap_caps_malloc(ART_SIZE * ART_SIZE * 2, MALLOC_CAP_SPIRAM);
     if (!blur_bg_buf)
-        blur_bg_buf = (uint16_t*)heap_caps_malloc(800 * 480 * 2, MALLOC_CAP_SPIRAM);
+        blur_bg_buf = (uint16_t*)heap_caps_malloc(DISPLAY_WIDTH * DISPLAY_HEIGHT * 2, MALLOC_CAP_SPIRAM);
     if (!art_buffer || !art_temp_buffer) { vTaskDelete(NULL); return; }
 
     if (!art_cache[0].pixels)

--- a/src/ui_handlers.cpp
+++ b/src/ui_handlers.cpp
@@ -1511,10 +1511,10 @@ static void displayCompletedArt() {
     }
     if (blur_bg_ready && img_blur_bg && blur_bg_buf) {
         memset(&blur_bg_dsc, 0, sizeof(blur_bg_dsc));
-        blur_bg_dsc.header.w  = 800;
-        blur_bg_dsc.header.h  = 480;
+        blur_bg_dsc.header.w  = DISPLAY_WIDTH;
+        blur_bg_dsc.header.h  = DISPLAY_HEIGHT;
         blur_bg_dsc.header.cf = LV_COLOR_FORMAT_RGB565;
-        blur_bg_dsc.data_size = 800 * 480 * 2;
+        blur_bg_dsc.data_size = DISPLAY_WIDTH * DISPLAY_HEIGHT * 2;
         blur_bg_dsc.data      = (const uint8_t*)blur_bg_buf;
         lv_img_set_src(img_blur_bg, &blur_bg_dsc);
         lv_obj_remove_flag(img_blur_bg, LV_OBJ_FLAG_HIDDEN);

--- a/web-installer/index.html
+++ b/web-installer/index.html
@@ -366,6 +366,7 @@
         }
         .so-badge.available { background: rgba(0,255,136,0.15); color: #00ff88; }
         .so-badge.soon { background: rgba(255,170,0,0.15); color: #ffaa00; }
+        .so-badge.beta { background: rgba(255,170,0,0.15); color: #ffaa00; }
         .coming-soon-note {
             color: #ffaa00; font-size: 0.92rem; text-align: center;
             padding: 1.25rem; border: 1px dashed rgba(255,170,0,0.4); border-radius: 8px;
@@ -426,7 +427,7 @@
                 <button class="screen-option" data-screen="7inch" type="button">
                     <span class="so-size">7&quot;</span>
                     <span class="so-model">GUITION JC1060P470C · 1024×600</span>
-                    <span class="so-badge soon">COMING SOON</span>
+                    <span class="so-badge beta">BETA</span>
                 </button>
             </div>
         </div>
@@ -518,7 +519,8 @@
                     ['Extra', 'Ethernet'],
                 ],
                 manifest: './manifest-7inch.json',
-                available: false,   // flip to true once firmware-7inch.bin is published
+                available: true,
+                beta: true,   // code-complete port, not yet validated on physical 7" hardware
             },
         };
 
@@ -579,6 +581,12 @@
 
             flashSection.innerHTML = '';
             if (b.available) {
+                if (b.beta) {
+                    const beta = document.createElement('div');
+                    beta.className = 'coming-soon-note';
+                    beta.innerHTML = '⚠ <strong>BETA — untested on hardware.</strong> The 7&quot; build is code-complete (JD9165 panel + responsive UI) but has not yet been validated on a physical 7&quot; unit. Flash only if you own this board and can report back. The 4&quot; firmware is unaffected.';
+                    flashSection.appendChild(beta);
+                }
                 const btn = document.createElement('esp-web-install-button');
                 btn.setAttribute('manifest', b.manifest);
                 btn.innerHTML = `<button slot="activate">INSTALL ${key === '7inch' ? '7&quot;' : '4&quot;'} FIRMWARE</button>`;
@@ -587,7 +595,7 @@
                 const i2 = document.createElement('p'); i2.className = 'browser-info'; i2.style.cssText = 'margin-top:0.5rem;color:#ffaa00;'; i2.textContent = 'After flashing completes, unplug and replug to reboot.';
                 flashSection.append(i1, i2);
                 wireInstallButton(btn);
-                logMessage('info', '●', `Selected ${key} — ready to flash`);
+                logMessage('info', '●', `Selected ${key} — ready to flash${b.beta ? ' (BETA)' : ''}`);
             } else {
                 flashSection.innerHTML = `<div class="coming-soon-note">⚠ The 7&quot; firmware is still in development (JD9165 panel + responsive UI), so it can't be flashed yet. Watch the repo for updates.</div>`;
                 logMessage('warning', '!', `${key} firmware not available yet`);

--- a/web-installer/index.html
+++ b/web-installer/index.html
@@ -504,7 +504,7 @@
                     ['Flash', '16 MB'],
                     ['PSRAM', '32 MB OPI'],
                 ],
-                manifest: './manifest.json',
+                manifest: './manifest-4inch.json',
                 available: true,
             },
             '7inch': {
@@ -598,7 +598,7 @@
             el.addEventListener('click', () => selectBoard(el.dataset.screen)));
 
         // version label from the canonical (4") manifest
-        fetch('./manifest.json').then(r => r.json())
+        fetch('./manifest-4inch.json').then(r => r.json())
             .then(d => { document.getElementById('project-version').textContent = `v${d.version}`; })
             .catch(() => {});
 

--- a/web-installer/index.html
+++ b/web-installer/index.html
@@ -342,7 +342,42 @@
         .log-error .log-icon { color: #ff4444; }
         .log-progress .log-icon { color: #aa88ff; }
 
-        /* Features */
+        /* Screen selector */
+        .screen-selector { margin-bottom: 2.5rem; }
+        .screen-selector h2 { font-size: 1.1rem; font-weight: 500; margin-bottom: 1rem; color: #fff; }
+        .screen-options { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+        @media (max-width: 768px) { .screen-options { grid-template-columns: 1fr; } }
+        .screen-option {
+            background: rgba(255,255,255,0.02);
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 10px;
+            padding: 1.25rem;
+            color: #fff; cursor: pointer; text-align: left;
+            font-family: inherit;
+            transition: border-color 0.2s, background 0.2s;
+        }
+        .screen-option:hover { border-color: rgba(255,255,255,0.35); }
+        .screen-option.selected { border-color: #fff; background: rgba(255,255,255,0.06); }
+        .screen-option .so-size { font-size: 1.35rem; font-weight: 600; display: block; }
+        .screen-option .so-model { color: rgba(255,255,255,0.5); font-size: 0.85rem; }
+        .screen-option .so-badge {
+            display: inline-block; margin-top: 0.75rem; font-size: 0.7rem;
+            padding: 0.15rem 0.6rem; border-radius: 10px; letter-spacing: 0.5px;
+        }
+        .so-badge.available { background: rgba(0,255,136,0.15); color: #00ff88; }
+        .so-badge.soon { background: rgba(255,170,0,0.15); color: #ffaa00; }
+        .coming-soon-note {
+            color: #ffaa00; font-size: 0.92rem; text-align: center;
+            padding: 1.25rem; border: 1px dashed rgba(255,170,0,0.4); border-radius: 8px;
+        }
+
+        /* Requirements / References lists */
+        .reqs { list-style: none; }
+        .reqs li { padding: 0.6rem 0 0.6rem 1.5rem; position: relative; font-size: 0.92rem; color: rgba(255,255,255,0.75); border-bottom: 1px solid rgba(255,255,255,0.05); }
+        .reqs li:last-child { border-bottom: none; }
+        .reqs li::before { content: "›"; position: absolute; left: 0; color: rgba(255,255,255,0.4); }
+        .reqs a { color: #fff; border-bottom: 1px solid rgba(255,255,255,0.3); text-decoration: none; }
+        .reqs a:hover { border-bottom-color: #fff; }
 
         /* Footer */
         footer {
@@ -379,37 +414,31 @@
             </a>
         </div>
 
-        <div class="notice">
-            <p><strong>Hardware Requirement:</strong> GUITION JC4880P433C (800x480 RGB, GT911 Touch, ESP32-P4 + ESP32-C6)</p>
+        <!-- 1. Screen selector -->
+        <div class="screen-selector">
+            <h2>1 · Choose your screen</h2>
+            <div class="screen-options" id="screen-options">
+                <button class="screen-option selected" data-screen="4inch" type="button">
+                    <span class="so-size">4&quot;</span>
+                    <span class="so-model">GUITION JC4880P433C · 800×480</span>
+                    <span class="so-badge available">AVAILABLE</span>
+                </button>
+                <button class="screen-option" data-screen="7inch" type="button">
+                    <span class="so-size">7&quot;</span>
+                    <span class="so-model">GUITION JC1060P470C · 1024×600</span>
+                    <span class="so-badge soon">COMING SOON</span>
+                </button>
+            </div>
         </div>
+
+        <div class="notice" id="board-notice"></div>
 
         <div class="grid">
             <div class="card">
                 <div class="card-content">
                     <div class="card-section">
                         <h2>Hardware Specifications</h2>
-                        <div class="specs">
-                            <div class="spec-row">
-                                <span class="spec-label">Microcontroller</span>
-                                <span class="spec-value">ESP32-P4</span>
-                            </div>
-                            <div class="spec-row">
-                                <span class="spec-label">Display</span>
-                                <span class="spec-value">800×480 RGB</span>
-                            </div>
-                            <div class="spec-row">
-                                <span class="spec-label">Touch</span>
-                                <span class="spec-value">GT911 I2C</span>
-                            </div>
-                            <div class="spec-row">
-                                <span class="spec-label">Flash</span>
-                                <span class="spec-value">16 MB</span>
-                            </div>
-                            <div class="spec-row">
-                                <span class="spec-label">PSRAM</span>
-                                <span class="spec-value">OPI</span>
-                            </div>
-                        </div>
+                        <div class="specs" id="specs-table"></div>
                     </div>
                 </div>
             </div>
@@ -417,40 +446,46 @@
             <div class="card">
                 <div class="card-content">
                     <div class="card-section">
-                        <h2>Installation Steps</h2>
+                        <h2>2 · Install</h2>
                         <ol class="steps">
-                            <li>
-                                <strong>Connect Device</strong>
-                                <span>Plug ESP32-P4 via USB-C</span>
-                            </li>
-                            <li>
-                                <strong>Flash Firmware</strong>
-                                <span>Click button below, select COM port</span>
-                            </li>
-                            <li>
-                                <strong>Wait for Completion</strong>
-                                <span>Do not disconnect during flash</span>
-                            </li>
-                            <li>
-                                <strong>Configure WiFi</strong>
-                                <span>Use on-screen keyboard after reboot</span>
-                            </li>
+                            <li><strong>Connect</strong><span>Plug the board in via USB-C</span></li>
+                            <li><strong>Flash</strong><span>Click below, then pick the serial port</span></li>
+                            <li><strong>Wait</strong><span>Do not disconnect during flashing</span></li>
+                            <li><strong>Set up WiFi</strong><span>On-screen keyboard after reboot</span></li>
                         </ol>
                     </div>
-
-                    <div class="flash-section">
-                        <esp-web-install-button manifest="./manifest.json">
-                            <button slot="activate">INSTALL FIRMWARE</button>
-                        </esp-web-install-button>
-                        <p class="browser-info">Requires Chrome, Edge, or Opera</p>
-                        <p class="browser-info" style="margin-top: 0.5rem; color: #ffaa00;">After installation completes, unplug and replug your device to reboot.</p>
-                    </div>
+                    <div class="flash-section" id="flash-section"></div>
                 </div>
             </div>
         </div>
 
+        <!-- Requirements -->
+        <div class="card" style="margin-bottom: 2rem;">
+            <h2>Requirements</h2>
+            <ul class="reqs">
+                <li>A supported board — the one selected above.</li>
+                <li>A <strong>data-capable USB-C cable</strong> (charge-only cables won't work).</li>
+                <li><strong>Chrome, Edge, or Opera</strong> on desktop — needs the Web Serial API (Safari / Firefox / mobile are not supported).</li>
+                <li>A <strong>2.4 GHz WiFi</strong> network and at least one <strong>Sonos</strong> speaker on the same LAN.</li>
+            </ul>
+        </div>
 
+        <!-- References -->
+        <div class="card" style="margin-bottom: 2rem;">
+            <h2>References</h2>
+            <ul class="reqs">
+                <li><a href="https://github.com/OpenSurface/SonosESP" target="_blank">Project repository &amp; documentation</a></li>
+                <li><a href="https://github.com/OpenSurface/SonosESP/releases" target="_blank">Releases &amp; changelog</a></li>
+                <li><a href="https://github.com/OpenSurface/SonosESP/issues" target="_blank">Report an issue / request a feature</a></li>
+                <li>After the first install, future updates arrive <strong>over-the-air</strong> from the device's <em>Settings → Update</em> — no re-flashing needed.</li>
+            </ul>
+        </div>
 
+        <!-- Installer log -->
+        <div class="console-wrapper" style="margin-bottom: 2rem;">
+            <div class="console-header">Installer Log</div>
+            <div class="console" id="console"></div>
+        </div>
 
         <footer>
             <p>SonosESP Controller | <a href="https://github.com/OpenSurface/SonosESP" target="_blank">GitHub</a> | Future updates via OTA from device settings</p>
@@ -458,125 +493,117 @@
     </div>
 
     <script>
-        // Fetch manifest data and update UI
-        fetch('./manifest.json')
-            .then(response => response.json())
-            .then(data => {
-                document.getElementById('project-title').textContent = data.name;
-                document.getElementById('project-version').textContent = `v${data.version}`;
-            })
-            .catch(err => console.error('Failed to load manifest:', err));
+        // ── Board definitions (one entry per screen variant) ─────────────────
+        const BOARDS = {
+            '4inch': {
+                notice: '<strong>Hardware:</strong> GUITION JC4880P433C — 800×480 RGB, GT911 touch, ESP32-P4 + ESP32-C6',
+                specs: [
+                    ['Microcontroller', 'ESP32-P4 + C6'],
+                    ['Display', '800×480 (ST7701)'],
+                    ['Touch', 'GT911 I²C'],
+                    ['Flash', '16 MB'],
+                    ['PSRAM', '32 MB OPI'],
+                ],
+                manifest: './manifest.json',
+                available: true,
+            },
+            '7inch': {
+                notice: '<strong>Hardware:</strong> GUITION JC1060P470C — 1024×600 RGB, GT911 touch, ESP32-P4 + ESP32-C6, Ethernet',
+                specs: [
+                    ['Microcontroller', 'ESP32-P4 + C6'],
+                    ['Display', '1024×600 (JD9165)'],
+                    ['Touch', 'GT911 I²C'],
+                    ['Flash', '16 MB'],
+                    ['PSRAM', '32 MB OPI'],
+                    ['Extra', 'Ethernet'],
+                ],
+                manifest: './manifest-7inch.json',
+                available: false,   // flip to true once firmware-7inch.bin is published
+            },
+        };
 
-        // Console logging system
+        // ── Console logging (guarded so it never throws if the element is absent) ──
         const console_elem = document.getElementById('console');
-
-        function getTimestamp() {
-            const now = new Date();
-            return now.toTimeString().split(' ')[0];
-        }
-
+        const ts = () => new Date().toTimeString().split(' ')[0];
         function logMessage(type, icon, message) {
+            if (!console_elem) return;
             const line = document.createElement('div');
             line.className = `log-line log-${type}`;
-
-            const time = document.createElement('span');
-            time.className = 'log-time';
-            time.textContent = getTimestamp();
-
-            const iconSpan = document.createElement('span');
-            iconSpan.className = 'log-icon';
-            iconSpan.textContent = icon;
-
-            const msg = document.createElement('span');
-            msg.className = 'log-message';
-            msg.textContent = message;
-
-            line.appendChild(time);
-            line.appendChild(iconSpan);
-            line.appendChild(msg);
+            const t = document.createElement('span'); t.className = 'log-time'; t.textContent = ts();
+            const i = document.createElement('span'); i.className = 'log-icon'; i.textContent = icon;
+            const m = document.createElement('span'); m.className = 'log-message'; m.textContent = message;
+            line.append(t, i, m);
             console_elem.appendChild(line);
             console_elem.scrollTop = console_elem.scrollHeight;
         }
 
-        // Initial messages
-        logMessage('info', '●', 'ESP32-P4 Web Installer initialized');
-        logMessage('info', '○', 'Waiting for device connection...');
-        logMessage('info', '→', 'Click "INSTALL FIRMWARE" to begin flashing');
-        logMessage('success', '✓', 'System ready');
-
-        // Live Logs from ESP32 (SSE)
-        if (!!window.EventSource) {
-            const source = new EventSource('/events');
-
-            source.onopen = function(e) {
-                logMessage('success', '●', 'Live log stream connected');
-            };
-
-            source.onerror = function(e) {
-                if (e.target.readyState != EventSource.OPEN) {
-                    // Silent error to avoid cluttering UI when not served from ESP32
-                }
-            };
-
-            source.addEventListener('log', function(e) {
-                logMessage('info', '»', e.data);
-            }, false);
-        }
-
-        // Monitor esp-web-install-button events
-        const installButton = document.querySelector('esp-web-install-button');
-
-        if (installButton) {
-            // Log all events for debugging
-            ['state-changed', 'progress', 'error'].forEach(eventType => {
-                installButton.addEventListener(eventType, (e) => {
-                    console.log(`Event: ${eventType}`, e.detail);
-                });
+        // ── Wire esp-web-install-button events (called after each (re)create) ──
+        function wireInstallButton(btn) {
+            btn.addEventListener('state-changed', (e) => {
+                const map = {
+                    CONNECTED: ['success', '✓', 'Device connected'],
+                    PREPARING: ['progress', '◆', 'Preparing flash…'],
+                    WRITING:   ['progress', '▶', 'Writing firmware…'],
+                    FINISHED:  ['success', '✓', 'Installation complete — device will reboot'],
+                    ERROR:     ['error', '✖', 'Installation failed — check the cable/port'],
+                    MANIFEST:  ['info', '●', 'Loading firmware manifest…'],
+                    ASK_ERASE: ['warning', '!', 'Confirmation required'],
+                };
+                logMessage(...(map[e.detail] || ['info', '●', `State: ${e.detail}`]));
             });
-
-            installButton.addEventListener('state-changed', (e) => {
-                const state = e.detail;
-
-                if (state === 'CONNECTED') {
-                    logMessage('success', '✓', 'Device connected successfully');
-                } else if (state === 'PREPARING') {
-                    logMessage('progress', '◆', 'Preparing flash operation...');
-                    logMessage('info', '→', 'Erasing existing firmware...');
-                } else if (state === 'WRITING') {
-                    logMessage('progress', '▶', 'Writing firmware to device');
-                } else if (state === 'FINISHED') {
-                    logMessage('success', '✓', 'Firmware installation complete');
-                    logMessage('success', '✓', 'Device will reboot automatically');
-                    logMessage('info', '→', 'Configure WiFi using on-screen keyboard');
-                } else if (state === 'ERROR') {
-                    logMessage('error', '✖', 'Installation failed - check connection');
-                } else if (state === 'MANIFEST') {
-                    logMessage('info', '●', 'Loading firmware manifest...');
-                } else if (state === 'ASK_ERASE') {
-                    logMessage('warning', '!', 'User confirmation required');
-                } else {
-                    logMessage('info', '●', `State: ${state}`);
-                }
-            });
-
-            installButton.addEventListener('progress', (e) => {
+            btn.addEventListener('progress', (e) => {
                 if (e.detail && e.detail.percentage !== undefined) {
                     const pct = Math.round(e.detail.percentage);
-                    if (pct % 10 === 0) { // Log every 10%
-                        logMessage('progress', '▶', `Progress: ${pct}%`);
-                    }
+                    if (pct % 10 === 0) logMessage('progress', '▶', `Progress: ${pct}%`);
                 }
             });
-
-            installButton.addEventListener('error', (e) => {
-                logMessage('error', '✖', `Error: ${e.detail?.message || 'Unknown error'}`);
-                if (e.detail?.error) {
-                    logMessage('error', '✖', `Details: ${e.detail.error}`);
-                }
-            });
-        } else {
-            logMessage('error', '✖', 'Install button not found - check esp-web-tools loaded');
+            btn.addEventListener('error', (e) =>
+                logMessage('error', '✖', `Error: ${e.detail?.message || 'Unknown error'}`));
         }
+
+        // ── Render a board selection ──────────────────────────────────────────
+        const flashSection = document.getElementById('flash-section');
+        const boardNotice  = document.getElementById('board-notice');
+        const specsTable   = document.getElementById('specs-table');
+
+        function selectBoard(key) {
+            const b = BOARDS[key];
+            if (!b) return;
+
+            document.querySelectorAll('.screen-option').forEach(el =>
+                el.classList.toggle('selected', el.dataset.screen === key));
+
+            boardNotice.innerHTML = b.notice;
+            specsTable.innerHTML = b.specs.map(([k, v]) =>
+                `<div class="spec-row"><span class="spec-label">${k}</span><span class="spec-value">${v}</span></div>`).join('');
+
+            flashSection.innerHTML = '';
+            if (b.available) {
+                const btn = document.createElement('esp-web-install-button');
+                btn.setAttribute('manifest', b.manifest);
+                btn.innerHTML = `<button slot="activate">INSTALL ${key === '7inch' ? '7&quot;' : '4&quot;'} FIRMWARE</button>`;
+                flashSection.appendChild(btn);
+                const i1 = document.createElement('p'); i1.className = 'browser-info'; i1.textContent = 'Requires Chrome, Edge, or Opera (desktop).';
+                const i2 = document.createElement('p'); i2.className = 'browser-info'; i2.style.cssText = 'margin-top:0.5rem;color:#ffaa00;'; i2.textContent = 'After flashing completes, unplug and replug to reboot.';
+                flashSection.append(i1, i2);
+                wireInstallButton(btn);
+                logMessage('info', '●', `Selected ${key} — ready to flash`);
+            } else {
+                flashSection.innerHTML = `<div class="coming-soon-note">⚠ The 7&quot; firmware is still in development (JD9165 panel + responsive UI), so it can't be flashed yet. Watch the repo for updates.</div>`;
+                logMessage('warning', '!', `${key} firmware not available yet`);
+            }
+        }
+
+        document.querySelectorAll('.screen-option').forEach(el =>
+            el.addEventListener('click', () => selectBoard(el.dataset.screen)));
+
+        // version label from the canonical (4") manifest
+        fetch('./manifest.json').then(r => r.json())
+            .then(d => { document.getElementById('project-version').textContent = `v${d.version}`; })
+            .catch(() => {});
+
+        logMessage('info', '●', 'Web installer ready');
+        selectBoard('4inch');
     </script>
 </body>
 </html>

--- a/web-installer/manifest-4inch.json
+++ b/web-installer/manifest-4inch.json
@@ -1,0 +1,15 @@
+{
+  "name": "SonosESP — 4\" Screen (GUITION JC4880P433C)",
+  "version": "1.8.4",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-P4",
+      "parts": [
+        { "path": "bootloader.bin",     "offset": 8192  },
+        { "path": "partitions.bin",     "offset": 32768 },
+        { "path": "firmware-4inch.bin", "offset": 65536 }
+      ]
+    }
+  ]
+}

--- a/web-installer/manifest-7inch.json
+++ b/web-installer/manifest-7inch.json
@@ -1,0 +1,16 @@
+{
+  "name": "SonosESP — 7\" Screen (GUITION JC1060P470C)",
+  "version": "0.0.0-wip",
+  "new_install_prompt_erase": true,
+  "_note": "PLACEHOLDER — 7in firmware (firmware-7inch.bin) is not built yet; the JD9165 panel driver must be ported first. The installer keeps the 7in option disabled until this manifest's binary exists. See docs/MULTI_SCREEN_SUPPORT.md.",
+  "builds": [
+    {
+      "chipFamily": "ESP32-P4",
+      "parts": [
+        { "path": "bootloader.bin",     "offset": 8192  },
+        { "path": "partitions.bin",     "offset": 32768 },
+        { "path": "firmware-7inch.bin", "offset": 65536 }
+      ]
+    }
+  ]
+}

--- a/web-installer/manifest-7inch.json
+++ b/web-installer/manifest-7inch.json
@@ -1,8 +1,8 @@
 {
-  "name": "SonosESP — 7\" Screen (GUITION JC1060P470C)",
-  "version": "0.0.0-wip",
+  "name": "SonosESP — 7\" Screen (GUITION JC1060P470C) [BETA]",
+  "version": "1.8.4",
   "new_install_prompt_erase": true,
-  "_note": "PLACEHOLDER — 7in firmware (firmware-7inch.bin) is not built yet; the JD9165 panel driver must be ported first. The installer keeps the 7in option disabled until this manifest's binary exists. See docs/MULTI_SCREEN_SUPPORT.md.",
+  "_note": "BETA — firmware-7inch.bin is code-complete (JD9165 1024x600 panel driver + responsive UI) but NOT yet validated on physical 7in hardware. Built by deploy-pages.yml from the esp32_7inch env. See docs/MULTI_SCREEN_SUPPORT.md.",
   "builds": [
     {
       "chipFamily": "ESP32-P4",


### PR DESCRIPTION
Foundation for **multi-screen support (#89)** — adds the structure for a 7″ variant alongside the 4″, **without changing the 4″ build** (verified byte-identical) and **without the 7″ panel yet** (placeholder, gated until the JD9165 driver + hardware land).

## What's in here

### Build / variant structure
- **`SCREEN_SIZE` abstraction** (`config.h`): `#if SCREEN_SIZE==4` (800×480) / `==7` (1024×600). Dims de-duplicated (removed from `display_driver.h`).
- **`platformio.ini`**: shared `[env]` base + `[env:esp32_4inch]` (working) + `[env:esp32_7inch]` (placeholder); `default_envs = esp32_4inch` so `pio run` builds only the 4″.
- **Env renamed** `esp32-p4 → esp32_4inch` (per-screen clarity) across all workflows + `remove_lvgl_asm.py`.
- **`include/ui_scale.h`**: `SX()/SY()` resolution-relative macros + font tiers — on 4″ they're 1:1 (zero visual change); the path to a responsive UI with **no per-size layout**.
- 7″ locations marked: `lib/jd9165_lcd/README.md` placeholder.

### Naming & OTA (symmetric + safe transition)
- Canonical assets: **`firmware-4inch.bin` / `firmware-7inch.bin`**, manifests **`manifest-4inch.json` / `manifest-7inch.json`**.
- ⚠️ **Backward-compat:** deployed ≤v1.8.4 units OTA-search the substring `firmware.bin`, which isn't in `firmware-4inch.bin` — so we **publish legacy `firmware.bin`/`manifest.json` during a ~1-month transition**, then drop them. (Documented in `docs/MULTI_SCREEN_SUPPORT.md`.)
- `bump_version.py` keeps all manifests version-synced.

### CI/CD optimization
- **ccache** (CI-gated, graceful — local builds & firmware unaffected), `timeout-minutes`, shallow checkout, pip cache.
- **deploy-pages** path-gated (no firmware rebuild on doc-only pushes).
- Deferred (bundled with the future 7″ matrix, nightly-validated): build-once merge + reusable workflow — free + parallel on a public repo, so no cost to leave.

### Web installer
- **2-screen selector** (4″ AVAILABLE / 7″ COMING SOON) — selecting a board swaps the `esp-web-install-button` manifest + dynamic specs/notice.
- Added **Requirements** + **References** sections.
- 🐛 Fixed the live-log console (referenced a `#console` element that never existed → threw on load).

## Plan / spec
Full blueprint in **`docs/MULTI_SCREEN_SUPPORT.md`** (phases, repo org, responsive-UI strategy, CI matrix, risks).

## Safety
- **4″ firmware is byte-identical to v1.8.4** at every step (flash size unchanged).
- 7″ is a **placeholder** — `pio run -e esp32_7inch` intentionally won't link until the JD9165 driver is ported; the installer's 7″ option is disabled.
- Release/nightly workflow changes validate when a nightly is cut; the `ci.yml` + ccache changes validate via this PR's build.

## Not in this PR (next, needs a physical 7″ unit)
JD9165 panel bring-up, the responsive-UI screen conversion, CI build matrix, enabling the 7″ installer option.