### PR TITLE
docs: restore the Ko-fi link, and put it on the README front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A wall-mount or desktop remote for Sonos speakers: album art, synced lyrics, ful
 [![GitHub Release](https://img.shields.io/github/v/release/OpenSurface/SonosESP?style=flat-square&logo=github&label=Latest%20Release)](https://github.com/OpenSurface/SonosESP/releases/latest)
 [![GitHub Stars](https://img.shields.io/github/stars/OpenSurface/SonosESP?style=flat-square&logo=github&label=Stars)](https://github.com/OpenSurface/SonosESP/stargazers)
 
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-Support%20the%20project-ff5e5b?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/pizzapasta)
+
 ### [Install in your browser — no toolchain required](https://opensurface.github.io/SonosESP/)
 
 [Features](#features) · [Music sources](#music-sources) · [Themes](#player-themes) · [Screensaver](#screensaver-themes) · [Hardware](#hardware) · [Install](#installation) · [Setup](#first-time-setup) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Contributing](#contributing)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -79,7 +79,8 @@ export default defineConfig({
     search: { provider: 'local' },
 
     footer: {
-      message: 'MIT licensed',
+      message:
+        'MIT licensed · <a href="https://ko-fi.com/pizzapasta" target="_blank" rel="noopener">Support on Ko-fi</a>',
       copyright: 'SonosESP'
     }
   }

--- a/docs/.vitepress/theme/HomeBody.vue
+++ b/docs/.vitepress/theme/HomeBody.vue
@@ -58,6 +58,20 @@ const steps = [
       </ol>
       <a class="btn" :href="withBase('/guide/install')">Install it now</a>
     </section>
+
+    <section class="support">
+      <div>
+        <h2>Free, and staying that way</h2>
+        <p>
+          SonosESP is MIT licensed and built in spare time. If it earns a place on
+          your wall, a coffee helps pay for the panels that get tested to breaking
+          point so yours doesn't.
+        </p>
+      </div>
+      <a class="kofi" href="https://ko-fi.com/pizzapasta" target="_blank" rel="noopener">
+        Support on Ko-fi
+      </a>
+    </section>
   </div>
 </template>
 
@@ -127,4 +141,24 @@ const steps = [
   .steps { padding: 34px 24px; }
 }
 @media (prefers-reduced-motion: reduce) { .card, .btn { transition: none; } }
+
+.support {
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 24px;
+  margin-top: 20px; padding: 30px 32px;
+  border: 1px solid var(--vp-c-divider); border-radius: 18px;
+  background: var(--vp-c-bg-soft);
+}
+.support h2 { margin: 0 0 8px; border: 0; padding: 0; font-size: 1.18rem; letter-spacing: -.015em; }
+.support p { margin: 0; max-width: 56ch; font-size: .92rem; line-height: 1.6; color: var(--vp-c-text-2); }
+.kofi {
+  flex-shrink: 0;
+  display: inline-block; padding: 11px 22px; border-radius: 999px;
+  background: #ff5e5b; color: #fff; font-weight: 600; font-size: .92rem;
+  text-decoration: none; white-space: nowrap;
+  transition: transform .18s ease, box-shadow .18s ease;
+}
+.kofi:hover { transform: translateY(-2px); box-shadow: 0 8px 20px rgba(255, 94, 91, .32); }
+@media (prefers-reduced-motion: reduce) { .kofi { transition: none; } .kofi:hover { transform: none; } }
+@media (max-width: 620px) { .support { flex-direction: column; align-items: flex-start; } }
 </style>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ sidebar: false
 aside: false
 outline: false
 navbar: true
-footer: false
+footer: true
 ---
 
 <HomeHero />

--- a/web-installer/index.html
+++ b/web-installer/index.html
@@ -174,7 +174,7 @@
             <nav class="nav">
                 <a href="https://github.com/OpenSurface/SonosESP" target="_blank" rel="noopener">GitHub</a>
                 <a href="https://github.com/OpenSurface/SonosESP/releases" target="_blank" rel="noopener">Releases</a>
-                <a href="https://ko-fi.com/opensurface" target="_blank" rel="noopener">Ko-fi &hearts;</a>
+                <a href="https://ko-fi.com/pizzapasta" target="_blank" rel="noopener">Ko-fi &hearts;</a>
             </nav>
         </div>
     </header>
@@ -190,7 +190,7 @@
                and over-the-air updates &mdash; on a 4&Prime; or 7&Prime; panel. No IDE, no toolchain.</p>
             <div class="cta">
                 <a class="btn" href="#install">Flash it now</a>
-                <a class="kofi" href="https://ko-fi.com/opensurface" target="_blank" rel="noopener">
+                <a class="kofi" href="https://ko-fi.com/pizzapasta" target="_blank" rel="noopener">
                     <img src="https://storage.ko-fi.com/cdn/kofi2.png?v=3" alt="Buy me a coffee at ko-fi.com">
                 </a>
                 <span class="vtag" id="version-tag">v0.1.0</span>
@@ -284,7 +284,7 @@
 <div class="wrap">
     <footer>
         <div>SonosESP Controller &middot; <a href="https://github.com/OpenSurface/SonosESP" target="_blank" rel="noopener">GitHub</a></div>
-        <div>Built by OpenSurface &middot; <a href="https://ko-fi.com/opensurface" target="_blank" rel="noopener">Support on Ko-fi</a></div>
+        <div>Built by OpenSurface &middot; <a href="https://ko-fi.com/pizzapasta" target="_blank" rel="noopener">Support on Ko-fi</a></div>
     </footer>
 </div>
 


### PR DESCRIPTION
The old single-page installer had a Ko-fi link in its footer and a Ko-fi button above it. The VitePress migration in #130 rebuilt that page from scratch and neither came across — so since the docs site went live it has had **no support link on it at all**. My miss.

### Which account

The two links in the repo disagreed:

| Location | URL | Last touched |
|---|---|---|
| `README.md` | `ko-fi.com/pizzapasta` | Jan 2026 |
| `web-installer/index.html` | `ko-fi.com/opensurface` | Aug 2026 |

Ko-fi returns 403 to anything scripted, so neither could be verified from CI. Confirmed with @pizza-init that **`pizzapasta`** is the live account, and that is what's used everywhere here. Nothing references `opensurface` any more; it goes away with `web-installer/` whenever that directory does.

### Where it lands

**Site footer** — every page. That's where people go looking for it.

**Home page card** — at the *end* of the flow, after the three install steps rather than before them. Someone who has just read how little work this is to build is a better moment to ask than someone who hasn't started reading.

It's styled off the existing `.card` / `.lead-card`, not as a banner — the last section of the page rather than an ad bolted onto the bottom. The button is the only saturated colour on the page, so it doesn't need to shout. Hover lift drops under `prefers-reduced-motion` like everything else.

`footer: false` comes off the home page frontmatter so the site footer renders there too. That was set back when the page had nothing worth ending on; now it does, and without it the page just stopped.

**README** — badge in the centred header block, directly above the browser install link, so it's visible without scrolling to the bottom. The existing Support section near the end stays as it is.

### Verified on the build

- Home page: support card **and** footer link (2 occurrences)
- Guide pages: footer link only (1 occurrence)
- All 13 links in the built output resolve to `ko-fi.com/pizzapasta`; zero to the old account

Docs only — no firmware, no version bump.