### PR TITLE
fix: collect the two safety mechanisms the build already pays for

### DIFF
--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -1,0 +1,125 @@
+name: Dependency Drift
+
+# Dependabot watches GitHub Actions and pip, but it has no PlatformIO ecosystem,
+# so the libraries that actually ship in the firmware — LVGL, ArduinoJson, PNGdec,
+# JPEGDEC, TAMC_GT911 — and the pinned platform are invisible to it. Before this
+# job they were current only because somebody remembered to run the check by hand.
+#
+# This does not open pull requests and does not bump anything. The platform pin in
+# particular is held back deliberately (see the comment above `platform =` in
+# platformio.ini), so an automatic bump would be wrong. It opens one issue when
+# something drifts, and updates that same issue rather than filing a new one each
+# week.
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'      # Mondays, 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: deps-check
+  cancel-in-progress: false
+
+jobs:
+  outdated:
+    name: pio pkg outdated
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Check library versions
+        id: check
+        shell: bash
+        run: |
+          set -o pipefail
+          pio pkg outdated 2>&1 | tee outdated.txt || true
+
+          # "Everything is up-to-date!" is the clean signal. Anything else means
+          # at least one package has a newer version available.
+          if grep -q "Everything is up-to-date" outdated.txt; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## PlatformIO dependencies"
+            echo
+            echo '```'
+            cat outdated.txt 2>/dev/null || echo "no output"
+            echo '```'
+            echo
+            echo "Pinned platform: \`$(grep -oE 'download/[^/]+/' platformio.ini | head -1 | cut -d/ -f2)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update the drift issue
+        if: steps.check.outputs.drift == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('outdated.txt', 'utf8').slice(0, 55000);
+            const title = 'Dependency drift: pio pkg outdated is not clean';
+
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'dependencies',
+            });
+            const existing = issues.data.find(i => i.title === title);
+
+            const text = [
+              'The weekly PlatformIO dependency check found newer versions available.',
+              '',
+              'Nothing has been bumped. The platform pin especially is held back on',
+              'purpose — see the comment above `platform =` in `platformio.ini` before',
+              'changing it.',
+              '',
+              '```',
+              body.trim(),
+              '```',
+              '',
+              `Checked: ${new Date().toISOString().slice(0, 10)} · [run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: text,
+              });
+              core.info(`Updated issue #${existing.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: text,
+                labels: ['dependencies'],
+              });
+              core.info('Opened a new drift issue');
+            }

