### PR TITLE
feat: capture screenshots over serial instead of photographing the panel

### DIFF
--- a/docs/SCREENSHOT.md
+++ b/docs/SCREENSHOT.md
@@ -1,0 +1,68 @@
+# Screenshots over serial
+
+Real screenshots for the README and the docs site, instead of photographing the
+panel with a phone.
+
+```
+pip install pyserial pillow
+python tools/screenshot.py COM7 docs/public/shots/player.png
+```
+
+Put the screen in the state you want first, then run the command. The UI freezes
+for a second or two while the frame transfers — that is the dump, not a crash.
+
+`--scale 2` upscales with nearest-neighbour for a crisp 2× image on the docs
+site. `--baud` only matters if you are capturing on the UART rather than native
+USB-CDC, which ignores it.
+
+## How it works
+
+LVGL renders with `LV_DISPLAY_RENDER_MODE_FULL`, so `display_flush()` is handed
+one contiguous RGB565 buffer holding the entire screen. Nothing is re-rendered
+for a screenshot; the bytes already exist and are simply base64'd out of the
+serial port.
+
+Typing `screenshot` sets a flag. The next full flush copies the frame into a
+PSRAM buffer, and the main task ships it between `[shot]` and `[/shot]` markers.
+
+On the 4" the capture is taken from `px_map` — the landscape 800×480 frame LVGL
+drew — and **not** from `rotate_buf`, which is the portrait version sent to the
+panel and would come out sideways.
+
+## Why it is built this way
+
+**Nothing is copied until you ask.** The cost on the flush path when idle is one
+`bool` test. Copying every frame unconditionally would be ~768 KB of `memcpy` at
+frame rate on the 4" and 1.2 MB on the 7", permanently, for a feature used a
+handful of times.
+
+**A pointer to `px_map` is not kept.** The draw buffers are double-buffered, so a
+stored pointer refers to a buffer that is being overwritten by the next render
+while you are still dumping it — that is what produces torn screenshots. The
+frame is copied once, on request, and the buffer is freed again afterwards
+rather than holding PSRAM for a feature that is idle almost always.
+
+**The byte count is in the header.** `[shot] <w> <h> <bytes>` lets the host prove
+it received everything. Without it a short read decodes into a plausible-looking
+image with a corrupt tail and no error at all.
+
+## Two traps, if you reimplement this
+
+**Do not use `readline()` on the host.** It returns a *partial* line when its
+timeout expires mid-transfer. A truncated base64 line silently drops bytes and
+you get a corrupt tail with no error raised. Read raw chunks and split on
+newlines afterwards, which is what `tools/screenshot.py` does.
+
+**Base64 lines must be a multiple of 4 characters.** A base64 group is 4
+characters encoding 3 bytes; splitting a group across a newline shifts every
+byte after it. The firmware uses 76.
+
+Other FreeRTOS tasks can print into the middle of the dump. The host matches
+payload lines against a strict base64 pattern rather than trusting position, so
+an interleaved `[WIFI] reconnecting...` is rejected without corrupting the frame.
+
+## Alternative considered
+
+`lv_snapshot_take()` exists in LVGL, but allocates a second full framebuffer to
+render into. Grabbing the frame that has already been drawn is cheaper and needs
+no extra memory in the steady state.

--- a/docs/SCREENSHOT.md
+++ b/docs/SCREENSHOT.md
@@ -5,64 +5,118 @@ panel with a phone.
 
 ```
 pip install pyserial pillow
-python tools/screenshot.py COM7 docs/public/shots/player.png
+python tools/screenshot.py COM9 docs/public/shots/player.png
 ```
 
-Put the screen in the state you want first, then run the command. The UI freezes
-for a second or two while the frame transfers — that is the dump, not a crash.
+Put the screen in the state you want first, then run the command. `--scale 2`
+upscales with nearest-neighbour for a crisp 2× image. `--baud` only matters if
+you are capturing on the UART rather than native USB-CDC, which ignores it.
 
-`--scale 2` upscales with nearest-neighbour for a crisp 2× image on the docs
-site. `--baud` only matters if you are capturing on the UART rather than native
-USB-CDC, which ignores it.
+The UI freezes for a second or two while the frame transfers. That is the dump,
+not a crash.
 
 ## How it works
 
 LVGL renders with `LV_DISPLAY_RENDER_MODE_FULL`, so `display_flush()` is handed
 one contiguous RGB565 buffer holding the entire screen. Nothing is re-rendered
-for a screenshot; the bytes already exist and are simply base64'd out of the
-serial port.
+for a screenshot; the bytes already exist and are base64'd out of the port.
 
-Typing `screenshot` sets a flag. The next full flush copies the frame into a
-PSRAM buffer, and the main task ships it between `[shot]` and `[/shot]` markers.
+Typing `screenshot` sets a flag **and invalidates the active screen**. That
+second part is essential: LVGL only flushes when something has been invalidated,
+so on a static screen no flush ever happens and the request would sit pending
+forever. The next flush copies the frame into a PSRAM buffer, and the main task
+ships it between `[shot]` and `[/shot]` markers.
 
 On the 4" the capture is taken from `px_map` — the landscape 800×480 frame LVGL
 drew — and **not** from `rotate_buf`, which is the portrait version sent to the
 panel and would come out sideways.
 
+### Wire format
+
+```
+[shot] <width> <height> <bytes> <lines>
+0000:<76 base64 chars>
+0001:<76 base64 chars>
+...
+[/shot]
+```
+
+Status lines are `[shot-busy]` and `[shot-err]`. They deliberately do **not**
+start with `[shot]`, because the host locates the header by pattern and an
+earlier version parsed a status line as the header.
+
+Commands: `screenshot`, `shotline <hex index>` (resend one line), `shotfree`
+(release the capture buffer).
+
 ## Why it is built this way
 
 **Nothing is copied until you ask.** The cost on the flush path when idle is one
-`bool` test. Copying every frame unconditionally would be ~768 KB of `memcpy` at
-frame rate on the 4" and 1.2 MB on the 7", permanently, for a feature used a
-handful of times.
+`bool` test. Copying every frame would be ~768 KB of `memcpy` at frame rate on
+the 4" and 1.2 MB on the 7", permanently, for a feature used occasionally.
 
-**A pointer to `px_map` is not kept.** The draw buffers are double-buffered, so a
-stored pointer refers to a buffer that is being overwritten by the next render
-while you are still dumping it — that is what produces torn screenshots. The
-frame is copied once, on request, and the buffer is freed again afterwards
-rather than holding PSRAM for a feature that is idle almost always.
+**No pointer to `px_map` is kept.** The draw buffers are double-buffered, so a
+stored pointer refers to a buffer being overwritten by the next render while you
+are still dumping it. That is what produces torn screenshots.
 
-**The byte count is in the header.** `[shot] <w> <h> <bytes>` lets the host prove
-it received everything. Without it a short read decodes into a plausible-looking
-image with a corrupt tail and no error at all.
+**Every line carries its index.** Other FreeRTOS tasks print to the same port
+and nothing stops one landing inside a payload line. Without an index there is
+no way to know *which* line was affected, and a damaged line silently shifts
+every byte after it — so a frame could decode to the right length and still be
+wrong from that point on.
 
-## Two traps, if you reimplement this
+**The byte and line counts are in the header** so the host can prove it received
+everything, rather than writing a plausible-looking image with a corrupt tail.
+
+## Traps, if you reimplement this
+
+**A log line stuck on the end is not corruption.** This is the one that caused
+the most trouble. Lines routinely arrive as:
+
+```
+1B24:wxjDGMMY...wxjD[SOAP/DMA] #3040: pre=136KB post=136KB
+```
+
+The base64 in front is complete and correct — another task's output simply
+landed between the payload and `println`'s newline. Requiring the whole line to
+match base64 throws away good data, and because the interfering log repeats
+constantly, re-requesting the line hits exactly the same problem. Match the
+*leading* base64 run and ignore what follows. A log spliced into the middle
+truncates that run and is genuinely damaged, so it still gets re-requested.
 
 **Do not use `readline()` on the host.** It returns a *partial* line when its
-timeout expires mid-transfer. A truncated base64 line silently drops bytes and
-you get a corrupt tail with no error raised. Read raw chunks and split on
-newlines afterwards, which is what `tools/screenshot.py` does.
+timeout expires mid-transfer. A truncated base64 line silently drops bytes with
+no error raised. Read raw chunks and split afterwards.
 
-**Base64 lines must be a multiple of 4 characters.** A base64 group is 4
-characters encoding 3 bytes; splitting a group across a newline shifts every
-byte after it. The firmware uses 76.
+**Use an idle timeout, not a total one.** A frame is ~1 MB of base64; how long
+that takes depends on the link. A fixed overall deadline truncates the transfer
+and then reports it as missing bytes, which looks like corruption but is only
+impatience.
 
