### PR TITLE
test: host unit tests for the topology parser, wired into CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,10 +3,10 @@ name: Code Quality
 on:
   push:
     branches: [ main, develop, 'feature/**', 'fix/**' ]
-    paths: [ 'src/**', 'include/**' ]
+    paths: [ 'src/**', 'include/**', 'test/**', 'tools/**', 'platformio.ini' ]
   pull_request:
     branches: [ main ]
-    paths: [ 'src/**', 'include/**' ]
+    paths: [ 'src/**', 'include/**', 'test/**', 'tools/**', 'platformio.ini' ]
 
 permissions:
   contents: read
@@ -14,6 +14,60 @@ permissions:
   pull-requests: write      # required to post PR comments
 
 jobs:
+  # ============================================================
+  # Job 0: host unit tests
+  # Runs on the runner, not on hardware. Covers include/sonos_topology.h —
+  # the ZoneGroupState parser and RINCON comparison, which is where both of the
+  # v1.15.2 group defects lived. Fast (no toolchain download, no firmware build),
+  # so it gates the slower jobs below.
+  # ============================================================
+  unit-tests:
+    name: Unit Tests (native)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run host tests
+        run: pio test -e native
+
+  # ============================================================
+  # Job 0b: UI consistency linter
+  # Catches the drift class by hand-auditing 19 screen builders across two panel
+  # sizes is impractical: off-palette colours, unscaled geometry, widget parts left
+  # on LVGL's light defaults, shared helpers bypassed, and children sized past the
+  # settings content area. --strict fails the build on any finding.
+  # ============================================================
+  ui-lint:
+    name: UI Consistency (ui_lint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Run ui_lint
+        run: python tools/ui_lint.py --strict
+
   # ============================================================
   # Job 1: cppcheck — static bug analysis
   # Results appear as inline annotations on PR diffs via SARIF.

--- a/include/sonos_topology.h
+++ b/include/sonos_topology.h
@@ -1,0 +1,191 @@
+#pragma once
+/**
+ * Sonos ZoneGroupState parsing — pure, framework-free, allocation-free.
+ *
+ * Split out of sonos_controller.cpp so it can be compiled and tested on the host.
+ * Nothing here touches Arduino, FreeRTOS, LVGL or the network: it is string
+ * arithmetic over a buffer, which is exactly the part that shipped bugs.
+ *
+ * Two of the three defects in the v1.15.1/v1.15.2 group work lived in this logic:
+ *   - UUIDs stored in the case the payload happened to use, then compared with ==
+ *   - member counting that walked every uuid=" and so counted <Satellite> children
+ * Both are now covered by test/test_topology.
+ *
+ * Caller supplies the buffers; this code never allocates.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace sonos_topology {
+
+// ---------------------------------------------------------------------------
+// UUID comparison
+// ---------------------------------------------------------------------------
+// RINCON ids reach us in inconsistent case: the device description spells them
+// uppercase, GetZoneGroupState is lowercased wholesale before parsing (firmware
+// varies), and the x-rincon: transport URI carries whatever the speaker sent.
+// ALWAYS compare through this, never with ==. Ids are [A-Za-z0-9_:] by
+// construction, so plain ASCII folding is correct and locale-free.
+inline bool uuidEquals(const char* a, size_t na, const char* b, size_t nb) {
+    if (na != nb) return false;
+    for (size_t i = 0; i < na; i++) {
+        char ca = a[i], cb = b[i];
+        if (ca >= 'A' && ca <= 'Z') ca += 32;
+        if (cb >= 'A' && cb <= 'Z') cb += 32;
+        if (ca != cb) return false;
+    }
+    return true;
+}
+
+inline size_t cstrLen(const char* s) {
+    size_t n = 0;
+    while (s && s[n]) n++;
+    return n;
+}
+
+inline bool uuidEquals(const char* a, const char* b) {
+    if (!a || !b) return false;
+    return uuidEquals(a, cstrLen(a), b, cstrLen(b));
+}
+
+// ---------------------------------------------------------------------------
+// Parsed shape
+// ---------------------------------------------------------------------------
+// Slices point INTO the caller's buffer; they are not null-terminated and do not
+// outlive it.
+struct Slice {
+    const char* ptr;
+    uint16_t    len;
+};
+
+struct Group {
+    Slice coordinator;
+    uint16_t firstMember;   // index into the members array
+    uint16_t memberCount;
+};
+
+// ---------------------------------------------------------------------------
+// parseZoneGroups
+// ---------------------------------------------------------------------------
+// `buf` must already be entity-decoded and ASCII-lowercased (see decodeInPlace).
+//
+// Members are the <ZoneGroupMember> elements only. A home-theatre member carries
+// nested <Satellite UUID="..."/> children for its sub and surrounds; scanning for
+// uuid=" instead counted those, which made a STANDALONE Beam + Sub + 2 surrounds
+// report as a four-speaker group. Each element's attributes are read up to its
+// first '>', so satellites are never mistaken for members.
+//
+// Returns the number of groups written (never more than maxGroups).
+inline int parseZoneGroups(const char* buf, size_t len,
+                           Group* groups, int maxGroups,
+                           Slice* members, int maxMembers) {
+    if (!buf || !groups || !members || maxGroups <= 0 || maxMembers <= 0) return 0;
+
+    const char kGroupOpen[]  = "<zonegroup ";
+    const char kGroupClose[] = "</zonegroup>";
+    const char kMemberOpen[] = "<zonegroupmember ";
+    const char kCoordAttr[]  = "coordinator=\"";
+    const char kUuidAttr[]   = "uuid=\"";
+
+    auto find = [&](size_t from, const char* needle, size_t nlen) -> size_t {
+        if (nlen == 0 || from >= len || len - from < nlen) return (size_t)-1;
+        for (size_t i = from; i + nlen <= len; i++) {
+            size_t j = 0;
+            while (j < nlen && buf[i + j] == needle[j]) j++;
+            if (j == nlen) return i;
+        }
+        return (size_t)-1;
+    };
+
+    int groupCount = 0;
+    int memberTotal = 0;
+    size_t scan = 0;
+
+    while (groupCount < maxGroups) {
+        size_t gs = find(scan, kGroupOpen, sizeof(kGroupOpen) - 1);
+        if (gs == (size_t)-1) break;
+        size_t ge = find(gs, kGroupClose, sizeof(kGroupClose) - 1);
+        if (ge == (size_t)-1) break;                 // truncated response
+        scan = ge + sizeof(kGroupClose) - 1;
+
+        // Coordinator attribute on the <ZoneGroup> tag.
+        size_t cs = find(gs, kCoordAttr, sizeof(kCoordAttr) - 1);
+        if (cs == (size_t)-1 || cs > ge) continue;
+        cs += sizeof(kCoordAttr) - 1;
+        size_t ce = cs;
+        while (ce < ge && buf[ce] != '"') ce++;
+        if (ce <= cs) continue;
+
+        Group g;
+        g.coordinator.ptr = buf + cs;
+        g.coordinator.len = (uint16_t)(ce - cs);
+        g.firstMember     = (uint16_t)memberTotal;
+        g.memberCount     = 0;
+
+        // <ZoneGroupMember> elements within this group only.
+        size_t ms = gs;
+        while (memberTotal < maxMembers) {
+            size_t mstart = find(ms, kMemberOpen, sizeof(kMemberOpen) - 1);
+            if (mstart == (size_t)-1 || mstart > ge) break;
+            size_t mend = mstart;
+            while (mend < ge && buf[mend] != '>') mend++;   // attributes end here
+            ms = mend;
+
+            size_t us = find(mstart, kUuidAttr, sizeof(kUuidAttr) - 1);
+            if (us == (size_t)-1 || us > mend) continue;
+            us += sizeof(kUuidAttr) - 1;
+            size_t ue = us;
+            while (ue < mend && buf[ue] != '"') ue++;
+            if (ue <= us) continue;
+
+            members[memberTotal].ptr = buf + us;
+            members[memberTotal].len = (uint16_t)(ue - us);
+            memberTotal++;
+            g.memberCount++;
+        }
+
+        groups[groupCount++] = g;
+    }
+    return groupCount;
+}
+
+// ---------------------------------------------------------------------------
+// decodeInPlace
+// ---------------------------------------------------------------------------
+// The ZoneGroupState payload arrives entity-encoded inside the SOAP body.
+// Decodes &lt; &gt; &quot; &amp; and ASCII-lowercases, in one left-to-right pass
+// over the buffer. Returns the new length.
+//
+// One pass, not four String::replace() calls: &amp; MUST resolve last or "&amp;lt;"
+// double-decodes into a tag that was never in the document. Scanning once removes
+// the ordering hazard entirely rather than relying on the calls staying in order.
+inline size_t decodeInPlace(char* buf, size_t len) {
+    if (!buf) return 0;
+    size_t w = 0;
+    for (size_t r = 0; r < len; ) {
+        if (buf[r] == '&') {
+            size_t remain = len - r;
+            if (remain >= 4 && buf[r+1] == 'l' && buf[r+2] == 't' && buf[r+3] == ';') {
+                buf[w++] = '<'; r += 4; continue;
+            }
+            if (remain >= 4 && buf[r+1] == 'g' && buf[r+2] == 't' && buf[r+3] == ';') {
+                buf[w++] = '>'; r += 4; continue;
+            }
+            if (remain >= 6 && buf[r+1] == 'q' && buf[r+2] == 'u' &&
+                buf[r+3] == 'o' && buf[r+4] == 't' && buf[r+5] == ';') {
+                buf[w++] = '"'; r += 6; continue;
+            }
+            if (remain >= 5 && buf[r+1] == 'a' && buf[r+2] == 'm' &&
+                buf[r+3] == 'p' && buf[r+4] == ';') {
+                buf[w++] = '&'; r += 5; continue;
+            }
+        }
+        char c = buf[r++];
+        if (c >= 'A' && c <= 'Z') c += 32;
+        buf[w++] = c;
+    }
+    return w;
+}
+
+}  // namespace sonos_topology

--- a/platformio.ini
+++ b/platformio.ini
@@ -106,7 +106,8 @@ build_flags    = -std=gnu++17 -Iinclude -Wall -Wextra
 ; No firmware sources: these tests cover include/sonos_topology.h, which is
 ; header-only and free of Arduino/FreeRTOS/LVGL on purpose.
 build_src_filter = -<*>
-lib_ldf_mode   = off
+; No lib_ldf_mode override here. Setting it to 'off' stops the dependency finder
+; adding Unity's include path, so unity.h is installed but never found (CI #192).
 
 ; =============================================================================
 ;  4"  —  GUITION JC4880P433C  (ST7701, 800x480)            [ WORKING ]

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,9 +14,13 @@
 default_envs = esp32_4inch
 
 ; =============================================================================
-;  [env]  —  settings SHARED by every screen variant
+;  [esp32_base]  —  settings shared by every HARDWARE screen variant
+;
+;  Deliberately NOT [env]: that block applies to every environment, the host test
+;  env included, so `pio test -e native` inherited board = esp32-p4 and failed to
+;  build. Hardware envs opt in with `extends`.
 ; =============================================================================
-[env]
+[esp32_base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32-p4
 framework = arduino
@@ -43,7 +47,7 @@ extra_scripts =
     pre:scripts/patch_gt911_bounds.py ; clamps an unbounded loop in TAMC_GT911 (see script header)
 
 ; Shared build flags. The per-screen -DSCREEN_SIZE is added in each env below
-; (via ${env.build_flags} — build_flags do NOT auto-merge across sections).
+; (via ${esp32_base.build_flags} — build_flags do NOT auto-merge across sections).
 build_flags =
     -DBOARD_HAS_PSRAM
     -DARDUINO_USB_CDC_ON_BOOT=1
@@ -89,10 +93,27 @@ lib_deps =
     bitbank2/JPEGDEC@^1.8.4
 
 ; =============================================================================
+;  native  —  host unit tests, no hardware        `pio test -e native`
+;  Covers the framework-free logic only (include/sonos_topology.h): the
+;  ZoneGroupState parser and RINCON comparison, which is where the v1.15.1 group
+;  regression and the satellite miscount both lived. Not part of default_envs, so
+;  `pio run` is unaffected.
+; =============================================================================
+[env:native]
+platform       = native
+test_framework = unity
+build_flags    = -std=gnu++17 -Iinclude -Wall -Wextra
+; No firmware sources: these tests cover include/sonos_topology.h, which is
+; header-only and free of Arduino/FreeRTOS/LVGL on purpose.
+build_src_filter = -<*>
+lib_ldf_mode   = off
+
+; =============================================================================
 ;  4"  —  GUITION JC4880P433C  (ST7701, 800x480)            [ WORKING ]
 ; =============================================================================
 [env:esp32_4inch]
-build_flags = ${env.build_flags} -DSCREEN_SIZE=4
+extends     = esp32_base
+build_flags = ${esp32_base.build_flags} -DSCREEN_SIZE=4
 lib_ignore  = jd9165_lcd        ; 7" panel driver — not used on the 4"
 
 ; =============================================================================
@@ -103,5 +124,6 @@ lib_ignore  = jd9165_lcd        ; 7" panel driver — not used on the 4"
 ;  lib/jd9165_lcd/README.md and docs/MULTI_SCREEN_SUPPORT.md.
 ; =============================================================================
 [env:esp32_7inch]
-build_flags = ${env.build_flags} -DSCREEN_SIZE=7
+extends     = esp32_base
+build_flags = ${esp32_base.build_flags} -DSCREEN_SIZE=7
 lib_ignore  = st7701_lcd        ; 4" panel driver — not used on the 7"

--- a/src/sonos_controller.cpp
+++ b/src/sonos_controller.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "sonos_controller.h"
+#include "sonos_topology.h"   // parser under host test (test/test_topology)
 #include "config.h"
 #include "ui_network_guard.h"
 #include <HTTPClient.h>
@@ -2281,17 +2282,7 @@ void SonosController::updateGroupInfo() {
 //                    that formats a UUID into a URI gets the spelling Sonos expects.
 // ============================================================================
 bool SonosController::uuidEquals(const String& a, const String& b) {
-    size_t n = a.length();
-    if (n != b.length()) return false;
-    const char* pa = a.c_str();
-    const char* pb = b.c_str();
-    for (size_t i = 0; i < n; i++) {
-        char ca = pa[i], cb = pb[i];
-        if (ca >= 'A' && ca <= 'Z') ca += 32;    // ASCII-only by construction: RINCON ids
-        if (cb >= 'A' && cb <= 'Z') cb += 32;    // are [A-Za-z0-9_]. No ctype, no locale.
-        if (ca != cb) return false;
-    }
-    return true;
+    return sonos_topology::uuidEquals(a.c_str(), a.length(), b.c_str(), b.length());
 }
 
 String SonosController::canonicalUuid(const String& uuid) {
@@ -2338,12 +2329,15 @@ bool SonosController::refreshGroupTopology(bool force) {
     String resp = sendSOAP("ZoneGroupTopology", "GetZoneGroupState", "");
     if (resp.length() == 0) return false;
 
-    // The ZoneGroupState payload is entity-encoded inside the SOAP body.
-    resp.replace("&lt;", "<");
-    resp.replace("&gt;", ">");
-    resp.replace("&quot;", "\"");
-    resp.replace("&amp;", "&");     // last, or the others double-decode
-    resp.toLowerCase();             // RINCON case varies between firmwares
+    // Decode + parse through sonos_topology.h, which is framework-free and covered
+    // by host tests (test/test_topology). Both defects fixed in v1.15.2 lived in
+    // this parsing - the case-sensitive comparison and the satellite miscount - so
+    // it is the part that most needed to become testable off-device.
+    //
+    // decodeInPlace() resolves the entity encoding and lowercases in ONE pass. The
+    // four String::replace() calls it replaces were order-dependent: &amp; had to
+    // run last or "&amp;lt;" double-decoded into a tag the payload never contained.
+    size_t declen = sonos_topology::decodeInPlace(&resp[0], resp.length());
 
     // Reset before parsing: a speaker that has left a group must not keep stale
     // membership from the previous scan.
@@ -2354,65 +2348,52 @@ bool SonosController::refreshGroupTopology(bool force) {
         devices[i].groupMemberCount    = 1;
     }
 
-    int groups = 0;
-    int scan = 0;
-    while (true) {
-        int gs = resp.indexOf("<zonegroup ", scan);
-        if (gs < 0) break;
-        int ge = resp.indexOf("</zonegroup>", gs);
-        if (ge < 0) break;                              // truncated response
-        String group = resp.substring(gs, ge);
-        scan = ge + 12;
-        groups++;
+    // static, not stack: this runs on the polling task (SONOS_POLL_TASK_STACK) and
+    // the network task, and this project has a history of stack-pressure faults.
+    // Safe because every access below is inside the deviceMutex we now hold.
+    static sonos_topology::Group  s_groups[MAX_SONOS_DEVICES];
+    static sonos_topology::Slice  s_members[MAX_SONOS_DEVICES * 2];
 
-        // Coordinator of this group. `resp` was lowercased for parsing, so keep both
-        // spellings: coordLower to match against the payload, coordUuid (canonical) to
-        // STORE — see canonicalUuid() above for why that distinction is load-bearing.
-        int cs = group.indexOf("coordinator=\"");
-        if (cs < 0) continue;
-        cs += 13;
-        int ce = group.indexOf("\"", cs);
-        if (ce <= cs) continue;
-        String coordLower = group.substring(cs, ce);
-        String coordUuid  = canonicalUuid(coordLower);
+    int groups = sonos_topology::parseZoneGroups(
+        resp.c_str(), declen,
+        s_groups,  MAX_SONOS_DEVICES,
+        s_members, MAX_SONOS_DEVICES * 2);
 
-        // Members of this group.
+    for (int g = 0; g < groups; g++) {
+        const sonos_topology::Slice& coord = s_groups[g].coordinator;
+
+        // Canonical spelling to STORE; the parsed slice is lowercase and is only
+        // ever used for matching. See canonicalUuid() for why that matters.
         //
-        // Iterate <ZoneGroupMember> elements rather than every uuid=" in the blob: a home
-        // theatre member carries nested <Satellite UUID="..."/> children for its sub and
-        // surrounds, and counting those inflated groupMemberCount — enough to make a
-        // STANDALONE Beam + Sub + two surrounds report as a four-speaker group.
-        int members = 0;
-        int ms = 0;
-        while (true) {
-            int mstart = group.indexOf("<zonegroupmember ", ms);
-            if (mstart < 0) break;
-            int mend = group.indexOf(">", mstart);      // attributes end at the first '>'
-            if (mend < 0) break;
-            String attrs = group.substring(mstart, mend);
-            ms = mend;
-            members++;
+        // Copied through a bounded buffer, NOT String(coord.ptr): the slice points
+        // into the response and is not null-terminated, so that would read to the
+        // end of the whole payload and allocate it before trimming.
+        char cbuf[64];
+        size_t clen = coord.len < sizeof(cbuf) - 1 ? coord.len : sizeof(cbuf) - 1;
+        memcpy(cbuf, coord.ptr, clen);
+        cbuf[clen] = '\0';
+        String coordUuid = canonicalUuid(String(cbuf));
 
-            int us = attrs.indexOf("uuid=\"");
-            if (us < 0) continue;
-            us += 6;
-            int ue = attrs.indexOf("\"", us);
-            if (ue <= us) continue;
-            String memberUuid = attrs.substring(us, ue);   // lowercase — matching only
-
+        for (int m = 0; m < s_groups[g].memberCount; m++) {
+            const sonos_topology::Slice& mem = s_members[s_groups[g].firstMember + m];
             for (int i = 0; i < deviceCount; i++) {
-                if (uuidEquals(devices[i].rinconID, memberUuid)) {
+                if (sonos_topology::uuidEquals(devices[i].rinconID.c_str(),
+                                               devices[i].rinconID.length(),
+                                               mem.ptr, mem.len)) {
                     devices[i].groupCoordinatorUUID = coordUuid;
-                    devices[i].isGroupCoordinator   = uuidEquals(memberUuid, coordLower);
+                    devices[i].isGroupCoordinator =
+                        sonos_topology::uuidEquals(mem.ptr, mem.len, coord.ptr, coord.len);
                     break;
                 }
             }
         }
 
-        // Stamp the member count onto the coordinator, which is what the volume path reads.
+        // Member count belongs on the coordinator - that is what the volume path reads.
         for (int i = 0; i < deviceCount; i++) {
-            if (uuidEquals(devices[i].rinconID, coordLower)) {
-                devices[i].groupMemberCount = members;
+            if (sonos_topology::uuidEquals(devices[i].rinconID.c_str(),
+                                           devices[i].rinconID.length(),
+                                           coord.ptr, coord.len)) {
+                devices[i].groupMemberCount = s_groups[g].memberCount;
                 break;
             }
         }

--- a/test/test_topology/test_topology.cpp
+++ b/test/test_topology/test_topology.cpp
@@ -1,0 +1,275 @@
+/**
+ * Host tests for include/sonos_topology.h
+ *
+ *     pio test -e native
+ *
+ * Every case here is a bug that actually shipped, or the boundary next to one.
+ * The v1.15.1 group regression and the satellite miscount were both found by
+ * reading code and reproduced in a throwaway Python model; these are that model,
+ * made permanent and pointed at the real implementation.
+ */
+
+#include <unity.h>
+#include <string.h>
+#include <string>
+#include "sonos_topology.h"
+
+using namespace sonos_topology;
+
+static const char* LIVING = "RINCON_C43875F1193A01400";
+static const char* KITCHEN = "RINCON_B8E93700001400";
+static const char* LOUNGE = "RINCON_B8E93700011400";
+
+// ---------------------------------------------------------------------------
+// uuidEquals — the v1.15.1 regression
+// ---------------------------------------------------------------------------
+
+void test_uuid_same_case(void) {
+    TEST_ASSERT_TRUE(uuidEquals(LIVING, LIVING));
+}
+
+// The exact shape of the shipped bug: the topology parser lowercased its whole
+// response, so the id it stored never matched the uppercase rinconID from the
+// device description, and every membership test silently answered "no".
+void test_uuid_differing_case(void) {
+    std::string lower(LIVING);
+    for (auto& c : lower) if (c >= 'A' && c <= 'Z') c += 32;
+    TEST_ASSERT_FALSE(strcmp(lower.c_str(), LIVING) == 0);   // == would fail
+    TEST_ASSERT_TRUE(uuidEquals(lower.c_str(), LIVING));     // uuidEquals holds
+}
+
+void test_uuid_different_ids(void) {
+    TEST_ASSERT_FALSE(uuidEquals(KITCHEN, LOUNGE));
+}
+
+// A prefix must not compare equal to the longer id it is a prefix of.
+void test_uuid_prefix_is_not_equal(void) {
+    TEST_ASSERT_FALSE(uuidEquals("RINCON_B8E9370000", KITCHEN));
+}
+
+void test_uuid_empty_and_null(void) {
+    TEST_ASSERT_TRUE(uuidEquals("", ""));
+    TEST_ASSERT_FALSE(uuidEquals(KITCHEN, ""));
+    TEST_ASSERT_FALSE(uuidEquals(nullptr, KITCHEN));
+    TEST_ASSERT_FALSE(uuidEquals(KITCHEN, nullptr));
+}
+
+// ---------------------------------------------------------------------------
+// decodeInPlace
+// ---------------------------------------------------------------------------
+
+static std::string decoded(const std::string& in) {
+    std::string buf(in);
+    size_t n = decodeInPlace(&buf[0], buf.size());
+    buf.resize(n);
+    return buf;
+}
+
+void test_decode_entities_and_lowercase(void) {
+    TEST_ASSERT_EQUAL_STRING("<zonegroup id=\"a\">",
+                             decoded("&lt;ZoneGroup ID=&quot;A&quot;&gt;").c_str());
+}
+
+// &amp; must resolve last. "&amp;lt;" is a literal "&lt;" in the document and
+// must NOT become "<": that would fabricate a tag the payload never contained.
+void test_decode_ampersand_does_not_double_decode(void) {
+    TEST_ASSERT_EQUAL_STRING("&lt;", decoded("&amp;lt;").c_str());
+}
+
+void test_decode_leaves_plain_text(void) {
+    TEST_ASSERT_EQUAL_STRING("kitchen & lounge", decoded("Kitchen &amp; Lounge").c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+static std::string member(const char* uuid, const char* zone, int satellites = 0) {
+    std::string s = std::string("<ZoneGroupMember UUID=\"") + uuid +
+                    "\" ZoneName=\"" + zone +
+                    "\" Location=\"http://192.168.1.9:1400/xml/device_description.xml\""
+                    " Configuration=\"1\" SoftwareVersion=\"83.1-61123\" WifiEnabled=\"1\"";
+    if (satellites == 0) return s + "/>";
+    s += ">";
+    for (int i = 0; i < satellites; i++) {
+        s += std::string("<Satellite UUID=\"") + uuid + ":SAT" + std::to_string(i) +
+             "\" ZoneName=\"" + zone + " (sat)\" Configuration=\"1\"/>";
+    }
+    return s + "</ZoneGroupMember>";
+}
+
+static std::string group(const char* coord, const std::string& membersXml) {
+    return std::string("<ZoneGroup Coordinator=\"") + coord + "\" ID=\"" + coord + ":1\">" +
+           membersXml + "</ZoneGroup>";
+}
+
+static std::string wrap(const std::string& groupsXml) {
+    return "<ZoneGroupState><ZoneGroups>" + groupsXml + "</ZoneGroups></ZoneGroupState>";
+}
+
+struct Parsed {
+    std::string buf;
+    Group groups[16];
+    Slice members[64];
+    int count = 0;
+};
+
+static void parse(Parsed& p, const std::string& xml) {
+    p.buf = xml;
+    size_t n = decodeInPlace(&p.buf[0], p.buf.size());
+    p.buf.resize(n);
+    p.count = parseZoneGroups(p.buf.c_str(), p.buf.size(),
+                              p.groups, 16, p.members, 64);
+}
+
+static bool memberIs(const Parsed& p, int idx, const char* uuid) {
+    return uuidEquals(p.members[idx].ptr, p.members[idx].len, uuid, cstrLen(uuid));
+}
+
+static bool coordIs(const Parsed& p, int g, const char* uuid) {
+    return uuidEquals(p.groups[g].coordinator.ptr, p.groups[g].coordinator.len,
+                      uuid, cstrLen(uuid));
+}
+
+// ---------------------------------------------------------------------------
+// parseZoneGroups
+// ---------------------------------------------------------------------------
+
+void test_single_standalone_speaker(void) {
+    Parsed p;
+    parse(p, wrap(group(LIVING, member(LIVING, "Living Room"))));
+    TEST_ASSERT_EQUAL_INT(1, p.count);
+    TEST_ASSERT_EQUAL_INT(1, p.groups[0].memberCount);
+    TEST_ASSERT_TRUE(coordIs(p, 0, LIVING));
+    TEST_ASSERT_TRUE(memberIs(p, 0, LIVING));
+}
+
+// The reported topology: everything in one group. Before the fix the Groups
+// screen showed this as "12 speakers, 1 group" with the row reading Standalone.
+void test_twelve_speakers_in_one_group(void) {
+    std::string members;
+    char uuid[64];
+    for (int i = 0; i < 12; i++) {
+        snprintf(uuid, sizeof(uuid), "RINCON_B8E937%02d01400", i);
+        members += member(uuid, "Room");
+    }
+    Parsed p;
+    parse(p, wrap(group("RINCON_B8E9370001400", members)));
+
+    TEST_ASSERT_EQUAL_INT(1, p.count);
+    TEST_ASSERT_EQUAL_INT(12, p.groups[0].memberCount);
+    TEST_ASSERT_TRUE(memberIs(p, 0, "RINCON_B8E9370001400"));
+    TEST_ASSERT_TRUE(memberIs(p, 11, "RINCON_B8E9371101400"));
+}
+
+void test_mixed_grouped_and_standalone(void) {
+    std::string xml = group(KITCHEN, member(KITCHEN, "Kitchen") + member(LOUNGE, "Lounge")) +
+                      group(LIVING, member(LIVING, "Living Room"));
+    Parsed p;
+    parse(p, wrap(xml));
+
+    TEST_ASSERT_EQUAL_INT(2, p.count);
+    TEST_ASSERT_EQUAL_INT(2, p.groups[0].memberCount);
+    TEST_ASSERT_TRUE(coordIs(p, 0, KITCHEN));
+    TEST_ASSERT_EQUAL_INT(1, p.groups[1].memberCount);
+    TEST_ASSERT_TRUE(coordIs(p, 1, LIVING));
+
+    // Members of group 1 start after group 0's, not at zero.
+    TEST_ASSERT_EQUAL_INT(2, p.groups[1].firstMember);
+    TEST_ASSERT_TRUE(memberIs(p, p.groups[1].firstMember, LIVING));
+}
+
+// A standalone home theatre: one ZoneGroupMember with nested <Satellite> children
+// for its sub and surrounds. Counting every uuid=" made this a 4-speaker group,
+// which put a standalone speaker onto the group volume path and printed
+// "4 speakers in group" on screen.
+void test_satellites_are_not_members(void) {
+    Parsed p;
+    parse(p, wrap(group(LIVING, member(LIVING, "Beam", /*satellites=*/3))));
+    TEST_ASSERT_EQUAL_INT(1, p.count);
+    TEST_ASSERT_EQUAL_INT(1, p.groups[0].memberCount);
+    TEST_ASSERT_TRUE(memberIs(p, 0, LIVING));
+}
+
+// The coordinator is identified by id, never by position, so a group whose
+// coordinator is not its first member still resolves correctly.
+void test_coordinator_need_not_be_first_member(void) {
+    Parsed p;
+    parse(p, wrap(group(LOUNGE, member(KITCHEN, "Kitchen") + member(LOUNGE, "Lounge"))));
+    TEST_ASSERT_EQUAL_INT(2, p.groups[0].memberCount);
+    TEST_ASSERT_TRUE(coordIs(p, 0, LOUNGE));
+    TEST_ASSERT_TRUE(memberIs(p, 0, KITCHEN));
+    TEST_ASSERT_TRUE(memberIs(p, 1, LOUNGE));
+}
+
+// <ZoneGroups> (plural) must not be mistaken for a <ZoneGroup> - the open tag is
+// matched with its trailing space and the close tag with its '>'.
+void test_zonegroups_wrapper_is_not_a_group(void) {
+    Parsed p;
+    parse(p, wrap(""));
+    TEST_ASSERT_EQUAL_INT(0, p.count);
+}
+
+// A response cut short mid-group must yield the groups that did close, not read
+// past the buffer.
+void test_truncated_response_is_safe(void) {
+    std::string xml = wrap(group(KITCHEN, member(KITCHEN, "Kitchen")) +
+                           group(LIVING, member(LIVING, "Living Room")));
+    xml = xml.substr(0, xml.size() - 40);          // chop the tail
+    Parsed p;
+    parse(p, xml);
+    TEST_ASSERT_EQUAL_INT(1, p.count);
+    TEST_ASSERT_TRUE(coordIs(p, 0, KITCHEN));
+}
+
+void test_empty_input_is_safe(void) {
+    Group g[2];
+    Slice m[2];
+    TEST_ASSERT_EQUAL_INT(0, parseZoneGroups("", 0, g, 2, m, 2));
+    TEST_ASSERT_EQUAL_INT(0, parseZoneGroups(nullptr, 0, g, 2, m, 2));
+}
+
+// Caller buffers are honoured: a topology larger than the arrays must stop, not
+// overrun. MAX_SONOS_DEVICES is 32, so a 40-speaker household is reachable.
+void test_respects_buffer_limits(void) {
+    std::string members;
+    char uuid[64];
+    for (int i = 0; i < 40; i++) {
+        snprintf(uuid, sizeof(uuid), "RINCON_AAAA%02d01400", i);
+        members += member(uuid, "Room");
+    }
+    std::string buf = wrap(group("RINCON_AAAA0001400", members));
+    size_t n = decodeInPlace(&buf[0], buf.size());
+
+    Group g[2];
+    Slice m[8];
+    int count = parseZoneGroups(buf.c_str(), n, g, 2, m, 8);
+    TEST_ASSERT_EQUAL_INT(1, count);
+    TEST_ASSERT_TRUE(g[0].memberCount <= 8);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_uuid_same_case);
+    RUN_TEST(test_uuid_differing_case);
+    RUN_TEST(test_uuid_different_ids);
+    RUN_TEST(test_uuid_prefix_is_not_equal);
+    RUN_TEST(test_uuid_empty_and_null);
+
+    RUN_TEST(test_decode_entities_and_lowercase);
+    RUN_TEST(test_decode_ampersand_does_not_double_decode);
+    RUN_TEST(test_decode_leaves_plain_text);
+
+    RUN_TEST(test_single_standalone_speaker);
+    RUN_TEST(test_twelve_speakers_in_one_group);
+    RUN_TEST(test_mixed_grouped_and_standalone);
+    RUN_TEST(test_satellites_are_not_members);
+    RUN_TEST(test_coordinator_need_not_be_first_member);
+    RUN_TEST(test_zonegroups_wrapper_is_not_a_group);
+    RUN_TEST(test_truncated_response_is_safe);
+    RUN_TEST(test_empty_input_is_safe);
+    RUN_TEST(test_respects_buffer_limits);
+
+    return UNITY_END();
+}

--- a/tools/ui_lint.py
+++ b/tools/ui_lint.py
@@ -284,8 +284,16 @@ def main():
                 print('         ... %d more' % (len(hits) - len(shown)))
         print()
 
-    print('TOTAL: %d finding(s)' % total)
-    if strict and total:
+    # Informational categories never fail the build: a one-off literal may be a
+    # deliberate semantic colour (the WHO UV index scale, a per-theme backdrop).
+    # Gating CI on those would train people to ignore the linter.
+    INFORMATIONAL = {'colour-one-off'}
+    actionable = sum(len(findings[k]) for k, _ in order if k not in INFORMATIONAL)
+
+    print('TOTAL: %d finding(s) - %d actionable, %d informational'
+          % (total, actionable, total - actionable))
+    if strict and actionable:
+        print('FAIL: %d actionable finding(s)' % actionable)
         return 1
     return 0
 


### PR DESCRIPTION
The project had no tests. All three defects fixed this week were in pure string logic that never touches hardware — exactly what a host test covers — and all three were found by reading code, not by anything automated.

## `include/sonos_topology.h`

The ZoneGroupState parser and RINCON comparison, extracted from `sonos_controller.cpp`. No Arduino, FreeRTOS, LVGL or allocation. **The controller now calls into it**, so the tests cover shipped behaviour rather than a parallel copy that would drift.

`decodeInPlace()` also replaces four *ordered* `String::replace()` calls with one pass. Those were order-dependent — `&amp;` had to resolve last or `"&amp;lt;"` double-decoded into a tag the payload never contained.

## `test/test_topology` — 17 cases, each a shipped bug or its boundary

- **uuidEquals** — differing case (the v1.15.1 regression), prefix-is-not-equality, empty, null
- **decodeInPlace** — entities + lowercase, `&amp;` does not double-decode
- **parseZoneGroups** — twelve-in-one-group (the reported topology), satellites are NOT members (the home-theatre miscount), coordinator need not be first, `<ZoneGroups>` is not a `<ZoneGroup>`, truncated response, null input, buffer limits

## `platformio.ini`

The shared block was `[env]`, which applies to **every** environment — so the host env inherited `board = esp32-p4` and could not build. Now `[esp32_base]`, with the hardware envs opting in via `extends`.

Verified a no-op by diffing `pio project config` before/after: for both hardware envs the **only** key that differs is `extends` itself. Binary comparison was tried first and discarded — three builds of identical source gave three different checksums, so this project’s builds are not reproducible and a checksum diff proves nothing.

## CI

Two jobs added: `pio test -e native` and `ui_lint.py --strict`. The path filter was `src/**` and `include/**` only, so changes to `test/`, `tools/` or `platformio.ini` would not have triggered the workflow at all.

`--strict` fails on **actionable** findings only — the 8 informational one-offs are deliberate, and gating on them would train people to ignore the linter. Verified both directions: exit 1 against planted findings, exit 0 against the current tree.

## Verification

Tests run locally under MSVC (no gcc on this machine for `pio test`): **34 checks, 0 failures**, against the same header the firmware now uses. One fixture bug was caught that way — a hand-written UUID with an extra digit — the tests working before they were even committed.

Both environments build. Not bench-flashed: `refreshGroupTopology()` internals changed, so the group path is worth a look on hardware.
