### PR TITLE
ci: deploy the site on docs-only pushes

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,10 +3,19 @@ name: Deploy Web Installer
 on:
   push:
     branches: [ main ]
-    # Only redeploy when the firmware or the installer page actually changes —
-    # not on doc/workflow-only pushes (which would otherwise trigger a full
-    # firmware rebuild for nothing). Manual runs are always available below.
+    # Only redeploy when something that ends up ON the published site changes.
+    # A push touching just the README, the issue templates or an unrelated
+    # workflow shouldn't spend five minutes rebuilding firmware for nothing.
+    #
+    # 'docs/**' is the important one: since the VitePress migration the site is
+    # BUILT from docs/, so a docs-only push is exactly the case that most needs
+    # to deploy. It was missing, and a home page rewrite touching nothing
+    # outside docs/ merged to main without deploying at all. Anything added
+    # later that renders into the site has to be listed here, or it publishes
+    # only by accident, on whatever unrelated push happens to come next.
     paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-pages.yml'
       - 'version.json'
       - 'web-installer/**'
       - 'src/**'


### PR DESCRIPTION
The Pages workflow still carried the path filter from when the site was a single hand-written page in `web-installer/`. The VitePress migration (#130) moved the source into `docs/` and repointed the publish path, but left the trigger alone — so `docs/**` was never in the list.

The gap only became visible on the *second* docs change:

- **#130** happened to touch `web-installer/` while removing it. That matched the old filter, so it deployed, and the site went live.
- **#131** (the home page rewrite) touched nothing outside `docs/`. It matched nothing, so the workflow never started. The merge landed on `main`, every other check passed green, and the published site quietly stayed on the old home page.

Nothing failed — which is why it wasn't obvious. There was no red X to notice, just an absent run.

### Change

Adds `docs/**` and `.github/workflows/deploy-pages.yml` to the trigger. The rest of the filter is intentionally kept: a push that only edits the README or an unrelated workflow still shouldn't spend five minutes rebuilding firmware.

### Already handled

Current `main` has been deployed by hand via `workflow_dispatch`, so the live site is correct now. This PR is about the next docs change, not this one.