-Other FreeRTOS tasks can print into the middle of the dump. The host matches
-payload lines against a strict base64 pattern rather than trusting position, so
-an interleaved `[WIFI] reconnecting...` is rejected without corrupting the frame.
+**Base64 lines must be a multiple of 4 characters.** A group is 4 characters
+encoding 3 bytes; splitting one across a newline shifts everything after it.
+The firmware uses 76.
+
+**USB-CDC silently discards writes** it cannot fit in the TX buffer — it does
+not block and does not retry. The dump raises the TX timeout so `write()` waits
+for space, and flushes periodically so the buffer never fills.
+
+**Do not yield inside the dump loop.** An earlier version called `vTaskDelay(1)`
+every 32 lines to be polite about CPU. That hands the core to exactly the tasks
+that then print into the middle of a line. The watchdog needs its reset, not a
+yield.
+
+**Batch the re-requests.** The board's CDC receive buffer is a few hundred
+bytes, so 92 `shotline` commands in one burst overflows it and most are never
+read.
 
 ## Alternative considered
 
-`lv_snapshot_take()` exists in LVGL, but allocates a second full framebuffer to
-render into. Grabbing the frame that has already been drawn is cheaper and needs
-no extra memory in the steady state.
+`lv_snapshot_take()` exists in LVGL but allocates a second full framebuffer to
+render into. Grabbing the frame already drawn is cheaper and needs no extra
+memory in the steady state.
+
+Serial is also not the ideal transport. The board has WiFi and already speaks
+HTTP, and an endpoint serving the raw framebuffer over TCP would need none of
+the framing, base64 or retransmit machinery above — TCP handles reliability, and
+binary is 33% smaller. Everything here exists to work around a shared, unframed
+byte stream. Worth doing if screenshots become a regular chore.

--- a/include/screenshot.h
+++ b/include/screenshot.h
@@ -1,0 +1,38 @@
+#ifndef SCREENSHOT_H
+#define SCREENSHOT_H
+
+#include <Arduino.h>
+#include "lvgl.h"
+
+// ---------------------------------------------------------------------------
+// Serial frame grab — for documentation screenshots.
+// ---------------------------------------------------------------------------
+// Type "screenshot" into the serial monitor and the next completed frame is
+// base64'd out of the port. tools/screenshot.py drives it and writes a PNG.
+//
+// The frame already exists: LVGL renders with LV_DISPLAY_RENDER_MODE_FULL, so
+// display_flush() is handed one contiguous RGB565 buffer of the whole screen.
+// Nothing is re-rendered; we copy bytes that are already there.
+//
+// Cost when idle is one bool test per flush. The frame is copied ONLY after a
+// request arrives, and the copy buffer is freed again once the dump completes,
+// so the steady-state cost of having this compiled in is nil. Copying every
+// frame unconditionally would be ~768KB of memcpy at frame rate for a feature
+// used a handful of times; keeping a bare pointer to px_map instead would be
+// worse, because the draw buffers are double-buffered and the frame you kept a
+// pointer to is being overwritten while you dump it.
+//
+// The dump blocks the calling task for a second or two, so the UI freezes for
+// its duration. That is fine for a deliberate debug command and is why nothing
+// calls it automatically.
+
+// Called from display_flush() on every frame. Returns immediately unless a
+// screenshot has been requested. `area` is used to confirm the flush really is
+// a full frame before anything is copied.
+void screenshotCaptureHook(const uint8_t* px_map, const lv_area_t* area);
+
+// Called from the main task loop. Reads the serial port for the "screenshot"
+// command and performs the dump once a frame has been captured.
+void screenshotPoll(void);
+
+#endif // SCREENSHOT_H

--- a/src/display_driver.cpp
+++ b/src/display_driver.cpp
@@ -1,5 +1,6 @@
 #include "display_driver.h"
 #include "config.h"
+#include "screenshot.h"
 
 // Defined in ui_globals.cpp, loaded from NVS in setup() before display_init().
 // Declared here rather than pulling in ui_common.h, which would drag the whole
@@ -174,6 +175,11 @@ void display_flush(lv_display_t *disp_drv, const lv_area_t *area, uint8_t *px_ma
         return;
     }
 
+    // Grab the frame for a pending screenshot before it is rotated: px_map is
+    // the landscape frame LVGL drew, rotate_buf is the portrait panel version
+    // which would come out sideways. No-op unless one has been requested.
+    screenshotCaptureHook(px_map, area);
+
     // Rotate the entire frame from landscape 800x480 to portrait 480x800 for panel
     // Panel DPI is now configured for 480×800 portrait
 #if USE_PPA_ACCELERATION
@@ -275,6 +281,8 @@ void display_flush(lv_display_t *disp_drv, const lv_area_t *area, uint8_t *px_ma
         lv_display_flush_ready(disp_drv);
         return;
     }
+
+    screenshotCaptureHook(px_map, area);
 
     // Native landscape: push the rendered region straight to the panel.
     lcd->lcd_draw_bitmap(area->x1, area->y1, area->x2 + 1, area->y2 + 1, (uint16_t *)px_map);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <esp_flash.h>
 #include <esp_task_wdt.h>
 #include "ui_fonts.h"
+#include "screenshot.h"
 #if SCREEN_SIZE == 7
 #include "../lib/jd9165_lcd/jd9165_panels.h"
 #endif