--- a/docs/COREDUMP.md
+++ b/docs/COREDUMP.md
@@ -1,0 +1,107 @@
+# Reading a crash off the device
+
+The firmware writes an ELF core dump to flash on every panic. This has always been
+on — `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y`, ELF format, CRC32-checked, into a
+64 KB `coredump` partition at `0xFF0000` — but nothing read it back until v1.15.3.
+
+Two things changed:
+
+- **`setup()` now reports a stored dump** on every boot: size, offset, faulting
+  task, PC, and the RISC-V trap registers. That much lands in any serial log a
+  user pastes into an issue, with no tooling.
+- **This page** is how to get the full symbolised backtrace.
+
+The dump is **not** erased after being reported. It survives reboots and is only
+overwritten by the next panic, so there is no rush to collect it — but reflashing
+a *different build* will make the symbols useless (see the ELF warning below).
+
+## What you get for free
+
+If the device has crashed, its next boot prints something like:
+
+```
+[BOOT] Reset reason: PANIC (4) - CRASH: exception or assert
+[BOOT] *** PREVIOUS RUN ENDED ABNORMALLY ***
+[COREDUMP] *** A CRASH FROM A PREVIOUS RUN IS STORED ON THIS DEVICE ***
+[COREDUMP] 12480 bytes at flash offset 0xFF0000
+[COREDUMP]   task   : SonosPoll
+[COREDUMP]   PC     : 0x400D2A1C
+[COREDUMP]   mcause : 0x00000005   mtval : 0x00000000
+[COREDUMP]   ra     : 0x400D29F0   sp    : 0x3FCA1B20
+```
+
+`mcause` is the RISC-V trap cause. The ones worth recognising:
+
+| mcause | Meaning |
+|---|---|
+| `0x2` | Illegal instruction — often a corrupted function pointer |
+| `0x5` | Load access fault — read from a bad address (null/freed pointer) |
+| `0x7` | Store access fault — write to a bad address |
+| `0x1` | Instruction access fault — jumped somewhere invalid |
+
+A load/store fault with `mtval` at or near `0x00000000` is a null dereference.
+
+## Full backtrace
+
+Install the tool once:
+
+```bash
+python -m pip install esp-coredump
+```
+
+Then read the dump straight off the device, symbolised against the firmware:
+
+```bash
+python -m esp_coredump --chip esp32p4 --port COM9 \
+    info_corefile .pio/build/esp32_4inch/firmware.elf
+```
+
+Use `esp32_7inch` for the 7" build, and your own serial port.
+
+### The ELF has to match the build that crashed
+
+`firmware.elf` is what turns addresses into function names and line numbers. It
+must be the **exact build that was running when the crash happened**. If you have
+rebuilt or reflashed since, the addresses will resolve to the wrong symbols and
+quietly produce a plausible, wrong backtrace.
+
+The dump records the crashing build's `app_elf_sha256`, so `esp_coredump` will
+warn on a mismatch — do not ignore that warning.
+
+If the build is gone, the reset reason and the register dump above are still
+valid; only the symbol names are lost.
+
+### Saving the raw dump
+
+To archive it before it is overwritten, or to hand it to someone else:
+
+```bash
+python -m esp_coredump --chip esp32p4 --port COM9 \
+    info_corefile -s crash.elf .pio/build/esp32_4inch/firmware.elf
+```
+
+`-s` writes the core file out. Attach that plus the matching `firmware.elf` to an
+issue and it can be decoded anywhere.
+
+## Reading it without the serial console
+
+The console is USB CDC, which means the serial port belongs to the chip. A reset
+tears the port down, so anything the panic handler printed on its way out is lost
+before it reaches the host — which is exactly why a spontaneous reboot shows a
+clean log, a dropped port, and a fresh boot with no explanation.
+
+The core dump is written to flash *before* that happens. It is the only account of
+the crash that survives, and it is why the boot-time report exists.
+
+## If there is no dump
+
+`[COREDUMP]` lines absent on boot means no dump is stored. Combined with the
+`[BOOT] Reset reason:` line, that narrows things considerably:
+
+| Reset reason | No dump means |
+|---|---|
+| `POWERON` | Power was applied or the button was pressed. Not a crash. |
+| `BROWNOUT` | The supply dipped. Cable, PSU, or USB port — **not firmware**. |
+| `TASK_WDT` / `INT_WDT` | A hang, not an exception. Watchdogs do not write dumps. |
+| `PANIC` | A crash that failed to write its dump — flash busy, or the panic hit inside the dump writer. |
+| `SW` | A deliberate `esp_restart()` — OTA or a settings change. |

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,17 @@ default_envs = esp32_4inch
 ;  build. Hardware envs opt in with `extends`.
 ; =============================================================================
 [esp32_base]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+; 55.03.38-1, not 55.03.38: a one-day-later patch whose release notes read
+; "Platform fix: Wrong cmd build for OpenOCD - no changes in Arduino, no changes
+; in IDF against release 55.03.38". Debugger tooling only; the firmware is byte
+; identical in intent.
+;
+; NOT 55.03.39 or 55.03.311, deliberately. Commit 2a01b884 ("fix p4 rev3", shipped
+; in 311) comments out the ESP32-P4 rev3 linker-script selection in
+; builder/frameworks/espidf.py, so every P4 falls back to sections.ld.in. 3.3.9
+; also still carries the esp-hosted regression, which matters on a board whose
+; WiFi runs over SDIO. Re-evaluate when the P4 linker line is restored upstream.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 board = esp32-p4
 framework = arduino
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,8 @@
 #include "clock_face.h"
 #include "ui_theme.h"
 #include <esp_flash.h>
