### PR TITLE
docs: custom home page for the documentation site

### DIFF
--- a/docs/.vitepress/theme/HomeBody.vue
+++ b/docs/.vitepress/theme/HomeBody.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { withBase } from 'vitepress'
+
+const cards = [
+  { t: 'Browse your whole library',
+    d: 'Artists, albums, genres, composers and tracks, plus saved playlists, internet radio, your NAS shares, the queue and line-in. The list comes from your speaker, so you only see what you actually have.' },
+  { t: 'Synced lyrics',
+    d: 'Time-synced and following the track, colour-matched to the artwork, and out of the way on songs that have none.' },
+  { t: 'Album art, properly',
+    d: 'Decoded by the P4\u2019s hardware JPEG unit, with the dominant colour pulled out to tint the rest of the screen.' },
+  { t: 'Multi-room and groups',
+    d: 'Switch zones with live indicators for what is playing where. Create and break speaker groups from the panel.' },
+  { t: 'Clock, weather, themes',
+    d: 'Four clock faces with a six-hour forecast, three player themes, and auto-dimming when you walk away.' },
+]
+
+const steps = [
+  { n: 'Plug it in',  d: 'USB-C to your computer. Chrome, Edge or Opera.' },
+  { n: 'Click install', d: 'Pick your screen size, pick the port. About a minute.' },
+  { n: 'Join Wi-Fi',  d: 'Type the password on the panel, scan for speakers, done.' },
+]
+</script>
+
+<template>
+  <div class="body">
+    <!-- headline capability gets the wide card because it is the reason to build one -->
+    <section class="lead-card">
+      <div class="lead-copy">
+        <p class="kicker">The bit people ask about</p>
+        <h2>Anything in your Sonos favourites plays from the panel</h2>
+        <p>
+          Whatever service it came from. Spotify playlists, YouTube Music mixes,
+          radio stations, all of it. You never sign into anything on the device —
+          your speaker already holds the accounts and does the work.
+        </p>
+        <a class="link" :href="withBase('/guide/sources')">How sources work →</a>
+      </div>
+      <ul class="chips">
+        <li>Spotify</li><li>YouTube Music</li><li>Apple Music</li>
+        <li>TuneIn</li><li>Amazon Music</li><li>Your NAS</li>
+      </ul>
+    </section>
+
+    <section class="grid">
+      <article v-for="c in cards" :key="c.t" class="card">
+        <h3>{{ c.t }}</h3>
+        <p>{{ c.d }}</p>
+      </article>
+    </section>
+
+    <section class="steps">
+      <h2 class="steps-title">Running in three steps</h2>
+      <ol>
+        <li v-for="(s, i) in steps" :key="s.n">
+          <span class="num">{{ i + 1 }}</span>
+          <div><strong>{{ s.n }}</strong><p>{{ s.d }}</p></div>
+        </li>
+      </ol>
+      <a class="btn" :href="withBase('/guide/install')">Install it now</a>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.body { max-width: 1180px; margin: 0 auto; padding: 0 24px 96px; }
+
+.kicker {
+  font-size: 12px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--vp-c-text-3); margin: 0 0 12px;
+}
+
+.lead-card {
+  display: grid; grid-template-columns: minmax(0,1.35fr) minmax(0,1fr); gap: 40px;
+  align-items: center; padding: 40px; border-radius: 20px; margin-bottom: 20px;
+  border: 1px solid var(--vp-c-divider);
+  background:
+    radial-gradient(120% 140% at 0% 0%, color-mix(in srgb, #d4a84b 12%, transparent), transparent 58%),
+    var(--vp-c-bg-soft);
+}
+.lead-card h2 { margin: 0 0 14px; font-size: clamp(1.5rem, 2.6vw, 2rem); line-height: 1.15; letter-spacing: -.025em; border: 0; padding: 0; }
+.lead-card p { margin: 0 0 18px; color: var(--vp-c-text-2); line-height: 1.65; }
+.link { font-weight: 600; text-decoration: none; color: var(--vp-c-brand-1); }
+.link:hover { text-decoration: underline; }
+
+.chips { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.chips li {
+  font-size: 13px; font-weight: 500; padding: 7px 14px; border-radius: 999px;
+  border: 1px solid var(--vp-c-divider); background: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+}
+
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 20px; margin-bottom: 20px; }
+.card {
+  padding: 26px; border-radius: 16px;
+  border: 1px solid var(--vp-c-divider); background: var(--vp-c-bg-soft);
+  transition: border-color .18s ease, transform .18s ease;
+}
+.card:hover { border-color: color-mix(in srgb, #d4a84b 55%, var(--vp-c-divider)); transform: translateY(-3px); }
+.card h3 { margin: 0 0 9px; font-size: 1.02rem; letter-spacing: -.01em; }
+.card p { margin: 0; font-size: .92rem; line-height: 1.6; color: var(--vp-c-text-2); }
+
+.steps {
+  padding: 44px 40px; border-radius: 20px; text-align: center;
+  border: 1px solid var(--vp-c-divider); background: var(--vp-c-bg-soft);
+}
+.steps-title { margin: 0 0 30px; border: 0; padding: 0; font-size: clamp(1.4rem, 2.4vw, 1.8rem); letter-spacing: -.02em; }
+.steps ol {
+  list-style: none; margin: 0 0 30px; padding: 0;
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); gap: 24px; text-align: left;
+}
+.steps li { display: flex; gap: 14px; align-items: flex-start; }
+.num {
+  flex: 0 0 30px; height: 30px; border-radius: 50%;
+  display: grid; place-items: center; font-size: 14px; font-weight: 700;
+  background: var(--vp-c-text-1); color: var(--vp-c-bg);
+}
+.steps li p { margin: 4px 0 0; font-size: .9rem; color: var(--vp-c-text-2); line-height: 1.55; }
+.btn {
+  display: inline-flex; padding: 13px 30px; border-radius: 999px; font-weight: 600;
+  text-decoration: none; background: var(--vp-c-text-1); color: var(--vp-c-bg);
+  transition: transform .16s ease;
+}
+.btn:hover { transform: translateY(-2px); }
+
+@media (max-width: 860px) {
+  .lead-card { grid-template-columns: 1fr; gap: 26px; padding: 30px; }
+  .steps { padding: 34px 24px; }
+}
+@media (prefers-reduced-motion: reduce) { .card, .btn { transition: none; } }
+</style>

--- a/docs/.vitepress/theme/HomeHero.vue
+++ b/docs/.vitepress/theme/HomeHero.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { withBase } from 'vitepress'
+
+const version = ref('')
+onMounted(async () => {
+  try {
+    const r = await fetch(withBase('/manifest-4inch.json'))
+    version.value = (await r.json()).version ?? ''
+  } catch {}
+})
+</script>
+
+<template>
+  <section class="hero">
+    <!--
+      The wash behind the device echoes what the firmware itself does: it samples
+      the dominant colour out of the album art and tints the whole screen with it.
+      Three slow-drifting blobs, pure CSS, no JS per frame.
+    -->
+    <div class="wash" aria-hidden="true">
+      <span class="blob b1"></span>
+      <span class="blob b2"></span>
+      <span class="blob b3"></span>
+    </div>
+    <div class="grain" aria-hidden="true"></div>
+
+    <div class="inner">
+      <div class="copy">
+        <p class="eyebrow">
+          ESP32-P4 · open source
+          <span v-if="version" class="ver">v{{ version }}</span>
+        </p>
+
+        <h1>
+          Your Sonos,<br />
+          <span class="grad">on a screen you own.</span>
+        </h1>
+
+        <p class="lede">
+          A touchscreen remote that shows album art, follows the lyrics, browses your
+          whole library and plays anything you have saved — including Spotify and
+          YouTube Music. It flashes from your browser in about a minute.
+        </p>
+
+        <div class="cta">
+          <a class="btn primary" :href="withBase('/guide/install')">Install it</a>
+          <a class="btn ghost" :href="withBase('/guide/features')">See what it does</a>
+        </div>
+
+        <p class="meta">
+          No login on the device · Updates over the air · 4″ and 7″ panels
+        </p>
+      </div>
+
+      <div class="device-wrap">
+        <div class="device">
+          <img :src="withBase('/sonosESP.gif')"
+               alt="SonosESP running on a GUITION ESP32-P4 touchscreen, showing album art and playback controls" />
+        </div>
+        <div class="reflect" aria-hidden="true"></div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.hero {
+  position: relative;
+  overflow: hidden;
+  margin: calc(-1 * var(--vp-nav-height)) calc(50% - 50vw) 0;
+  padding: calc(var(--vp-nav-height) + 72px) 24px 88px;
+  isolation: isolate;
+}
+
+/* ---- ambient colour wash ---- */
+/* Fades out before the hero's bottom edge. Without this the overflow:hidden
+   clips the blobs dead straight and the colour reads as a band stuck across the
+   top of the page rather than light falling on it. */
+.wash {
+  position: absolute; inset: -20%; z-index: -2; filter: blur(90px); opacity: .55;
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 42%, transparent 88%);
+          mask-image: linear-gradient(to bottom, #000 0%, #000 42%, transparent 88%);
+}
+:root.dark .wash { opacity: .42; }
+.blob { position: absolute; display: block; border-radius: 50%; }
+.b1 { width: 46vw; height: 46vw; left: 4%;  top: -8%;  background: #c9552f; animation: drift1 26s ease-in-out infinite; }
+.b2 { width: 40vw; height: 40vw; right: 2%; top: 6%;   background: #d4a84b; animation: drift2 31s ease-in-out infinite; }
+.b3 { width: 52vw; height: 52vw; left: 28%; bottom: -26%; background: #2f4d86; animation: drift3 37s ease-in-out infinite; }
+
+@keyframes drift1 { 0%,100% { transform: translate3d(0,0,0) scale(1); } 50% { transform: translate3d(6%,4%,0) scale(1.12); } }
+@keyframes drift2 { 0%,100% { transform: translate3d(0,0,0) scale(1.06); } 50% { transform: translate3d(-5%,6%,0) scale(.94); } }
+@keyframes drift3 { 0%,100% { transform: translate3d(0,0,0) scale(1); } 50% { transform: translate3d(4%,-5%,0) scale(1.1); } }
+
+/* very fine texture so the gradient does not band on wide screens */
+.grain {
+  position: absolute; inset: 0; z-index: -1; pointer-events: none; opacity: .035;
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 45%, transparent 90%);
+          mask-image: linear-gradient(to bottom, #000 0%, #000 45%, transparent 90%);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='3'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* ---- layout ---- */
+.inner {
+  max-width: 1180px; margin: 0 auto;
+  display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  gap: 56px; align-items: center;
+}
+
+.eyebrow {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  font-size: 12px; font-weight: 600; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--vp-c-text-3); margin: 0 0 18px;
+}
+.ver {
+  font-variant-numeric: tabular-nums; letter-spacing: .04em; text-transform: none;
+  padding: 2px 9px; border-radius: 999px;
+  border: 1px solid var(--vp-c-divider); color: var(--vp-c-text-2);
+}
+
+h1 {
+  margin: 0 0 20px; font-size: clamp(2.4rem, 5.2vw, 4rem); line-height: 1.04;
+  letter-spacing: -.035em; font-weight: 800; text-wrap: balance;
+}
+.grad {
+  background: linear-gradient(96deg, #d4a84b 0%, #e0873f 42%, #c9552f 100%);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+
+.lede {
+  margin: 0 0 30px; max-width: 34rem; font-size: 1.06rem; line-height: 1.65;
+  color: var(--vp-c-text-2);
+}
+
+.cta { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 22px; }
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 13px 26px; border-radius: 999px; font-weight: 600; font-size: 15px;
+  text-decoration: none; transition: transform .16s ease, box-shadow .16s ease, background .16s ease;
+  border: 1px solid transparent;
+}
+.btn:hover { transform: translateY(-2px); }
+.primary {
+  background: var(--vp-c-text-1); color: var(--vp-c-bg);
+  box-shadow: 0 10px 26px rgba(0,0,0,.22);
+}
+.primary:hover { box-shadow: 0 14px 32px rgba(0,0,0,.3); }
+.ghost {
+  border-color: var(--vp-c-divider); color: var(--vp-c-text-1);
+  background: color-mix(in srgb, var(--vp-c-bg) 55%, transparent);
+  backdrop-filter: blur(8px);
+}
+.ghost:hover { border-color: var(--vp-c-text-3); }
+
+.meta { margin: 0; font-size: 13px; color: var(--vp-c-text-3); }
+
+/* ---- device ---- */
+.device-wrap { position: relative; }
+.device {
+  border-radius: 18px; padding: 10px; background: #16161a;
+  box-shadow: 0 30px 70px rgba(0,0,0,.45), 0 0 0 1px rgba(255,255,255,.07);
+  transform: perspective(1400px) rotateY(-7deg) rotateX(2deg);
+  transition: transform .5s cubic-bezier(.2,.7,.3,1);
+}
+.device:hover { transform: perspective(1400px) rotateY(-2deg) rotateX(0deg); }
+.device img { display: block; width: 100%; border-radius: 10px; }
+.reflect {
+  position: absolute; left: 6%; right: 6%; top: 100%; height: 90px;
+  background: linear-gradient(180deg, rgba(255,255,255,.10), transparent 70%);
+  filter: blur(14px); border-radius: 50%;
+}
+
+@media (max-width: 900px) {
+  .inner { grid-template-columns: 1fr; gap: 40px; }
+  .device { transform: none; }
+  .hero { padding-bottom: 64px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .blob { animation: none; }
+  .btn, .device { transition: none; }
+}
+</style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,18 @@
+/* The home page is a full-bleed marketing layout. layout:page still reserves the
+   sidebar column and the doc container padding, so both are removed here —
+   frontmatter alone hides the sidebar contents but keeps its gutter. */
+.home-page .VPSidebar,
+.home-page .VPLocalNav,
+.home-page .VPDoc .aside,
+.home-page .VPDocFooter,
+.home-page .VPFooter { display: none !important; }
+
+.home-page .VPContent,
+.home-page .VPContent.has-sidebar { padding: 0 !important; margin: 0 !important; }
+
+.home-page .VPPage { padding: 0 !important; }
+
+.home-page .VPDoc { padding: 0 !important; }
+.home-page .VPDoc .container { max-width: none !important; margin: 0 !important; display: block !important; }
+.home-page .VPDoc .content { max-width: none !important; padding: 0 !important; margin: 0 !important; }
+.home-page .VPDoc .content-container { max-width: none !important; }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,15 @@
+import './custom.css'
 import DefaultTheme from 'vitepress/theme'
 import type { Theme } from 'vitepress'
 import InstallPanel from './InstallPanel.vue'
+import HomeHero from './HomeHero.vue'
+import HomeBody from './HomeBody.vue'
 
 export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
     app.component('InstallPanel', InstallPanel)
+    app.component('HomeHero', HomeHero)
+    app.component('HomeBody', HomeBody)
   }
 } satisfies Theme

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,39 +1,14 @@
 ---
-layout: home
-
-hero:
-  name: SonosESP
-  text: A touchscreen Sonos controller
-  tagline: Album art, synced lyrics, full library browsing and multi-room control on a 4-inch or 7-inch panel. Flashes from your browser.
-  image:
-    src: /sonosESP.gif
-    alt: SonosESP running on a GUITION ESP32-P4 touchscreen
-  actions:
-    - theme: brand
-      text: Install it
-      link: /guide/install
-    - theme: alt
-      text: What you need
-      link: /guide/hardware
-    - theme: alt
-      text: GitHub
-      link: https://github.com/OpenSurface/SonosESP
-
-features:
-  - title: Play what you already saved
-    details: Anything in your Sonos favourites plays from the panel, whatever service it came from — Spotify, YouTube Music, radio stations. You never sign into anything on the device.
-  - title: Browse your whole library
-    details: Artists, albums, genres, composers and tracks, plus playlists, internet radio, your NAS shares, the queue and line-in.
-  - title: Synced lyrics
-    details: Time-synced lyrics that follow the track and colour-match the artwork, hiding themselves when a song has none.
-  - title: Album art, properly
-    details: Hardware JPEG decoding with PNG support, and the dominant colour pulled out to tint the rest of the screen.
-  - title: Multi-room and groups
-    details: Switch between zones with live indicators for what is playing where, and create or break speaker groups from the panel.
-  - title: Clock, weather and themes
-    details: Four clock faces with a 6-hour forecast, three player themes, and auto-dimming when you leave it alone.
-  - title: Updates over the air
-    details: The panel updates itself from settings, on a stable or nightly channel, and resumes interrupted downloads rather than starting again.
-  - title: One codebase, two screens
-    details: The 4-inch and 7-inch builds come from the same source, with type and spacing scaling to the panel.
+layout: page
+title: SonosESP
+titleTemplate: A touchscreen Sonos controller
+pageClass: home-page
+sidebar: false
+aside: false
+outline: false
+navbar: true
+footer: false
 ---
+
+<HomeHero />
+<HomeBody />


### PR DESCRIPTION
The docs site went live with the stock VitePress hero and feature grid. It worked, but it looked like every other VitePress site — a poor advert for a project whose entire selling point is how a screen looks.

### The backdrop is the device's own effect

The firmware samples the dominant colour out of the album art and washes the screen with it. The hero does the same thing: three slow-drifting blobs in the demo artwork's palette. Pure CSS, nothing running per frame, and it stops entirely under `prefers-reduced-motion`.

The wash is masked to fade out before the hero's bottom edge. With `overflow: hidden` alone it was clipped dead straight and read as a coloured band stuck across the top of the page rather than light falling across it.

### Everything else

- Headline is "Your Sonos, on a screen you own" rather than "A touchscreen Sonos controller" — a reason instead of a category.
- The device is tilted and shadowed so it reads as hardware sitting in space, not a screenshot pasted onto a page.
- Favourites gets a wide lead card, because it is the thing people actually ask about. Service names are chips so Spotify and YouTube Music are scannable rather than buried in a paragraph.
- A three-step install strip at the bottom. "How much work is this?" is the question standing between reading the page and building one.
- Version pill reads from the published manifest, so it tracks releases without anyone editing the page.

`sidebar`, `aside` and `outline` are `false` in frontmatter, so the home page renders without them rather than hiding them with CSS and keeping the empty gutter. The stylesheet only strips the container padding that `layout: page` still applies.

### Scope

Docs only — no firmware, no version bump, no flash test needed. Every other page is untouched and keeps its sidebar. The web installer, the manifests and the firmware binaries are all unaffected; the existing CI guard that verifies the built site still serves them passes.

Local build is clean in ~2.5s.