@@ -539,6 +540,7 @@ static void mainAppTask(void* param) {
             checkClockTrigger();
             checkWiFiReconnect();
             logHeapStatus();  // Periodic memory monitoring
+            screenshotPoll();  // serial "screenshot" command — no-op otherwise
 
             // ── DMA recovery handler ─────────────────────────────────────────────
             // Art task (PSRAM stack) cannot call esp_restart() or Preferences.begin()

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -60,6 +60,16 @@ static void dumpScreenshot(void) {
     // looking image with a corrupt tail, which is worse than a clear failure.
     Serial.printf("[shot] %u %u %u\n", (unsigned)s_w, (unsigned)s_h, (unsigned)s_len);
 
+    // USB-CDC drops writes it cannot place in the TX buffer — it does not block
+    // and does not retry — so a host that falls behind silently loses whole
+    // lines mid-stream. Raising the TX timeout makes write() wait for space
+    // instead of discarding, and flushing periodically stops the buffer ever
+    // filling in the first place. Without this the frame arrives 99% complete
+    // with a few lines missing, which decodes to a shifted, corrupt image.
+#if ARDUINO_USB_CDC_ON_BOOT
+    Serial.setTxTimeoutMs(1000);
+#endif
+
     const uint8_t* p = s_buf;
     char line[kLineLen + 1];
     int  col   = 0;
@@ -79,15 +89,25 @@ static void dumpScreenshot(void) {
             line[col] = 0;
             Serial.println(line);
             col = 0;
-            // ~1MB of serial writes takes a second or two even over USB-CDC,
-            // and this runs on the task that owns the watchdog.
-            if ((++lines & 0x3F) == 0) esp_task_wdt_reset();
+            // ~1MB of serial writes, on the task that owns the watchdog. The
+            // flush drains the CDC buffer so it never overflows; the yield lets
+            // the USB stack actually run, which it cannot do if this loop hogs
+            // the core.
+            if ((++lines & 0x1F) == 0) {
+                Serial.flush();
+                esp_task_wdt_reset();
+                vTaskDelay(1);
+            }
         }
     }
     if (col) { line[col] = 0; Serial.println(line); }
 
     Serial.println("[/shot]");
+    Serial.flush();
     esp_task_wdt_reset();
+#if ARDUINO_USB_CDC_ON_BOOT
+    Serial.setTxTimeoutMs(0);   // back to non-blocking so logging never stalls the UI
+#endif
 
     // Give the memory straight back. Holding 768KB of PSRAM permanently for a
     // feature used occasionally is not a trade worth making on a board that has

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -39,7 +39,7 @@ void screenshotCaptureHook(const uint8_t* px_map, const lv_area_t* area) {
         s_buf = (uint8_t*)heap_caps_malloc(need, MALLOC_CAP_SPIRAM);
         if (!s_buf) {
             s_request = false;
-            Serial.println("[shot] ERROR: could not allocate capture buffer");
+            Serial.println("[shot-err] could not allocate capture buffer");
             return;
         }
     }
@@ -111,9 +111,11 @@ void screenshotPoll(void) {
             cmd[n] = 0;
             if (n && strcmp(cmd, "screenshot") == 0) {
                 if (s_request) {
-                    Serial.println("[shot] already pending");
+                    Serial.println("[shot-busy] request already queued");
                 } else {
-                    s_request = true;   // the next full flush captures it
+                    s_request = true;
+                    lv_obj_t* scr = lv_screen_active();
+                    if (scr) lv_obj_invalidate(scr);   // force a flush to capture
                 }
             }
             n = 0;

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -14,10 +14,46 @@ static uint8_t*      s_buf     = nullptr;
 static size_t        s_len     = 0;
 static uint32_t      s_w = 0, s_h = 0;
 
-// Base64 line length. MUST be a multiple of 4: a base64 group is 4 characters
-// encoding 3 bytes, and splitting a group across a newline shifts every byte
-// that follows it.
+// Base64 payload per line. MUST be a multiple of 4: a base64 group is 4
+// characters encoding 3 bytes, and splitting a group across a newline shifts
+// every byte that follows it.
 static const int kLineLen = 76;
+static const int kPerLine = (kLineLen / 4) * 3;   // 57 source bytes per line
+
+// Every payload line carries its own index: "0A3F:AAAA...".
+//
+// Other FreeRTOS tasks print to this same port and nothing prevents one landing
+// in the middle of a payload line. That line is then unrecoverable — and
+// without an index there is no way to know WHICH line was damaged, so the frame
+// simply arrives short. With an index the host knows exactly which lines it is
+// missing and asks for those again, so a stray log line costs one retransmitted
+// line instead of the entire capture.
+static void emitLine(uint32_t idx, const char* payload) {
+    char out[8 + kLineLen + 1];
+    snprintf(out, sizeof(out), "%04X:%s", (unsigned)idx, payload);
+    Serial.println(out);
+}
+
+// Encode one line's worth of source bytes (57 -> 76 base64 characters).
+static void encodeLine(size_t byteOff, char* dst) {
+    static const char* B64 =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const uint8_t* p = s_buf;
+    int col = 0;
+    size_t end = byteOff + kPerLine;
+    if (end > s_len) end = s_len;
+
+    for (size_t i = byteOff; i < end; i += 3) {
+        uint32_t v = (uint32_t)p[i] << 16;
+        if (i + 1 < s_len) v |= (uint32_t)p[i + 1] << 8;
+        if (i + 2 < s_len) v |= p[i + 2];
+        dst[col++] = B64[(v >> 18) & 63];
+        dst[col++] = B64[(v >> 12) & 63];
+        dst[col++] = (i + 1 < s_len) ? B64[(v >> 6) & 63] : '=';
+        dst[col++] = (i + 2 < s_len) ? B64[ v        & 63] : '=';
+    }
+    dst[col] = 0;
+}
 
 void screenshotCaptureHook(const uint8_t* px_map, const lv_area_t* area) {
     // The entire cost of this feature on the hot path.
@@ -51,56 +87,42 @@ void screenshotCaptureHook(const uint8_t* px_map, const lv_area_t* area) {
     s_ready   = true;
 }
 
-static void dumpScreenshot(void) {
-    static const char* B64 =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static void releaseBuffer(void) {
+    if (s_buf) { heap_caps_free(s_buf); s_buf = nullptr; }
+    s_len   = 0;
+    s_ready = false;
+}
 
-    // The byte count goes in the header so the host can prove it received the
-    // whole thing. A truncated transfer otherwise decodes into a plausible-
-    // looking image with a corrupt tail, which is worse than a clear failure.
-    Serial.printf("[shot] %u %u %u\n", (unsigned)s_w, (unsigned)s_h, (unsigned)s_len);
+static void dumpScreenshot(void) {
+    const uint32_t nLines = (uint32_t)((s_len + kPerLine - 1) / kPerLine);
+
+    // The byte and line counts go in the header so the host can prove it
+    // received everything. A truncated transfer otherwise decodes into a
+    // plausible-looking image with a corrupt tail — worse than a clear failure.
+    Serial.printf("[shot] %u %u %u %u\n",
+                  (unsigned)s_w, (unsigned)s_h, (unsigned)s_len, (unsigned)nLines);
 
     // USB-CDC drops writes it cannot place in the TX buffer — it does not block
     // and does not retry — so a host that falls behind silently loses whole
-    // lines mid-stream. Raising the TX timeout makes write() wait for space
-    // instead of discarding, and flushing periodically stops the buffer ever
-    // filling in the first place. Without this the frame arrives 99% complete
-    // with a few lines missing, which decodes to a shifted, corrupt image.
+    // lines. Raising the TX timeout makes write() wait for space instead of
+    // discarding; flushing periodically stops the buffer ever filling.
 #if ARDUINO_USB_CDC_ON_BOOT
     Serial.setTxTimeoutMs(1000);
 #endif
 
-    const uint8_t* p = s_buf;
-    char line[kLineLen + 1];
-    int  col   = 0;
-    int  lines = 0;
+    char payload[kLineLen + 1];
+    for (uint32_t i = 0; i < nLines; i++) {
+        encodeLine((size_t)i * kPerLine, payload);
+        emitLine(i, payload);
 
-    for (size_t i = 0; i < s_len; i += 3) {
-        uint32_t v = (uint32_t)p[i] << 16;
-        if (i + 1 < s_len) v |= (uint32_t)p[i + 1] << 8;
-        if (i + 2 < s_len) v |= p[i + 2];
-
-        line[col++] = B64[(v >> 18) & 63];
-        line[col++] = B64[(v >> 12) & 63];
-        line[col++] = (i + 1 < s_len) ? B64[(v >> 6) & 63] : '=';
-        line[col++] = (i + 2 < s_len) ? B64[ v        & 63] : '=';
-
-        if (col >= kLineLen) {
-            line[col] = 0;
-            Serial.println(line);
-            col = 0;
-            // ~1MB of serial writes, on the task that owns the watchdog. The
-            // flush drains the CDC buffer so it never overflows; the yield lets
-            // the USB stack actually run, which it cannot do if this loop hogs
-            // the core.
-            if ((++lines & 0x1F) == 0) {
-                Serial.flush();
-                esp_task_wdt_reset();
-                vTaskDelay(1);
-            }
+        // Deliberately NO vTaskDelay here. Yielding hands the CPU to tasks that
+        // then print into the middle of a line, and every such line costs a
+        // retransmit. The watchdog needs the reset, not a yield.
+        if ((i & 0x1F) == 0) {
+            Serial.flush();
+            esp_task_wdt_reset();
         }
     }
-    if (col) { line[col] = 0; Serial.println(line); }
 
     Serial.println("[/shot]");
     Serial.flush();
@@ -109,33 +131,47 @@ static void dumpScreenshot(void) {
     Serial.setTxTimeoutMs(0);   // back to non-blocking so logging never stalls the UI
 #endif
 
-    // Give the memory straight back. Holding 768KB of PSRAM permanently for a
-    // feature used occasionally is not a trade worth making on a board that has
-    // had heap pressure problems.
-    heap_caps_free(s_buf);
-    s_buf = nullptr;
-    s_len = 0;
-    s_ready = false;
+    s_ready = false;   // buffer deliberately kept, for "shotline" retransmits
+}
+
+// Resend one line. The host asks for these when a log line has landed inside
+// one. The capture buffer is still held from the dump.
+static void resendLine(uint32_t idx) {
+    if (!s_buf || (size_t)idx * kPerLine >= s_len) {
+        Serial.printf("[shot-err] line %u unavailable\n", (unsigned)idx);
+        return;
+    }
+    char payload[kLineLen + 1];
+    encodeLine((size_t)idx * kPerLine, payload);
+    emitLine(idx, payload);
+    Serial.flush();
 }
 
 void screenshotPoll(void) {
     // A frame captured on a previous pass is ready — ship it.
     if (s_ready) { dumpScreenshot(); return; }
 
-    static char cmd[24];
+    static char cmd[32];
     static uint8_t n = 0;
 
     while (Serial.available()) {
         char c = (char)Serial.read();
         if (c == '\n' || c == '\r') {
             cmd[n] = 0;
-            if (n && strcmp(cmd, "screenshot") == 0) {
-                if (s_request) {
-                    Serial.println("[shot-busy] request already queued");
-                } else {
-                    s_request = true;
-                    lv_obj_t* scr = lv_screen_active();
-                    if (scr) lv_obj_invalidate(scr);   // force a flush to capture
+            if (n) {
+                if (strcmp(cmd, "screenshot") == 0) {
+                    if (s_request) {
+                        Serial.println("[shot-busy] request already queued");
+                    } else {
+                        releaseBuffer();                    // drop any previous frame
+                        s_request = true;
+                        lv_obj_t* scr = lv_screen_active();
+                        if (scr) lv_obj_invalidate(scr);    // force a flush to capture
+                    }
+                } else if (strncmp(cmd, "shotline ", 9) == 0) {
+                    resendLine((uint32_t)strtoul(cmd + 9, nullptr, 16));
+                } else if (strcmp(cmd, "shotfree") == 0) {
+                    releaseBuffer();
                 }
             }
             n = 0;

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -1,0 +1,126 @@
+#include "screenshot.h"
+#include "config.h"
+#include <esp_heap_caps.h>
+#include <esp_task_wdt.h>
+
+// ── State shared between the flush callback and the main task ───────────────
+// s_request is set by the serial command and cleared by the flush callback;
+// s_ready is set by the flush callback and cleared by the dump. Both are single
+// writer / single reader in each direction, so a plain volatile bool is enough
+// and no mutex is needed on the flush path (which must stay cheap).
+static volatile bool s_request = false;
+static volatile bool s_ready   = false;
+static uint8_t*      s_buf     = nullptr;
+static size_t        s_len     = 0;
+static uint32_t      s_w = 0, s_h = 0;
+
+// Base64 line length. MUST be a multiple of 4: a base64 group is 4 characters
+// encoding 3 bytes, and splitting a group across a newline shifts every byte
+// that follows it.
+static const int kLineLen = 76;
+
+void screenshotCaptureHook(const uint8_t* px_map, const lv_area_t* area) {
+    // The entire cost of this feature on the hot path.
+    if (!s_request || s_ready) return;
+
+    // With LV_DISPLAY_RENDER_MODE_FULL this is always the whole screen, but a
+    // partial area would mean copying DISPLAY_WIDTH*DISPLAY_HEIGHT out of a
+    // smaller buffer — a read overrun. Leave the request pending and try again
+    // on the next flush rather than capture a torn or short frame.
+    const uint32_t w = (uint32_t)(area->x2 - area->x1 + 1);
+    const uint32_t h = (uint32_t)(area->y2 - area->y1 + 1);
+    if (w != DISPLAY_WIDTH || h != DISPLAY_HEIGHT) return;
+
+    const size_t need = (size_t)w * h * 2;   // RGB565, LV_COLOR_DEPTH 16
+
+    if (!s_buf) {
+        // PSRAM deliberately: this is 768KB on the 4" and 1.2MB on the 7", and
+        // internal DMA-capable heap is the scarce resource on this board.
+        s_buf = (uint8_t*)heap_caps_malloc(need, MALLOC_CAP_SPIRAM);
+        if (!s_buf) {
+            s_request = false;
+            Serial.println("[shot] ERROR: could not allocate capture buffer");
+            return;
+        }
+    }
+
+    memcpy(s_buf, px_map, need);
+    s_w = w; s_h = h; s_len = need;
+
+    s_request = false;
+    s_ready   = true;
+}
+
+static void dumpScreenshot(void) {
+    static const char* B64 =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    // The byte count goes in the header so the host can prove it received the
+    // whole thing. A truncated transfer otherwise decodes into a plausible-
+    // looking image with a corrupt tail, which is worse than a clear failure.
+    Serial.printf("[shot] %u %u %u\n", (unsigned)s_w, (unsigned)s_h, (unsigned)s_len);
+
+    const uint8_t* p = s_buf;
+    char line[kLineLen + 1];
+    int  col   = 0;
+    int  lines = 0;
+
+    for (size_t i = 0; i < s_len; i += 3) {
+        uint32_t v = (uint32_t)p[i] << 16;
+        if (i + 1 < s_len) v |= (uint32_t)p[i + 1] << 8;
+        if (i + 2 < s_len) v |= p[i + 2];
+
+        line[col++] = B64[(v >> 18) & 63];
+        line[col++] = B64[(v >> 12) & 63];
+        line[col++] = (i + 1 < s_len) ? B64[(v >> 6) & 63] : '=';
+        line[col++] = (i + 2 < s_len) ? B64[ v        & 63] : '=';
+
+        if (col >= kLineLen) {
+            line[col] = 0;
+            Serial.println(line);
+            col = 0;
+            // ~1MB of serial writes takes a second or two even over USB-CDC,
+            // and this runs on the task that owns the watchdog.
+            if ((++lines & 0x3F) == 0) esp_task_wdt_reset();
+        }
+    }
+    if (col) { line[col] = 0; Serial.println(line); }
+
+    Serial.println("[/shot]");
+    esp_task_wdt_reset();
+
+    // Give the memory straight back. Holding 768KB of PSRAM permanently for a
+    // feature used occasionally is not a trade worth making on a board that has
+    // had heap pressure problems.
+    heap_caps_free(s_buf);
+    s_buf = nullptr;
+    s_len = 0;
+    s_ready = false;
+}
+
+void screenshotPoll(void) {
+    // A frame captured on a previous pass is ready — ship it.
+    if (s_ready) { dumpScreenshot(); return; }
+
+    static char cmd[24];
+    static uint8_t n = 0;
+
+    while (Serial.available()) {
+        char c = (char)Serial.read();
+        if (c == '\n' || c == '\r') {
+            cmd[n] = 0;
+            if (n && strcmp(cmd, "screenshot") == 0) {
+                if (s_request) {
+                    Serial.println("[shot] already pending");
+                } else {
+                    s_request = true;   // the next full flush captures it
+                }
+            }
+            n = 0;
+        } else if (n < sizeof(cmd) - 1) {
+            cmd[n++] = c;
+        } else {
+            n = 0;   // overlong garbage — resync on the next newline
+        }
+    }
+}

--- a/tools/screenshot.py
+++ b/tools/screenshot.py
@@ -30,7 +30,17 @@ except ImportError:
 # Payload lines are "XXXX:<base64>". The index is what makes recovery possible:
 # other FreeRTOS tasks print to the same port and can land inside a line, and
 # without an index there is no way to know which line was damaged.
-PAY_RE = re.compile(rb"^([0-9A-Fa-f]{4}):([A-Za-z0-9+/]+={0,2})$")
+#
+# Deliberately NOT anchored at the end. Another task's log output regularly
+# lands between the payload and println's newline, giving lines like:
+#
+#   1B24:wxjDGMMY...wxjD[SOAP/DMA] #3040: pre=136KB post=136KB
+#
+# The base64 in front of that is complete and correct. Requiring the whole line
+# to be base64 threw away good data, and because the interfering log repeats
+# constantly, re-requesting the line hit exactly the same problem. Take the
+# leading base64 run and ignore whatever followed it.
+PAY_RE = re.compile(rb"^([0-9A-Fa-f]{4}):([A-Za-z0-9+/]*={0,2})")
 
 # Match the header by shape rather than splitting on "[shot]". The firmware also
 # emits [shot-busy] and [shot-err] status lines, and a bare split on the marker
@@ -69,12 +79,32 @@ def read_until_quiet(port, timeout, progress=False, seen=0):
     return b"".join(chunks), got
 
 
-def harvest(buf, lines):
-    """Pull every intact indexed payload line out of `buf` into `lines`."""
+def harvest(buf, lines, n_lines=None, expect=None):
+    """Pull every usable indexed payload line out of `buf` into `lines`.
+
+    A line is accepted only if the leading base64 run is the full length that
+    index should carry, so a log spliced into the MIDDLE (which truncates the
+    run) is still rejected and re-requested, while one appended to the END is
+    simply ignored.
+    """
     for raw in buf.splitlines():
         m = PAY_RE.match(raw.strip())
-        if m:
-            lines[int(m.group(1), 16)] = m.group(2)
+        if not m:
+            continue
+        idx, payload = int(m.group(1), 16), m.group(2)
+        if n_lines is not None and expect is not None:
+            want = 76 if idx < n_lines - 1 else _tail_chars(expect)
+            if len(payload) != want:
+                continue
+        elif len(payload) != 76:
+            continue
+        lines[idx] = payload
+
+
+def _tail_chars(total_bytes):
+    """base64 characters in the final (possibly short) line."""
+    rem = total_bytes % PER_LINE or PER_LINE
+    return ((rem + 2) // 3) * 4
 
 
 def diagnose(blob, idx, lines, n_lines):
@@ -138,7 +168,7 @@ def capture(port_name, baud, timeout, progress=True, retries=3, raw_path=None):
         w, h, expect, n_lines = (int(m.group(i)) for i in (1, 2, 3, 4))
 
         lines = {}
-        harvest(buf[m.end():], lines)
+        harvest(buf[m.end():], lines, n_lines, expect)
 
         # Re-request only what is missing. A log line printed by another task
         # mid-dump corrupts exactly the line it landed in; asking for that one
@@ -159,7 +189,7 @@ def capture(port_name, baud, timeout, progress=True, retries=3, raw_path=None):
                     port.write(b"shotline %04X\n" % idx)
                 port.flush()
                 more, _ = read_until_quiet(port, 1.5)
-                harvest(more, lines)
+                harvest(more, lines, n_lines, expect)
                 if raw is not None:
                     raw.append(more)
 

--- a/tools/screenshot.py
+++ b/tools/screenshot.py
@@ -77,7 +77,33 @@ def harvest(buf, lines):
             lines[int(m.group(1), 16)] = m.group(2)
 
 
-def capture(port_name, baud, timeout, progress=True, retries=3):
+def diagnose(blob, idx, lines, n_lines):
+    """Explain a line that never arrived intact, using what is actually there."""
+    out = []
+    tag = b"%04X:" % idx
+    hits = [m.start() for m in re.finditer(re.escape(tag), blob)]
+    out.append("  index %04X appeared %d time(s) in the stream" % (idx, len(hits)))
+    for pos in hits[:3]:
+        end = blob.find(b"\n", pos)
+        seg = blob[pos:end if end != -1 else pos + 120]
+        out.append("    %r" % seg[:120])
+    if not hits:
+        # Never sent at all, or lost wholesale. Show the neighbours so we can
+        # see whether the stream simply jumps over it.
+        for probe in (idx - 1, idx + 1):
+            if 0 <= probe < n_lines:
+                t = b"%04X:" % probe
+                out.append("    neighbour %04X present: %s"
+                           % (probe, "yes" if t in blob else "no"))
+    got = len(lines)
+    out.append("  recovered %d of %d lines; stream held %d bytes"
+               % (got, n_lines, len(blob)))
+    return "\n".join(out)
+
+
+def capture(port_name, baud, timeout, progress=True, retries=3, raw_path=None):
+    raw = [] if raw_path else None
+
     with serial.Serial(port_name, baud, timeout=0.1) as port:
         time.sleep(0.2)
         port.reset_input_buffer()
@@ -85,6 +111,8 @@ def capture(port_name, baud, timeout, progress=True, retries=3):
         port.flush()
 
         buf, got = read_until_quiet(port, timeout, progress)
+        if raw is not None:
+            raw.append(buf)
         if not buf.strip():
             port.write(CMD)          # first one may have been missed
             port.flush()
@@ -122,21 +150,37 @@ def capture(port_name, baud, timeout, progress=True, retries=3):
             if progress:
                 sys.stderr.write("\r  recovering %d damaged line%s\n"
                                  % (len(missing), "" if len(missing) == 1 else "s"))
-            for idx in missing:
-                port.write(b"shotline %04X\n" % idx)
-            port.flush()
-            more, _ = read_until_quiet(port, max(2.0, timeout / 3))
-            harvest(more, lines)
+            # Send in small batches. The board's CDC receive buffer is a few
+            # hundred bytes, so 92 requests in one burst (~1.4KB) overflows it
+            # and most are never read. That is why large recoveries crawled
+            # (92 -> 91 -> 89) rather than completing in one round.
+            for start in range(0, len(missing), 8):
+                for idx in missing[start:start + 8]:
+                    port.write(b"shotline %04X\n" % idx)
+                port.flush()
+                more, _ = read_until_quiet(port, 1.5)
+                harvest(more, lines)
+                if raw is not None:
+                    raw.append(more)
 
         port.write(b"shotfree\n")     # let the board free its 768KB capture buffer
         port.flush()
 
+    if raw_path:
+        with open(raw_path, "wb") as f:
+            f.write(b"".join(raw))
+        sys.stderr.write("  raw stream written to %s\n" % raw_path)
+
     missing = [i for i in range(n_lines) if i not in lines]
     if missing:
+        # Show what actually arrived where the line should have been rather
+        # than asserting a cause: absent, truncated and corrupted look
+        # different, and only one of them is fixable by re-requesting.
+        blob = b"".join(raw) if raw else buf
         raise RuntimeError(
-            "%d of %d lines could not be recovered (first: %d). Re-run; if it "
-            "persists, close any serial monitor sharing the port."
-            % (len(missing), n_lines, missing[0]))
+            "%d of %d lines could not be recovered (first: %d)\n%s"
+            % (len(missing), n_lines, missing[0],
+               diagnose(blob, missing[0], lines, n_lines)))
 
     b64 = b"".join(lines[i] for i in range(n_lines))
     data = base64.b64decode(b64 + b"=" * (-len(b64) % 4))
@@ -177,12 +221,15 @@ def main():
                     help="nearest-neighbour upscale (2 = crisp 2x for docs)")
     ap.add_argument("--retries", type=int, default=3,
                     help="rounds of re-requesting damaged lines")
+    ap.add_argument("--raw", metavar="FILE",
+                    help="save the raw serial stream for diagnosis")
     ap.add_argument("-q", "--quiet", action="store_true", help="suppress progress")
     a = ap.parse_args()
 
     try:
         data, w, h = capture(a.port, a.baud, a.timeout,
-                             progress=not a.quiet, retries=a.retries)
+                             progress=not a.quiet, retries=a.retries,
+                             raw_path=a.raw)
     except Exception as e:
         print("error: %s" % e, file=sys.stderr)
         return 1

--- a/tools/screenshot.py
+++ b/tools/screenshot.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Grab a screenshot off a running SonosESP over the serial port.
 
-    python tools/screenshot.py COM7 docs/public/shots/player.png
-    python tools/screenshot.py COM7 out.png --scale 2
+    python tools/screenshot.py COM9 docs/public/shots/player.png
+    python tools/screenshot.py COM9 out.png --scale 2
 
 Sends "screenshot", collects the base64 frame the firmware dumps between the
 [shot] and [/shot] markers, and writes a PNG.
@@ -26,14 +26,20 @@ except ImportError:
     sys.exit("Pillow missing:  pip install pillow")
 
 
-# A valid payload line is nothing but base64 and, on this firmware, always 76
-# characters except the last. Log lines from other FreeRTOS tasks can land in
-# the middle of the dump, so lines are matched rather than merely un-prefixed.
+# A valid payload line is nothing but base64. Log lines from other FreeRTOS
+# tasks can land in the middle of the dump, so lines are matched rather than
+# merely un-prefixed.
 LINE_RE = re.compile(rb"^[A-Za-z0-9+/]+={0,2}$")
+
+# Match the header by shape rather than splitting on "[shot]". The firmware also
+# emits [shot-busy] and [shot-err] status lines, and a bare split on the marker
+# will happily parse one of those as the header instead.
+HDR_RE = re.compile(rb"\[shot\] (\d+) (\d+) (\d+)[^\n]*\n")
+ERR_RE = re.compile(rb"\[shot-err\]([^\r\n]*)")
 
 
 def capture(port_name: str, baud: int, timeout: float) -> tuple[bytes, int, int]:
-    # baudrate is ignored by native USB-CDC but matters if you are on the UART.
+    # baudrate is ignored by native USB-CDC but matters on the UART.
     with serial.Serial(port_name, baud, timeout=0.1) as port:
         time.sleep(0.2)
         port.reset_input_buffer()
@@ -42,36 +48,44 @@ def capture(port_name: str, baud: int, timeout: float) -> tuple[bytes, int, int]
 
         # NEVER readline() here. It returns a partial line when its timeout
         # expires mid-transfer, and a truncated base64 line silently drops
-        # bytes — you get an image with a corrupt tail and no error. Read raw
-        # chunks and split on newlines afterwards.
+        # bytes - you get an image with a corrupt tail and no error raised.
+        # Read raw chunks and split on newlines afterwards.
         buf = b""
         deadline = time.time() + timeout
+        nudged = False
         while time.time() < deadline:
             chunk = port.read(4096)
             if chunk:
                 buf += chunk
                 if b"[/shot]" in buf:
                     break
-            elif b"[shot]" not in buf:
-                port.write(b"screenshot\n")   # missed the first one; nudge
+            elif not nudged and b"[shot" not in buf:
+                port.write(b"screenshot\n")   # first one may have been missed
                 port.flush()
+                nudged = True
                 time.sleep(0.3)
 
-    if b"[shot]" not in buf:
+    err = ERR_RE.search(buf)
+    if err:
+        raise RuntimeError("firmware:" + err.group(1).decode(errors="replace"))
+
+    m = HDR_RE.search(buf)
+    if not m:
+        if b"[shot" in buf:
+            raise RuntimeError(
+                "firmware acknowledged the command but sent no frame. If it "
+                "reported 'already queued', an earlier request is still waiting "
+                "on a redraw - power-cycle the board and retry."
+            )
         raise RuntimeError(
-            "no [shot] marker seen — is the firmware built with screenshot "
+            "no [shot] header seen - is the firmware built with screenshot "
             "support, and is anything else holding the port open?"
         )
     if b"[/shot]" not in buf:
-        raise RuntimeError(f"transfer did not finish within {timeout:.0f}s")
+        raise RuntimeError("transfer did not finish within %.0fs" % timeout)
 
-    body = buf.split(b"[shot]", 1)[1].split(b"[/shot]", 1)[0]
-    header, _, payload = body.partition(b"\n")
-
-    parts = header.split()
-    if len(parts) < 3:
-        raise RuntimeError(f"bad header: {header!r}")
-    w, h, expect = int(parts[0]), int(parts[1]), int(parts[2])
+    w, h, expect = int(m.group(1)), int(m.group(2)), int(m.group(3))
+    payload = buf[m.end():].split(b"[/shot]", 1)[0]
 
     b64 = b"".join(l for l in (x.strip() for x in payload.splitlines())
                    if l and LINE_RE.match(l))
@@ -81,9 +95,9 @@ def capture(port_name: str, baud: int, timeout: float) -> tuple[bytes, int, int]
     # short read produces a plausible-looking image with a corrupt tail.
     if len(data) != expect:
         raise RuntimeError(
-            f"incomplete transfer: got {len(data)} of {expect} bytes "
-            f"({expect - len(data)} missing). Re-run; if it persists, close "
-            f"any serial monitor sharing the port."
+            "incomplete transfer: got %d of %d bytes (%d missing). Re-run; if "
+            "it persists, close any serial monitor sharing the port."
+            % (len(data), expect, expect - len(data))
         )
     return data, w, h
 
@@ -91,7 +105,7 @@ def capture(port_name: str, baud: int, timeout: float) -> tuple[bytes, int, int]
 def to_png(data: bytes, w: int, h: int, path: str, scale: int) -> None:
     # RGB565 little-endian (LV_COLOR_DEPTH 16, LV_COLOR_16_SWAP 0) -> RGB888.
     # The *255//31 form maps 31 to a true 255; a plain <<3 leaves white at 248
-    # and everything looks faintly grey.
+    # and the whole image reads faintly grey.
     out = bytearray(w * h * 3)
     for i in range(w * h):
         v = data[i * 2] | (data[i * 2 + 1] << 8)
@@ -108,7 +122,7 @@ def to_png(data: bytes, w: int, h: int, path: str, scale: int) -> None:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("port", help="serial port, e.g. COM7 or /dev/ttyACM0")
+    ap.add_argument("port", help="serial port, e.g. COM9 or /dev/ttyACM0")
     ap.add_argument("out", nargs="?", default="screenshot.png", help="output PNG")
     ap.add_argument("--baud", type=int, default=115200)
     ap.add_argument("--timeout", type=float, default=30.0)
@@ -119,12 +133,12 @@ def main() -> int:
     try:
         data, w, h = capture(a.port, a.baud, a.timeout)
     except Exception as e:
-        print(f"error: {e}", file=sys.stderr)
+        print("error: %s" % e, file=sys.stderr)
         return 1
 
     to_png(data, w, h, a.out, a.scale)
-    px = f"{w}x{h}" if a.scale == 1 else f"{w}x{h} -> {w*a.scale}x{h*a.scale}"
-    print(f"{a.out}  ({px})")
+    px = "%dx%d" % (w, h) if a.scale == 1 else "%dx%d -> %dx%d" % (w, h, w * a.scale, h * a.scale)
+    print("%s  (%s)" % (a.out, px))
     return 0
 
 

--- a/tools/screenshot.py
+++ b/tools/screenshot.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Grab a screenshot off a running SonosESP over the serial port.
+
+    python tools/screenshot.py COM7 docs/public/shots/player.png
+    python tools/screenshot.py COM7 out.png --scale 2
+
+Sends "screenshot", collects the base64 frame the firmware dumps between the
+[shot] and [/shot] markers, and writes a PNG.
+
+Requires: pyserial, Pillow.  (pip install pyserial pillow)
+"""
+
+import argparse
+import base64
+import re
+import sys
+import time
+
+try:
+    import serial
+except ImportError:
+    sys.exit("pyserial missing:  pip install pyserial")
+try:
+    from PIL import Image
+except ImportError:
+    sys.exit("Pillow missing:  pip install pillow")
+
+
+# A valid payload line is nothing but base64 and, on this firmware, always 76
+# characters except the last. Log lines from other FreeRTOS tasks can land in
+# the middle of the dump, so lines are matched rather than merely un-prefixed.
+LINE_RE = re.compile(rb"^[A-Za-z0-9+/]+={0,2}$")
+
+
+def capture(port_name: str, baud: int, timeout: float) -> tuple[bytes, int, int]:
+    # baudrate is ignored by native USB-CDC but matters if you are on the UART.
+    with serial.Serial(port_name, baud, timeout=0.1) as port:
+        time.sleep(0.2)
+        port.reset_input_buffer()
+        port.write(b"screenshot\n")
+        port.flush()
+
+        # NEVER readline() here. It returns a partial line when its timeout
+        # expires mid-transfer, and a truncated base64 line silently drops
+        # bytes — you get an image with a corrupt tail and no error. Read raw
+        # chunks and split on newlines afterwards.
+        buf = b""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            chunk = port.read(4096)
+            if chunk:
+                buf += chunk
+                if b"[/shot]" in buf:
+                    break
+            elif b"[shot]" not in buf:
+                port.write(b"screenshot\n")   # missed the first one; nudge
+                port.flush()
+                time.sleep(0.3)
+
+    if b"[shot]" not in buf:
+        raise RuntimeError(
+            "no [shot] marker seen — is the firmware built with screenshot "
+            "support, and is anything else holding the port open?"
+        )
+    if b"[/shot]" not in buf:
+        raise RuntimeError(f"transfer did not finish within {timeout:.0f}s")
+
+    body = buf.split(b"[shot]", 1)[1].split(b"[/shot]", 1)[0]
+    header, _, payload = body.partition(b"\n")
+
+    parts = header.split()
+    if len(parts) < 3:
+        raise RuntimeError(f"bad header: {header!r}")
+    w, h, expect = int(parts[0]), int(parts[1]), int(parts[2])
+
+    b64 = b"".join(l for l in (x.strip() for x in payload.splitlines())
+                   if l and LINE_RE.match(l))
+    data = base64.b64decode(b64)
+
+    # The firmware sends its byte count for exactly this check. Without it a
+    # short read produces a plausible-looking image with a corrupt tail.
+    if len(data) != expect:
+        raise RuntimeError(
+            f"incomplete transfer: got {len(data)} of {expect} bytes "
+            f"({expect - len(data)} missing). Re-run; if it persists, close "
+            f"any serial monitor sharing the port."
+        )
+    return data, w, h
+
+
+def to_png(data: bytes, w: int, h: int, path: str, scale: int) -> None:
+    # RGB565 little-endian (LV_COLOR_DEPTH 16, LV_COLOR_16_SWAP 0) -> RGB888.
+    # The *255//31 form maps 31 to a true 255; a plain <<3 leaves white at 248
+    # and everything looks faintly grey.
+    out = bytearray(w * h * 3)
+    for i in range(w * h):
+        v = data[i * 2] | (data[i * 2 + 1] << 8)
+        out[i * 3]     = ((v >> 11) & 0x1F) * 255 // 31
+        out[i * 3 + 1] = ((v >> 5)  & 0x3F) * 255 // 63
+        out[i * 3 + 2] = ( v        & 0x1F) * 255 // 31
+
+    img = Image.frombytes("RGB", (w, h), bytes(out))
+    if scale > 1:
+        img = img.resize((w * scale, h * scale), Image.NEAREST)
+    img.save(path, optimize=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("port", help="serial port, e.g. COM7 or /dev/ttyACM0")
+    ap.add_argument("out", nargs="?", default="screenshot.png", help="output PNG")
+    ap.add_argument("--baud", type=int, default=115200)
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--scale", type=int, default=1,
+                    help="nearest-neighbour upscale (2 = crisp 2x for docs)")
+    a = ap.parse_args()
+
+    try:
+        data, w, h = capture(a.port, a.baud, a.timeout)
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    to_png(data, w, h, a.out, a.scale)
+    px = f"{w}x{h}" if a.scale == 1 else f"{w}x{h} -> {w*a.scale}x{h*a.scale}"
+    print(f"{a.out}  ({px})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/screenshot.py
+++ b/tools/screenshot.py
@@ -4,8 +4,9 @@
     python tools/screenshot.py COM9 docs/public/shots/player.png
     python tools/screenshot.py COM9 out.png --scale 2
 
-Sends "screenshot", collects the base64 frame the firmware dumps between the
-[shot] and [/shot] markers, and writes a PNG.
+Sends "screenshot", collects the indexed base64 frame the firmware dumps between
+the [shot] and [/shot] markers, re-requests any line that arrived damaged, and
+writes a PNG.
 
 Requires: pyserial, Pillow.  (pip install pyserial pillow)
 """
@@ -26,101 +27,123 @@ except ImportError:
     sys.exit("Pillow missing:  pip install pillow")
 
 
-# A valid payload line is nothing but base64. Log lines from other FreeRTOS
-# tasks can land in the middle of the dump, so lines are matched rather than
-# merely un-prefixed.
-LINE_RE = re.compile(rb"^[A-Za-z0-9+/]+={0,2}$")
+# Payload lines are "XXXX:<base64>". The index is what makes recovery possible:
+# other FreeRTOS tasks print to the same port and can land inside a line, and
+# without an index there is no way to know which line was damaged.
+PAY_RE = re.compile(rb"^([0-9A-Fa-f]{4}):([A-Za-z0-9+/]+={0,2})$")
 
 # Match the header by shape rather than splitting on "[shot]". The firmware also
 # emits [shot-busy] and [shot-err] status lines, and a bare split on the marker
 # will happily parse one of those as the header instead.
-HDR_RE = re.compile(rb"\[shot\] (\d+) (\d+) (\d+)[^\n]*\n")
+HDR_RE = re.compile(rb"\[shot\] (\d+) (\d+) (\d+) (\d+)[^\n]*\n")
 ERR_RE = re.compile(rb"\[shot-err\]([^\r\n]*)")
 
 CMD = b"screenshot\n"
+PER_LINE = 57          # source bytes encoded per line (76 base64 chars)
 
 
-def capture(port_name, baud, timeout, progress=True):
-    # baudrate is ignored by native USB-CDC but matters on the UART.
+def read_until_quiet(port, timeout, progress=False, seen=0):
+    """Read raw chunks until the port goes quiet for `timeout` seconds.
+
+    NEVER readline() here: it returns a PARTIAL line when its timeout expires
+    mid-transfer, so a truncated base64 line silently drops bytes.
+
+    The timeout is an IDLE timeout, not a total one. A frame is ~1MB of base64
+    and how long that takes depends on the link; a fixed overall deadline just
+    truncates the transfer and reports it as missing bytes.
+    """
+    chunks = []
+    got = 0
+    last = time.time()
+    while time.time() - last < timeout:
+        chunk = port.read(65536)
+        if chunk:
+            chunks.append(chunk)
+            got += len(chunk)
+            last = time.time()
+            if progress:
+                sys.stderr.write("\r  %d KB" % ((seen + got) // 1024))
+                sys.stderr.flush()
+            if b"[/shot]" in chunk:
+                break
+    return b"".join(chunks), got
+
+
+def harvest(buf, lines):
+    """Pull every intact indexed payload line out of `buf` into `lines`."""
+    for raw in buf.splitlines():
+        m = PAY_RE.match(raw.strip())
+        if m:
+            lines[int(m.group(1), 16)] = m.group(2)
+
+
+def capture(port_name, baud, timeout, progress=True, retries=3):
     with serial.Serial(port_name, baud, timeout=0.1) as port:
         time.sleep(0.2)
         port.reset_input_buffer()
         port.write(CMD)
         port.flush()
 
-        # Two things matter in this loop.
-        #
-        # NEVER readline(). It returns a PARTIAL line when its timeout expires
-        # mid-transfer, so a truncated base64 line silently drops bytes and you
-        # get a corrupt tail with no error raised. Read raw chunks, split later.
-        #
-        # And the timeout is an IDLE timeout, not a total one. A frame is ~1MB
-        # of base64 and how long that takes depends on the link; a fixed overall
-        # deadline just truncates the transfer and then reports it as missing
-        # bytes, which looks like corruption but is only impatience.
-        chunks = []
-        got = 0
-        last = time.time()
-        nudged = False
-        while time.time() - last < timeout:
-            chunk = port.read(65536)
-            if chunk:
-                chunks.append(chunk)
-                got += len(chunk)
-                last = time.time()
-                if progress:
-                    sys.stderr.write("\r  %d KB" % (got // 1024))
-                    sys.stderr.flush()
-                if b"[/shot]" in chunk:
-                    break
-            elif not nudged and not chunks:
-                port.write(CMD)          # first one may have been missed
-                port.flush()
-                nudged = True
-                time.sleep(0.3)
+        buf, got = read_until_quiet(port, timeout, progress)
+        if not buf.strip():
+            port.write(CMD)          # first one may have been missed
+            port.flush()
+            more, n = read_until_quiet(port, timeout, progress, got)
+            buf += more
+            got += n
 
-        buf = b"".join(chunks)
-        if progress and got:
-            sys.stderr.write("\r  %d KB received\n" % (got // 1024))
+        err = ERR_RE.search(buf)
+        if err:
+            raise RuntimeError("firmware:" + err.group(1).decode(errors="replace"))
 
-    err = ERR_RE.search(buf)
-    if err:
-        raise RuntimeError("firmware:" + err.group(1).decode(errors="replace"))
-
-    m = HDR_RE.search(buf)
-    if not m:
-        if b"[shot" in buf:
+        m = HDR_RE.search(buf)
+        if not m:
+            if b"[shot" in buf:
+                raise RuntimeError(
+                    "firmware acknowledged the command but sent no frame. If it "
+                    "reported 'already queued', an earlier request is still "
+                    "waiting on a redraw - power-cycle the board and retry.")
             raise RuntimeError(
-                "firmware acknowledged the command but sent no frame. If it "
-                "reported 'already queued', an earlier request is still waiting "
-                "on a redraw - power-cycle the board and retry."
-            )
-        raise RuntimeError(
-            "no [shot] header seen - is the firmware built with screenshot "
-            "support, and is anything else holding the port open?"
-        )
-    if b"[/shot]" not in buf:
-        raise RuntimeError(
-            "transfer stalled: %.0fs of silence with no [/shot] marker. It "
-            "started arriving then stopped - close any serial monitor on the "
-            "port, or raise --timeout." % timeout
-        )
+                "no [shot] header seen - is the firmware built with screenshot "
+                "support, and is anything else holding the port open?")
 
-    w, h, expect = int(m.group(1)), int(m.group(2)), int(m.group(3))
-    payload = buf[m.end():].split(b"[/shot]", 1)[0]
+        w, h, expect, n_lines = (int(m.group(i)) for i in (1, 2, 3, 4))
 
-    b64 = b"".join(l for l in (x.strip() for x in payload.splitlines())
-                   if l and LINE_RE.match(l))
+        lines = {}
+        harvest(buf[m.end():], lines)
+
+        # Re-request only what is missing. A log line printed by another task
+        # mid-dump corrupts exactly the line it landed in; asking for that one
+        # again costs milliseconds instead of a whole 1MB recapture.
+        for attempt in range(retries):
+            missing = [i for i in range(n_lines) if i not in lines]
+            if not missing:
+                break
+            if progress:
+                sys.stderr.write("\r  recovering %d damaged line%s\n"
+                                 % (len(missing), "" if len(missing) == 1 else "s"))
+            for idx in missing:
+                port.write(b"shotline %04X\n" % idx)
+            port.flush()
+            more, _ = read_until_quiet(port, max(2.0, timeout / 3))
+            harvest(more, lines)
+
+        port.write(b"shotfree\n")     # let the board free its 768KB capture buffer
+        port.flush()
+
+    missing = [i for i in range(n_lines) if i not in lines]
+    if missing:
+        raise RuntimeError(
+            "%d of %d lines could not be recovered (first: %d). Re-run; if it "
+            "persists, close any serial monitor sharing the port."
+            % (len(missing), n_lines, missing[0]))
+
+    b64 = b"".join(lines[i] for i in range(n_lines))
     data = base64.b64decode(b64 + b"=" * (-len(b64) % 4))
 
-    # The firmware sends its byte count for exactly this check. Without it a
-    # short read produces a plausible-looking image with a corrupt tail.
     if len(data) != expect:
-        raise RuntimeError(
-            "incomplete transfer: got %d of %d bytes (%d missing). The board "
-            "dropped serial writes - reflash with the current firmware, which "
-            "flushes as it sends." % (len(data), expect, expect - len(data))
-        )
+        raise RuntimeError("length mismatch: decoded %d, header said %d"
+                           % (len(data), expect))
     return data, w, h
 
 
@@ -152,11 +175,14 @@ def main():
                     help="seconds of SILENCE before giving up (not a total limit)")
     ap.add_argument("--scale", type=int, default=1,
                     help="nearest-neighbour upscale (2 = crisp 2x for docs)")
+    ap.add_argument("--retries", type=int, default=3,
+                    help="rounds of re-requesting damaged lines")
     ap.add_argument("-q", "--quiet", action="store_true", help="suppress progress")
     a = ap.parse_args()
 
     try:
-        data, w, h = capture(a.port, a.baud, a.timeout, progress=not a.quiet)
+        data, w, h = capture(a.port, a.baud, a.timeout,
+                             progress=not a.quiet, retries=a.retries)
     except Exception as e:
         print("error: %s" % e, file=sys.stderr)
         return 1

--- a/tools/screenshot.py
+++ b/tools/screenshot.py
@@ -37,33 +37,51 @@ LINE_RE = re.compile(rb"^[A-Za-z0-9+/]+={0,2}$")
 HDR_RE = re.compile(rb"\[shot\] (\d+) (\d+) (\d+)[^\n]*\n")
 ERR_RE = re.compile(rb"\[shot-err\]([^\r\n]*)")
 
+CMD = b"screenshot\n"
 
-def capture(port_name: str, baud: int, timeout: float) -> tuple[bytes, int, int]:
+
+def capture(port_name, baud, timeout, progress=True):
     # baudrate is ignored by native USB-CDC but matters on the UART.
     with serial.Serial(port_name, baud, timeout=0.1) as port:
         time.sleep(0.2)
         port.reset_input_buffer()
-        port.write(b"screenshot\n")
+        port.write(CMD)
         port.flush()
 
-        # NEVER readline() here. It returns a partial line when its timeout
-        # expires mid-transfer, and a truncated base64 line silently drops
-        # bytes - you get an image with a corrupt tail and no error raised.
-        # Read raw chunks and split on newlines afterwards.
-        buf = b""
-        deadline = time.time() + timeout
+        # Two things matter in this loop.
+        #
+        # NEVER readline(). It returns a PARTIAL line when its timeout expires
+        # mid-transfer, so a truncated base64 line silently drops bytes and you
+        # get a corrupt tail with no error raised. Read raw chunks, split later.
+        #
+        # And the timeout is an IDLE timeout, not a total one. A frame is ~1MB
+        # of base64 and how long that takes depends on the link; a fixed overall
+        # deadline just truncates the transfer and then reports it as missing
+        # bytes, which looks like corruption but is only impatience.
+        chunks = []
+        got = 0
+        last = time.time()
         nudged = False
-        while time.time() < deadline:
-            chunk = port.read(4096)
+        while time.time() - last < timeout:
+            chunk = port.read(65536)
             if chunk:
-                buf += chunk
-                if b"[/shot]" in buf:
+                chunks.append(chunk)
+                got += len(chunk)
+                last = time.time()
+                if progress:
+                    sys.stderr.write("\r  %d KB" % (got // 1024))
+                    sys.stderr.flush()
+                if b"[/shot]" in chunk:
                     break
-            elif not nudged and b"[shot" not in buf:
-                port.write(b"screenshot\n")   # first one may have been missed
+            elif not nudged and not chunks:
+                port.write(CMD)          # first one may have been missed
                 port.flush()
                 nudged = True
                 time.sleep(0.3)
+
+        buf = b"".join(chunks)
+        if progress and got:
+            sys.stderr.write("\r  %d KB received\n" % (got // 1024))
 
     err = ERR_RE.search(buf)
     if err:
@@ -82,27 +100,31 @@ def capture(port_name: str, baud: int, timeout: float) -> tuple[bytes, int, int]
             "support, and is anything else holding the port open?"
         )
     if b"[/shot]" not in buf:
-        raise RuntimeError("transfer did not finish within %.0fs" % timeout)
+        raise RuntimeError(
+            "transfer stalled: %.0fs of silence with no [/shot] marker. It "
+            "started arriving then stopped - close any serial monitor on the "
+            "port, or raise --timeout." % timeout
+        )
 
     w, h, expect = int(m.group(1)), int(m.group(2)), int(m.group(3))
     payload = buf[m.end():].split(b"[/shot]", 1)[0]
 
     b64 = b"".join(l for l in (x.strip() for x in payload.splitlines())
                    if l and LINE_RE.match(l))
-    data = base64.b64decode(b64)
+    data = base64.b64decode(b64 + b"=" * (-len(b64) % 4))
 
     # The firmware sends its byte count for exactly this check. Without it a
     # short read produces a plausible-looking image with a corrupt tail.
     if len(data) != expect:
         raise RuntimeError(
-            "incomplete transfer: got %d of %d bytes (%d missing). Re-run; if "
-            "it persists, close any serial monitor sharing the port."
-            % (len(data), expect, expect - len(data))
+            "incomplete transfer: got %d of %d bytes (%d missing). The board "
+            "dropped serial writes - reflash with the current firmware, which "
+            "flushes as it sends." % (len(data), expect, expect - len(data))
         )
     return data, w, h
 
 
-def to_png(data: bytes, w: int, h: int, path: str, scale: int) -> None:
+def to_png(data, w, h, path, scale):
     # RGB565 little-endian (LV_COLOR_DEPTH 16, LV_COLOR_16_SWAP 0) -> RGB888.
     # The *255//31 form maps 31 to a true 255; a plain <<3 leaves white at 248
     # and the whole image reads faintly grey.
@@ -119,25 +141,30 @@ def to_png(data: bytes, w: int, h: int, path: str, scale: int) -> None:
     img.save(path, optimize=True)
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("port", help="serial port, e.g. COM9 or /dev/ttyACM0")
     ap.add_argument("out", nargs="?", default="screenshot.png", help="output PNG")
     ap.add_argument("--baud", type=int, default=115200)
-    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--timeout", type=float, default=8.0,
+                    help="seconds of SILENCE before giving up (not a total limit)")
     ap.add_argument("--scale", type=int, default=1,
                     help="nearest-neighbour upscale (2 = crisp 2x for docs)")
+    ap.add_argument("-q", "--quiet", action="store_true", help="suppress progress")
     a = ap.parse_args()
 
     try:
-        data, w, h = capture(a.port, a.baud, a.timeout)
+        data, w, h = capture(a.port, a.baud, a.timeout, progress=not a.quiet)
     except Exception as e:
         print("error: %s" % e, file=sys.stderr)
         return 1
 
     to_png(data, w, h, a.out, a.scale)
-    px = "%dx%d" % (w, h) if a.scale == 1 else "%dx%d -> %dx%d" % (w, h, w * a.scale, h * a.scale)
+    px = "%dx%d" % (w, h)
+    if a.scale > 1:
+        px += " -> %dx%d" % (w * a.scale, h * a.scale)
     print("%s  (%s)" % (a.out, px))
     return 0
 


### PR DESCRIPTION
Every image in the README and on the docs site was a phone photo of a lit panel in a dark room — moiré, reflections, keystone, and a black surround to crop. This produces exact framebuffer captures instead.

**Bench-tested on hardware by @pizza-init**, which is what produced the clean assets in #135.

```
pip install pyserial pillow
python tools/screenshot.py COM9 shot.png --scale 2
```

### How

The finished frame already exists. LVGL renders with `LV_DISPLAY_RENDER_MODE_FULL`, so `display_flush()` receives one contiguous RGB565 buffer of the whole screen. Nothing is re-rendered; the bytes are base64'd out of the port and `tools/screenshot.py` decodes them to a PNG.

On the 4" the frame comes from `px_map` (the landscape 800×480 buffer LVGL drew), not `rotate_buf` (the portrait version sent to the panel, which would come out sideways).

### Cost when idle: one `bool` test per flush

Request-driven, deliberately. Copying every frame would be ~768KB of `memcpy` at frame rate on the 4" and 1.2MB on the 7", permanently, for a feature used occasionally. Keeping a pointer to `px_map` instead would be worse — the draw buffers are double-buffered, so the frame you kept a pointer to is being overwritten while you dump it. The capture buffer is PSRAM, allocated on request and released on `shotfree`; this board has a history of heap pressure and doesn't need another permanent 768KB resident.

### What went wrong on the way

Documented in `docs/SCREENSHOT.md` because most of it is not obvious:

- **The request was never serviced on a static screen.** LVGL only flushes when something is invalidated, so with nothing animating no flush ever ran. Requesting a screenshot now invalidates the active screen.
- **A log line stuck on the end is not corruption.** Lines arrive as `1B24:wxjD...wxjD[SOAP/DMA] #3040: pre=136KB`. The base64 in front is complete — another task's output just landed before `println`'s newline. Requiring the whole line to match threw away good data, and since that log repeats constantly, re-requesting hit the same problem. Now the *leading* base64 run is taken; a log spliced into the *middle* truncates it and is still re-requested.
- **USB-CDC silently discards writes** it can't buffer. It does not block or retry.
- **Yielding inside the dump made things worse** — `vTaskDelay` hands the core to exactly the tasks that then print mid-line.
- **`readline()` returns partial lines** on timeout, silently dropping bytes.
- Header carries byte and line counts so a short transfer fails loudly instead of producing a plausible image with a corrupt tail.

### Also worth saying

Serial is not the ideal transport. The board has WiFi and already speaks HTTP; an endpoint serving the raw framebuffer over TCP would need none of the framing, base64 or retransmit machinery here. That's noted in the doc as the follow-up if screenshots become a regular chore.

### Scope

Adds `src/screenshot.cpp`, `include/screenshot.h`, `tools/screenshot.py`, `docs/SCREENSHOT.md`. Touches `display_driver.cpp` (one hook per flush path) and `main.cpp` (one poll call, one include). Both envs build. No version bump — flag whether you want one before release.