+#include <esp_ota_ops.h>    // OTA trial-run validation
+#include <esp_core_dump.h>  // stored crash reporting
 #include <esp_system.h>   // esp_reset_reason()
 #include <esp_task_wdt.h>
 #include "ui_fonts.h"
@@ -33,6 +35,134 @@ static void deferredDiscoveryTask(void* param);  // forward declaration — one-
 // serial log of a spontaneous reboot therefore shows a clean run, a dropped port,
 // and a fresh boot - with no indication of what happened. This survives the reset
 // and says which it was.
+// ============================================================================
+// OTA trial run
+// ----------------------------------------------------------------------------
+// The bootloader has rollback enabled (CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE),
+// so a freshly flashed image boots in PENDING_VERIFY and reverts to the previous
+// build unless something confirms it. The Arduino core confirms it inside
+// initArduino() - before setup(), before WiFi, before the display. That only
+// protects against an image too broken to reach Arduino init at all. An image
+// that boots, confirms itself, and then dies in setup() is a brick that needs a
+// USB cable, which is the worst outcome available to a fleet this size.
+//
+// verifyRollbackLater() is a weak symbol in cores/esp32/esp32-hal-misc.c.
+// Overriding it to return true stops the core confirming, and hands the decision
+// to loop() below.
+//
+// extern "C" is REQUIRED, not stylistic: the default is defined in a .c file, so
+// a C++-mangled symbol would not override it. The build would link, the core
+// would keep confirming during init, and this whole mechanism would be silently
+// inert. Verified after building by checking firmware.map resolves the symbol to
+// main.cpp.o rather than esp32-hal-misc.c.o.
+// ============================================================================
+static const uint32_t OTA_TRIAL_MS = 60000;   // healthy runtime before confirming
+
+static bool s_ota_on_trial   = false;
+static bool s_ota_confirmed  = false;
+static uint32_t s_ota_next_try_ms = 0;
+
+extern "C" bool verifyRollbackLater() {
+    return true;   // defer to loop(); see the block comment above
+}
+
+static void beginOtaTrial() {
+    const esp_partition_t* running = esp_ota_get_running_partition();
+    esp_ota_img_states_t st;
+    const bool known = running && esp_ota_get_state_partition(running, &st) == ESP_OK;
+
+    // Arm unless we positively know this image is NOT on trial.
+    //
+    // The two failure directions are not symmetric. Confirming an image that was
+    // already valid is a no-op - the call just restates that the app works. NOT
+    // confirming an image that was on trial reverts a build that may be perfectly
+    // fine, on every device that took the update. So an unreadable OTA state must
+    // fall through to confirming, never to silence.
+    if (known && st != ESP_OTA_IMG_PENDING_VERIFY) {
+        return;   // definitively a normal boot, nothing on trial
+    }
+    if (!known) {
+        Serial.println("[OTA] OTA state unreadable - arming the trial anyway (fail-safe).");
+    }
+
+    s_ota_on_trial = true;
+    Serial.printf("[OTA] Image on trial from '%s'.\n",
+                  running ? running->label : "unknown");
+    Serial.printf("[OTA] Confirming after %us of healthy runtime; a crash or hang\n",
+                  (unsigned)(OTA_TRIAL_MS / 1000));
+    Serial.println("[OTA] before then rolls back to the previous build automatically.");
+}
+
+// Called from loop(). Retries on failure rather than giving up: leaving the image
+// unconfirmed would roll back a build that is actually fine.
+static void confirmOtaIfDue() {
+    if (!s_ota_on_trial || s_ota_confirmed) return;
+    uint32_t now = millis();
+    if (now < OTA_TRIAL_MS || now < s_ota_next_try_ms) return;
+
+    esp_err_t e = esp_ota_mark_app_valid_cancel_rollback();
+    if (e == ESP_OK) {
+        s_ota_confirmed = true;
+        Serial.println("[OTA] Image confirmed good - rollback cancelled.");
+    } else {
+        s_ota_next_try_ms = now + 10000;    // back off, but keep trying
+        Serial.printf("[OTA] Could not confirm image (%s) - retrying in 10s\n",
+                      esp_err_to_name(e));
+    }
+}
+
+// ============================================================================
+// Stored crash reporting
+// ----------------------------------------------------------------------------
+// Core dumps have been enabled to flash this whole time
+// (CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH, ELF format, CRC32, 64KB partition), and
+// nothing has ever read one back. Every panic the firmware has taken was written
+// down and then ignored.
+//
+// The dump is NOT erased here. It stays until the next panic overwrites it, so it
+// can still be pulled off the device in full afterwards; this only surfaces its
+// existence and the headline facts, which is what turns "it rebooted, no idea
+// why" into something actionable from a pasted log.
+// ============================================================================
+static void reportStoredCoreDump() {
+    size_t addr = 0, size = 0;
+    if (esp_core_dump_image_get(&addr, &size) != ESP_OK) {
+        return;   // ESP_ERR_NOT_FOUND: no dump stored, which is the normal case
+    }
+
+    Serial.println("[COREDUMP] *** A CRASH FROM A PREVIOUS RUN IS STORED ON THIS DEVICE ***");
+    Serial.printf("[COREDUMP] %u bytes at flash offset 0x%06X\n",
+                  (unsigned)size, (unsigned)addr);
+
+    if (esp_core_dump_image_check() != ESP_OK) {
+        Serial.println("[COREDUMP] Stored image fails its checksum - cannot summarise it.");
+        return;
+    }
+
+    // ~1KB of stack dump inside; heap it rather than spend that on loopTask.
+    esp_core_dump_summary_t* sum =
+        (esp_core_dump_summary_t*)malloc(sizeof(esp_core_dump_summary_t));
+    if (!sum) {
+        Serial.println("[COREDUMP] Not enough heap to summarise; raw dump is still readable.");
+        return;
+    }
+
+    if (esp_core_dump_get_summary(sum) == ESP_OK) {
+        Serial.printf("[COREDUMP]   task   : %.16s\n", sum->exc_task);
+        Serial.printf("[COREDUMP]   PC     : 0x%08X\n", (unsigned)sum->exc_pc);
+        Serial.printf("[COREDUMP]   mcause : 0x%08X   mtval : 0x%08X\n",
+                      (unsigned)sum->ex_info.mcause, (unsigned)sum->ex_info.mtval);
+        Serial.printf("[COREDUMP]   ra     : 0x%08X   sp    : 0x%08X\n",
+                      (unsigned)sum->ex_info.ra, (unsigned)sum->ex_info.sp);
+    } else {
+        Serial.println("[COREDUMP] Summary unavailable; the raw dump is still readable.");
+    }
+    free(sum);
+
+    Serial.println("[COREDUMP] Full backtrace: read the partition and decode it against");
+    Serial.println("[COREDUMP]   .pio/build/<env>/firmware.elf  (see docs/COREDUMP.md)");
+}
+
 static void logResetReason() {
     esp_reset_reason_t r = esp_reset_reason();
     const char* why;
@@ -64,6 +194,8 @@ void setup() {
     delay(500);
     Serial.println("\n=== SONOS CONTROLLER ===");
     logResetReason();
+    reportStoredCoreDump();
+    beginOtaTrial();
     Serial.printf("Free heap: %d, PSRAM: %d\n", esp_get_free_heap_size(), heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
 
     // Detect flash chip - auto-suspend only works with specific chips
@@ -717,5 +849,11 @@ static void mainAppTask(void* param) {
 void loop() {
     // Idle — all UI/LVGL work is done in mainAppTask (32KB stack).
     // loopTask hard-coded 8KB stack cannot be changed via build flags.
+    //
+    // The one thing that does run here: confirming a freshly OTA'd image once it
+    // has survived OTA_TRIAL_MS. This task existing and ticking IS the health
+    // signal - if the firmware panics or hangs before then, loop() stops running,
+    // nothing confirms, and the bootloader reverts on the next boot.
+    confirmOtaIfDue();
     vTaskDelay(pdMS_TO_TICKS(100));
 }


### PR DESCRIPTION
Both were already enabled, already costing flash and boot time, and already producing nothing. Neither is a new feature — this wires up what was configured and never read.

## 1. OTA rollback now means "this build works", not "this image is not corrupt"

Rollback is enabled in the bootloader, so a fresh image boots `PENDING_VERIFY` and reverts unless confirmed. **The Arduino core confirms it inside `initArduino()`** — before `setup()`, before WiFi, before the display (`esp32-hal-misc.c:312-318`). So it only ever guarded against an image too broken to reach Arduino init. One that boots, confirms itself, then dies in `setup()` is a brick needing a USB cable — on every device that took the update.

`verifyRollbackLater()` is a weak symbol. Overridden to return `true`; `loop()` confirms instead, after 60s. **`loop()` ticking is the health signal** — panic or hang before then and nothing confirms, so the bootloader reverts.

Two details decide whether this works or silently does nothing:

- **`extern "C"` is required.** The default lives in a `.c` file, so a C++-mangled symbol would not override it — the build would link, the core would keep confirming, and the mechanism would be inert with no sign of it. **Verified in `firmware.map` for both environments:** the symbol resolves to `src/main.cpp.o`, not `esp32-hal-misc.c.o`.
- **`beginOtaTrial()` fails safe.** The directions are not symmetric: confirming an already-valid image is a no-op; failing to confirm one on trial reverts a good build fleet-wide. An unreadable OTA state therefore falls through to confirming.

## 2. Core dumps are read back instead of discarded

`CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y`, ELF, CRC32, 64KB at `0xFF0000`. Every panic this firmware ever took was written to flash and never looked at. `setup()` now reports a stored dump — size, offset, faulting task, PC, and the RISC-V trap registers.

That lands in any serial log a user pastes into an issue, with no tooling on their side. `docs/COREDUMP.md` covers the full backtrace; the `esp_coredump` invocation there was **run locally to confirm its flags**, and the doc is explicit that `firmware.elf` must match the crashing build or symbols resolve to plausible nonsense.

The dump is deliberately **not** erased — it survives reboots and is only overwritten by the next panic, so it can still be collected in full.

Pairs with the reset-reason logging: reason says which class of failure, the dump says where.

## 3. Platform `55.03.38` → `55.03.38-1`

Verified inert: *"Platform fix: Wrong cmd build for OpenOCD — no changes in Arduino, no changes in IDF against release 55.03.38"*.

Still **not** 39 or 311, and the reason now lives in `platformio.ini` instead of memory: commit `2a01b884` comments out the ESP32-P4 rev3 linker-script selection, so every P4 falls back to `sections.ld.in`. I read that diff rather than trusting the note.

## 4. Weekly PlatformIO dependency check

Dependabot has no PlatformIO ecosystem, so LVGL, ArduinoJson, PNGdec, JPEGDEC, TAMC_GT911 and the platform pin are invisible to it — exactly the dependencies that ship. `deps-check.yml` runs `pio pkg outdated` weekly and opens (or updates) **one** issue when it is not clean. It deliberately bumps nothing, since the platform pin is held back on purpose.

Verified rather than assumed: the clean-signal grep matches current output, the script body passes `node --check`, `github-script@v9` is the current major, and the `dependencies` label already exists — `issues.create` would have failed without it.

## Testing

Both environments build; `ui_lint` clean. **Not bench-flashed.**

The rollback change is the one to exercise deliberately: flash this, confirm `[OTA] Image confirmed good` appears ~60s after an OTA, then ship a build that aborts in `setup()` and confirm it reverts.