### PR TITLE
docs: gold accent site-wide, rebuilt installer, and a wrong part number

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ First off, thank you for considering contributing to SonosESP! It's people like 
 Before creating bug reports, please check existing issues to avoid duplicates. When you create a bug report, include as many details as possible:
 
 **Bug Report Template:**
-- **Device**: GUITION JC4880P433C (ESP32-P4 + ESP32-C6) or your specific board
+- **Device**: GUITION JC4880P443C (ESP32-P4 + ESP32-C6) or your specific board
 - **Firmware Version**: (e.g., v1.2.1)
 - **Description**: Clear description of the issue
 - **Steps to Reproduce**: Numbered list of steps
@@ -45,7 +45,7 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 
 ### Hardware Requirements
 
-- **Board**: GUITION JC4880P433C (ESP32-P4 + ESP32-C6 via SDIO)
+- **Board**: GUITION JC4880P443C (ESP32-P4 + ESP32-C6 via SDIO)
 - **Display**: ST7701 MIPI DSI (480x800 portrait, rendered 800x480 landscape)
 - **PSRAM**: 32MB OPI at 200MHz
 - **Sonos System**: For testing

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **Hardware**
-- Board: [e.g., GUITION JC4880P433C]
+- Board: [e.g., GUITION JC4880P443C]
 - Flash: [e.g., Boya BY25Q]
 - PSRAM: [e.g., 32MB OPI]
 - Display: [e.g., ST7701 MIPI DSI 480x800]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Fixes #(issue number)
 <!-- Describe the tests you ran to verify your changes -->
 
 ### Hardware Testing
-- [ ] Tested on GUITION JC4880P433C (ESP32-P4 + ESP32-C6)
+- [ ] Tested on GUITION JC4880P443C (ESP32-P4 + ESP32-C6)
 - [ ] Tested on other hardware: _______________
 
 ### Functionality Testing

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ SonosESP runs on **GUITION ESP32-P4 + ESP32-C6 touchscreen boards**. Both panel 
 build from the same codebase, and the installer and OTA select the right image
 automatically (`firmware-4inch.bin` / `firmware-7inch.bin`).
 
-![GUITION JC4880P433C ESP32-P4 touchscreen development board](assets/image.png)
+![GUITION JC4880P443C ESP32-P4 touchscreen development board](assets/image.png)
 
 | | **4″ — stable** | **7″ — beta** |
 |---|---|---|
-| **Board** | GUITION JC4880P433C | GUITION JC1060P470C |
+| **Board** | GUITION JC4880P443C | GUITION JC1060P470C |
 | **Display** | 800×480, ST7701 (MIPI DSI) | 1024×600, JD9165 (MIPI DSI) |
 | **Touch** | GT911 capacitive (I²C) | GT911 capacitive (I²C) |
 | **MCU** | ESP32-P4, 400 MHz dual-core RISC-V | ESP32-P4, 400 MHz dual-core RISC-V |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,7 +36,7 @@ the same source via PlatformIO envs (see `platformio.ini`):
 
 | Variant | Env | Board | App binary |
 |---|---|---|---|
-| **4″** (shipping) | `esp32_4inch` | GUITION JC4880P433C (ST7701, 800×480) | `firmware-4inch.bin` |
+| **4″** (shipping) | `esp32_4inch` | GUITION JC4880P443C (ST7701, 800×480) | `firmware-4inch.bin` |
 | **7″** (BETA) | `esp32_7inch` | GUITION JC1060P470C (JD9165, 1024×600) | `firmware-7inch.bin` |
 
 - `bootloader.bin` / `partitions.bin` are **board-level and identical** across both, so a release ships one shared copy of each.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,7 +56,18 @@ export default defineConfig({
     }
   },
 
+  // The design is a single dark surface - there is no light variant of it, and
+  // half-applying it would leave the docs in one palette and the home page in
+  // another. force-dark also drops the appearance toggle from the nav.
+  appearance: 'force-dark',
+
   themeConfig: {
+    // VPNavBarTitle renders this with v-html, so the wordmark can be markup and
+    // "ESP" can carry the firmware's gold. Doing it here rather than through a
+    // component in the nav-bar-title-before slot: that slot sits INSIDE the
+    // title's own <a>, so the two could both render and did.
+    siteTitle: 'Sonos<span class="site-esp">ESP</span>',
+
     nav: [
       { text: 'Install', link: '/guide/install' },
       { text: 'Features', link: '/guide/features' },

--- a/docs/.vitepress/theme/HomeBody.vue
+++ b/docs/.vitepress/theme/HomeBody.vue
@@ -18,10 +18,15 @@ const cards = [
 ]
 
 // The toggle swaps the spec row. Values match docs/guide/hardware.md.
+// Prices are a rough guide checked Sept 2026 and they move, so the wording is
+// "about" and the link is a SEARCH by part number, not a listing URL -
+// individual AliExpress listings go dead constantly, a search does not.
 const panel = ref<4 | 7>(4)
 const spec = computed(() => panel.value === 4
-  ? { part: 'JC4880P433C', screen: '4″ · 480×480' }
-  : { part: 'JC1060P470C', screen: '7″ · 1024×600' })
+  ? { part: 'JC4880P443C', screen: '4″ · 800×480', price: '~$32' }
+  : { part: 'JC1060P470C', screen: '7″ · 1024×600', price: '~$37' })
+const buyUrl = computed(
+  () => `https://www.aliexpress.com/w/wholesale-${spec.value.part}.html`)
 
 const steps = [
   { n: '01', t: 'Plug it in',   d: 'USB-C to your computer. Chrome, Edge or Opera.' },
@@ -92,7 +97,7 @@ const showcaseUrl =
       <div class="col-a">
         <div class="hw-shot">
           <img :src="withBase('/panel.png')"
-               alt="GUITION JC4880P433C ESP32-P4 touchscreen panel, shown front and back"
+               alt="GUITION JC4880P443C ESP32-P4 touchscreen panel, shown front and back"
                width="636" height="608" loading="lazy" />
         </div>
       </div>
@@ -116,9 +121,17 @@ const showcaseUrl =
           <div class="cell"><span class="k">Part</span><span class="v">{{ spec.part }}</span></div>
           <div class="cell"><span class="k">Screen</span><span class="v nowrap">{{ spec.screen }}</span></div>
           <div class="cell"><span class="k">Cable</span><span class="v">USB-C</span></div>
+          <div class="cell"><span class="k">Price</span><span class="v nowrap">{{ spec.price }}</span></div>
         </div>
 
-        <a class="ulink" :href="withBase('/guide/hardware')">Which one to buy &#8594;</a>
+        <p class="pricenote">
+          About <strong>$30&#8211;40</strong> shipped, depending on the seller and the day.
+        </p>
+
+        <div class="hw-links">
+          <a class="ulink" :href="buyUrl" target="_blank" rel="noopener">Find it on AliExpress &#8594;</a>
+          <a class="ulink" :href="withBase('/guide/hardware')">Which one to buy &#8594;</a>
+        </div>
       </div>
     </div>
   </section>
@@ -245,7 +258,7 @@ const showcaseUrl =
 .ulink {
   display: inline-block; margin-top: 22px; font-size: 14.5px; font-weight: 500;
   color: var(--se-accent-text); text-decoration: none;
-  border-bottom: 1px solid oklch(.78 .13 42 / .35); padding-bottom: 2px;
+  border-bottom: 1px solid rgba(224, 178, 82, .35); padding-bottom: 2px;
 }
 .ulink:hover { color: var(--se-accent-hover); }
 
@@ -292,6 +305,10 @@ const showcaseUrl =
   background: rgba(242, 236, 228, .015);
 }
 .hw-shot img { display: block; width: 100%; height: auto; border-radius: 16px; }
+.pricenote { margin: 14px 0 0; font-size: .9rem; color: rgba(242, 236, 228, .58); }
+.pricenote strong { color: rgba(242, 236, 228, .82); font-weight: 600; }
+.hw-links { display: flex; flex-wrap: wrap; gap: 22px; }
+.hw-links .ulink { margin-top: 18px; }
 
 .seg {
   display: inline-flex; gap: 4px; margin-top: 28px; padding: 4px;
@@ -376,7 +393,7 @@ const showcaseUrl =
   padding: clamp(28px, 4vw, 48px); border-radius: 20px;
   border: 1px solid rgba(242, 236, 228, .1);
   background:
-    radial-gradient(80% 140% at 100% 0%, oklch(.7 .16 40 / .14), transparent 70%),
+    radial-gradient(80% 140% at 100% 0%, rgba(224, 178, 82, .16), transparent 70%),
     rgba(242, 236, 228, .025);
   display: flex; flex-wrap: wrap; gap: 28px;
   align-items: center; justify-content: space-between;
@@ -384,7 +401,7 @@ const showcaseUrl =
 .sup-copy { flex: 1 1 420px; min-width: 0; }
 .sup-copy .body { max-width: 58ch; margin-top: 16px; }
 .btn.kofi { background: var(--se-accent); color: #17120f; padding: 15px 26px; }
-.btn.kofi:hover { background: oklch(.76 .15 42); transform: translateY(-1px); }
+.btn.kofi:hover { background: var(--se-accent-hover); transform: translateY(-1px); }
 
 /* ---- footer ---- */
 .site-foot {

--- a/docs/.vitepress/theme/HomeHero.vue
+++ b/docs/.vitepress/theme/HomeHero.vue
@@ -160,8 +160,8 @@ onMounted(async () => {
 .bloom {
   position: absolute; inset: -10% -20% 30% -20%; pointer-events: none;
   background:
-    radial-gradient(52% 60% at 22% 8%, oklch(.7 .16 40 / .2), transparent 70%),
-    radial-gradient(46% 54% at 82% 4%, oklch(.74 .12 72 / .15), transparent 72%);
+    radial-gradient(52% 60% at 22% 8%, var(--se-bloom-a), transparent 70%),
+    radial-gradient(46% 54% at 82% 4%, var(--se-bloom-b), transparent 72%);
 }
 .hero-inner {
   position: relative; max-width: 1180px; margin: 0 auto;
@@ -184,7 +184,7 @@ h1 {
   margin: 0; font-size: clamp(2.6rem, 6.4vw, 4.5rem); line-height: .98;
   letter-spacing: -.035em; font-weight: 600; text-wrap: balance;
 }
-.accent { color: oklch(.72 .16 40); }
+.accent { color: var(--se-gold); }
 
 .lede {
   margin: 26px 0 0; max-width: 46ch; font-size: clamp(1rem, 1.3vw, 1.12rem);

--- a/docs/.vitepress/theme/InstallPanel.vue
+++ b/docs/.vitepress/theme/InstallPanel.vue
@@ -4,9 +4,11 @@ import { withBase } from 'vitepress'
 
 const BOARDS = {
   '4inch': {
-    manifest: 'manifest-4inch.json',
-    label: 'Install 4″ firmware',
     name: '4-inch',
+    part: 'JC4880P443C',
+    bin: 'firmware-4inch.bin',
+    manifest: 'manifest-4inch.json',
+    label: 'Connect and install',
     beta: false,
     specs: [
       ['Controller', 'ESP32-P4 + ESP32-C6'],
@@ -17,9 +19,11 @@ const BOARDS = {
     ],
   },
   '7inch': {
-    manifest: 'manifest-7inch.json',
-    label: 'Install 7″ firmware (beta)',
     name: '7-inch',
+    part: 'JC1060P470C',
+    bin: 'firmware-7inch.bin',
+    manifest: 'manifest-7inch.json',
+    label: 'Connect and install',
     beta: true,
     specs: [
       ['Controller', 'ESP32-P4 + ESP32-C6'],
@@ -37,26 +41,51 @@ type BoardId = keyof typeof BOARDS
 const selected = ref<BoardId>('4inch')
 const board = computed(() => BOARDS[selected.value])
 const manifestUrl = computed(() => withBase('/' + board.value.manifest))
-const version = ref('')
 
-onMounted(async () => {
-  // Version pill. Failure stays silent on purpose — a stale or unreachable
-  // manifest should not put an error in front of someone about to flash.
+const version = ref('')
+const parts = ref<{ path: string; offset: string }[]>([])
+
+/* Read the manifest we are about to flash rather than hardcoding a parts list.
+   It is the same file esp-web-tools consumes, so what is shown here is exactly
+   what gets written - including boot_app0.bin at 0xe000, the omission that
+   deploy-pages.yml has a guard for because leaving it out bricks the boot. */
+async function loadManifest(url: string) {
+  parts.value = []
   try {
-    const r = await fetch(withBase('/manifest-4inch.json'))
-    version.value = (await r.json()).version ?? ''
-  } catch {}
-})
+    const m = await (await fetch(url)).json()
+    version.value = m.version ?? version.value
+    const build = m.builds?.[0]
+    parts.value = (build?.parts ?? []).map((p: any) => ({
+      path: String(p.path ?? '').split('/').pop() ?? '',
+      offset: '0x' + Number(p.offset ?? 0).toString(16),
+    }))
+  } catch {
+    // Silent on purpose: an unreachable manifest should not put an error in
+    // front of someone who is about to plug a board in. The button still works.
+  }
+}
+
+onMounted(() => loadManifest(manifestUrl.value))
+
+function pick(id: BoardId) {
+  selected.value = id
+  loadManifest(withBase('/' + BOARDS[id].manifest))
+}
 </script>
 
 <template>
   <div class="ip">
     <div class="ip-head">
-      <span class="ip-title">Choose your screen</span>
-      <span v-if="version" class="ip-ver">v{{ version }}</span>
+      <div>
+        <p class="ip-kicker">Browser installer</p>
+        <p class="ip-title">Flash it over USB</p>
+      </div>
+      <span class="ip-env">Web Serial · Chrome · Edge · Opera</span>
     </div>
 
-    <div class="ip-boards" role="radiogroup" aria-label="Screen size">
+    <!-- ── step 1 ────────────────────────────────────────────────────────── -->
+    <p class="ip-step"><span class="ip-num">01</span> Pick your panel</p>
+    <div class="ip-boards" role="radiogroup" aria-label="Panel size">
       <button
         v-for="(b, id) in BOARDS"
         :key="id"
@@ -64,10 +93,14 @@ onMounted(async () => {
         role="radio"
         class="ip-board"
         :aria-checked="selected === id"
-        @click="selected = id as BoardId"
+        @click="pick(id as BoardId)"
       >
-        <span class="ip-board-name">{{ b.name }}</span>
-        <span v-if="b.beta" class="ip-beta">beta</span>
+        <span class="ip-b-top">
+          <span class="ip-b-name">{{ b.name }}</span>
+          <span v-if="b.beta" class="ip-beta">beta</span>
+        </span>
+        <span class="ip-b-part">{{ b.part }}</span>
+        <span class="ip-b-bin">{{ b.bin }}</span>
       </button>
     </div>
 
@@ -84,69 +117,162 @@ onMounted(async () => {
       first-boot wizard works out which one you have.
     </p>
 
+    <!-- ── step 2 ────────────────────────────────────────────────────────── -->
+    <p class="ip-step"><span class="ip-num">02</span> Plug the panel in over USB-C</p>
+
     <!--
       :key forces Vue to destroy and recreate the element when the board changes.
       esp-web-tools parses and caches the manifest on the element, so reusing it
       would keep flashing the previously selected build.
     -->
     <esp-web-install-button :key="selected" :manifest="manifestUrl">
-      <button slot="activate" type="button" class="ip-go">{{ board.label }}</button>
+      <button slot="activate" type="button" class="ip-go">
+        {{ board.label }} <span class="ip-arrow">&#8594;</span>
+      </button>
       <span slot="unsupported" class="ip-unsupported">
-        This browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.
+        This browser cannot flash over USB — it has no Web Serial. Use Chrome,
+        Edge or Opera on a desktop.
       </span>
       <span slot="not-allowed" class="ip-unsupported">
         Flashing needs a secure connection (https).
       </span>
     </esp-web-install-button>
+
+    <!-- What actually gets written. This is the part people get wrong by hand. -->
+    <div v-if="parts.length" class="ip-parts">
+      <p class="ip-parts-h">
+        Writes {{ parts.length }} parts
+        <span v-if="version" class="ip-ver">v{{ version }}</span>
+      </p>
+      <ul>
+        <li v-for="p in parts" :key="p.offset">
+          <code>{{ p.offset }}</code><span>{{ p.path }}</span>
+        </li>
+      </ul>
+      <p class="ip-parts-f">Your Wi-Fi and speaker settings are kept.</p>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .ip {
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 12px;
-  padding: 20px;
-  margin: 24px 0;
-  background: var(--vp-c-bg-soft);
+  border: 1px solid rgba(242, 236, 228, .12);
+  border-radius: 18px;
+  padding: clamp(20px, 3vw, 28px);
+  margin: 28px 0;
+  background:
+    radial-gradient(90% 120% at 100% 0%, rgba(224, 178, 82, .08), transparent 62%),
+    rgba(242, 236, 228, .025);
 }
-.ip-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
-.ip-title { font-weight: 600; }
-.ip-ver {
-  font-size: 12px; font-variant-numeric: tabular-nums;
-  color: var(--vp-c-text-2); border: 1px solid var(--vp-c-divider);
-  border-radius: 999px; padding: 2px 8px;
+
+.ip-head {
+  display: flex; flex-wrap: wrap; gap: 12px;
+  align-items: flex-start; justify-content: space-between;
+  padding-bottom: 18px; border-bottom: 1px solid rgba(242, 236, 228, .08);
 }
-.ip-boards { display: flex; gap: 10px; margin: 14px 0 16px; flex-wrap: wrap; }
+.ip-kicker {
+  margin: 0 0 6px; font-family: var(--vp-font-family-mono);
+  font-size: 10.5px; letter-spacing: .18em; text-transform: uppercase;
+  color: var(--se-gold);
+}
+.ip-title { margin: 0; font-size: 1.25rem; font-weight: 600; letter-spacing: -.02em; }
+.ip-env {
+  font-family: var(--vp-font-family-mono); font-size: 11px; letter-spacing: .06em;
+  color: var(--vp-c-text-3); padding-top: 4px;
+}
+
+.ip-step {
+  display: flex; align-items: center; gap: 10px;
+  margin: 22px 0 12px; font-size: .95rem; font-weight: 600;
+}
+.ip-num {
+  font-family: var(--vp-font-family-mono); font-size: 11px; letter-spacing: .16em;
+  color: var(--se-gold);
+}
+
+.ip-boards { display: flex; gap: 10px; flex-wrap: wrap; }
 .ip-board {
-  flex: 1 1 140px; display: flex; align-items: center; justify-content: center; gap: 8px;
-  padding: 12px 14px; border-radius: 10px; cursor: pointer;
-  border: 1px solid var(--vp-c-divider); background: var(--vp-c-bg);
-  color: var(--vp-c-text-1); font: inherit; font-weight: 600;
+  flex: 1 1 180px; display: flex; flex-direction: column; gap: 5px;
+  padding: 14px 16px; border-radius: 12px; cursor: pointer; text-align: left;
+  border: 1px solid rgba(242, 236, 228, .12);
+  background: rgba(242, 236, 228, .02);
+  color: var(--vp-c-text-1); font: inherit;
   transition: border-color .15s, background .15s;
 }
-.ip-board:hover { border-color: var(--vp-c-brand-1); }
+.ip-board:hover { border-color: rgba(242, 236, 228, .3); }
 .ip-board[aria-checked='true'] {
-  border-color: var(--vp-c-brand-1);
-  background: var(--vp-c-brand-soft);
+  border-color: var(--se-gold);
+  background: rgba(242, 236, 228, .08);
 }
+.ip-b-top { display: flex; align-items: center; gap: 8px; }
+.ip-b-name { font-weight: 600; font-size: 15px; }
+.ip-b-part, .ip-b-bin {
+  font-family: var(--vp-font-family-mono); font-size: 11.5px;
+  color: var(--vp-c-text-3);
+}
+.ip-b-part { color: var(--vp-c-text-2); }
 .ip-beta {
-  font-size: 10px; letter-spacing: .08em; text-transform: uppercase;
-  padding: 2px 6px; border-radius: 3px;
-  background: var(--vp-c-warning-soft); color: var(--vp-c-warning-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 9.5px; letter-spacing: .12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  background: rgba(201, 117, 47, .18); color: #e09a5a;
 }
-.ip-specs { margin: 0 0 16px; display: grid; gap: 6px; }
-.ip-specs > div { display: flex; justify-content: space-between; font-size: 14px; }
-.ip-specs dt { color: var(--vp-c-text-2); }
-.ip-specs dd { margin: 0; font-variant-numeric: tabular-nums; }
+
+.ip-specs {
+  margin: 16px 0 0; display: grid; gap: 1px; border-radius: 12px; overflow: hidden;
+  background: rgba(242, 236, 228, .08);
+  border: 1px solid rgba(242, 236, 228, .08);
+}
+.ip-specs > div {
+  display: flex; justify-content: space-between; gap: 16px;
+  padding: 10px 14px; background: #100e0d; font-size: 13.5px;
+}
+.ip-specs dt { color: var(--vp-c-text-3); }
+.ip-specs dd {
+  margin: 0; font-family: var(--vp-font-family-mono); font-size: 12.5px;
+  color: var(--vp-c-text-1);
+}
+
 .ip-note {
-  font-size: 13px; color: var(--vp-c-text-2);
-  border-left: 3px solid var(--vp-c-warning-1); padding-left: 12px; margin: 0 0 16px;
+  font-size: 13px; line-height: 1.6; color: var(--vp-c-text-2);
+  border-left: 2px solid #c9752f; padding: 2px 0 2px 14px; margin: 16px 0 0;
 }
+
 .ip-go {
-  width: 100%; padding: 12px 16px; border: 0; border-radius: 10px; cursor: pointer;
-  background: var(--vp-c-brand-1); color: var(--vp-c-white);
+  width: 100%; padding: 15px 20px; border: 0; border-radius: 999px; cursor: pointer;
+  background: var(--se-gold); color: #17120f;
   font: inherit; font-weight: 600; font-size: 15px;
+  display: inline-flex; align-items: center; justify-content: center; gap: 10px;
+  transition: background .15s, transform .15s;
 }
-.ip-go:hover { background: var(--vp-c-brand-2); }
-.ip-unsupported { display: block; font-size: 13px; color: var(--vp-c-text-2); }
+.ip-go:hover { background: var(--se-accent-hover); transform: translateY(-1px); }
+.ip-arrow { font-family: var(--vp-font-family-mono); }
+.ip-unsupported {
+  display: block; font-size: 13px; line-height: 1.6; color: var(--vp-c-text-2);
+  border: 1px dashed rgba(242, 236, 228, .18); border-radius: 10px; padding: 14px 16px;
+}
+
+.ip-parts { margin-top: 20px; padding-top: 16px; border-top: 1px solid rgba(242, 236, 228, .08); }
+.ip-parts-h {
+  display: flex; align-items: center; gap: 10px; margin: 0 0 10px;
+  font-family: var(--vp-font-family-mono); font-size: 10.5px;
+  letter-spacing: .16em; text-transform: uppercase; color: var(--vp-c-text-3);
+}
+.ip-ver {
+  letter-spacing: .04em; text-transform: none; padding: 2px 8px; border-radius: 999px;
+  border: 1px solid rgba(242, 236, 228, .16); color: var(--vp-c-text-2);
+}
+.ip-parts ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 4px; }
+.ip-parts li { display: flex; gap: 12px; align-items: baseline; font-size: 12.5px; }
+.ip-parts code {
+  font-family: var(--vp-font-family-mono); color: var(--se-gold);
+  background: none; padding: 0; min-width: 62px;
+}
+.ip-parts li span { color: var(--vp-c-text-2); }
+.ip-parts-f { margin: 12px 0 0; font-size: 12.5px; color: var(--vp-c-text-3); }
+
+@media (prefers-reduced-motion: reduce) {
+  .ip-board, .ip-go { transition: none; }
+  .ip-go:hover { transform: none; }
+}
 </style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -25,11 +25,22 @@
 :root {
   --se-ground: #0c0b0a;
   --se-ink: #f2ece4;
-  --se-accent: oklch(0.7 0.16 40);          /* coral - the site accent        */
-  --se-accent-text: oklch(0.78 0.13 42);
-  --se-accent-hover: oklch(0.86 0.1 45);
-  --se-accent-glow: oklch(0.7 0.16 40 / 0.8);
-  --se-gold: #E0B252;                        /* the firmware's AMB_ACCENT      */
+
+  /* The accent is the firmware's own gold, value for value, so the site and the
+     device are not two different brands. These are AMB_ACCENT, AMB_ACCENT_HI,
+     AMB_ACCENT_DIM and AMB_ACCENT_WASH out of include/amber.h. */
+  --se-gold:        #E0B252;
+  --se-accent:      #E0B252;
+  --se-accent-text: #E0B252;
+  --se-accent-hover:#EFC468;
+  --se-accent-glow: rgba(224, 178, 82, .8);
+  --se-accent-dim:  #4A3D22;   /* gold hairline border   */
+  --se-accent-wash: #241F16;   /* gold-tinted surface    */
+
+  /* Kept coral, deliberately: the hero bloom is atmosphere, not meaning, and a
+     single-hue gradient reads flat. Coral into amber keeps the warmth. */
+  --se-bloom-a: oklch(0.7 0.16 40 / 0.2);
+  --se-bloom-b: oklch(0.74 0.12 72 / 0.15);
   --se-mono: 'Space Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
   --se-sans: Sora, Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;
 }
@@ -49,7 +60,145 @@
    short page does not show the docs theme's background under the footer. */
 body:has(.home-page) { background: var(--se-ground); }
 
-.home-page ::selection { background: oklch(0.7 0.16 40 / 0.35); }
+.home-page ::selection { background: rgba(224, 178, 82, .3); }
 .home-page a { text-decoration: none; }
 html:has(.home-page) { scroll-behavior: smooth; }
 @media (prefers-reduced-motion: reduce) { html:has(.home-page) { scroll-behavior: auto; } }
+
+/* ══ Docs pages ═══════════════════════════════════════════════════════════
+   The design ships two docs artboards (Install, Features) that share one
+   shell: sticky 62px header, 220px sticky sidebar, 780px body, 1320px
+   container. Rather than replace VitePress's layout with a custom one, this
+   maps its own tokens onto the design's palette and type - so every page gets
+   it, including the ones the handoff never drew (setup, sources, themes,
+   updates, troubleshooting, 7-inch, and the 404).
+
+   Declared on `:root, .dark` because appearance:'force-dark' stamps .dark on
+   the html element, and a bare :root would only tie with the theme's own .dark
+   block rather than beat it.                                                  */
+:root, .dark {
+  --vp-c-bg:        #0c0b0a;
+  --vp-c-bg-alt:    #0a0908;   /* sidebar, footer            */
+  --vp-c-bg-soft:   #100e0d;   /* cards, inset panels        */
+  --vp-c-bg-elv:    #151311;   /* popovers, search modal     */
+
+  --vp-c-text-1: #f2ece4;
+  --vp-c-text-2: rgba(242, 236, 228, .68);
+  --vp-c-text-3: rgba(242, 236, 228, .5);
+
+  --vp-c-divider: rgba(242, 236, 228, .1);
+  --vp-c-gutter:  rgba(242, 236, 228, .08);
+  --vp-c-border:  rgba(242, 236, 228, .12);
+
+  --vp-c-brand-1: #E0B252;
+  --vp-c-brand-2: #EFC468;
+  --vp-c-brand-3: #E0B252;
+  --vp-c-brand-soft: rgba(224, 178, 82, .14);
+
+  --vp-font-family-base: Sora, Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --vp-font-family-mono: 'Space Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --vp-nav-height: 62px;
+  --vp-layout-max-width: 1320px;
+  --vp-sidebar-width: 240px;
+
+  --vp-code-block-bg: #060505;
+  --vp-code-copy-code-bg: #151311;
+
+  /* Buttons take the design's filled-ink pill rather than a coral fill. */
+  --vp-button-brand-bg: #f2ece4;
+  --vp-button-brand-text: #17120f;
+  --vp-button-brand-hover-bg: #ffffff;
+  --vp-button-brand-hover-text: #17120f;
+  --vp-button-brand-border: transparent;
+}
+
+/* Header: the same blurred bar the home page draws itself. */
+.VPNavBar, .VPNavBar.has-sidebar .content-body {
+  background: rgba(12, 11, 10, .72) !important;
+  backdrop-filter: blur(18px) saturate(1.4);
+  -webkit-backdrop-filter: blur(18px) saturate(1.4);
+}
+.VPNavBar { border-bottom: 1px solid rgba(242, 236, 228, .08); }
+.VPNavBar .divider { display: none; }
+/* The gold half of the wordmark, from themeConfig.siteTitle. */
+.VPNavBarTitle .site-esp { color: var(--se-gold); }
+.VPNavBarMenuLink { font-size: 13.5px; font-weight: 500; }
+
+/* Sidebar: active item gets the coral rule the design specifies. */
+.VPSidebar { background: var(--vp-c-bg-alt); border-right: 1px solid rgba(242, 236, 228, .07); }
+.VPSidebarItem.level-0 > .item > .text {
+  font-family: var(--vp-font-family-mono); font-size: 10.5px;
+  letter-spacing: .16em; text-transform: uppercase;
+  color: rgba(242, 236, 228, .5); font-weight: 400;
+}
+.VPSidebarItem.level-1 .link .link-text { font-size: 14px; }
+.VPSidebarItem.is-active > .item .link-text { color: var(--vp-c-text-1); font-weight: 600; }
+.VPSidebarItem.level-1.is-active > .item {
+  border-left: 2px solid var(--se-gold);
+  background: rgba(242, 236, 228, .05);
+  margin-left: -14px; padding-left: 12px; border-radius: 0 6px 6px 0;
+}
+
+/* Body type. Headings pick up the design's tight tracking and hairline rule. */
+.vp-doc h1 { font-size: clamp(2rem, 4vw, 2.8rem); line-height: 1.08; letter-spacing: -.035em; font-weight: 600; }
+.vp-doc h2 {
+  margin: 48px 0 16px; padding-bottom: 12px; letter-spacing: -.025em; font-weight: 600;
+  font-size: clamp(1.35rem, 2.4vw, 1.7rem);
+  border-top: 0; border-bottom: 1px solid rgba(242, 236, 228, .1);
+}
+.vp-doc h3 { margin-top: 32px; letter-spacing: -.02em; font-weight: 600; font-size: 1.15rem; }
+.vp-doc p, .vp-doc li { line-height: 1.65; }
+.vp-doc a { font-weight: 500; text-decoration-color: rgba(224, 178, 82, .35); }
+
+/* Tables - the design has no spec for these, so they follow the card grammar. */
+.vp-doc table { display: table; width: 100%; border-collapse: collapse; margin: 22px 0; }
+.vp-doc tr { background: transparent; border-top: 1px solid rgba(242, 236, 228, .07); }
+.vp-doc th {
+  font-family: var(--vp-font-family-mono); font-size: 10.5px; font-weight: 700;
+  letter-spacing: .14em; text-transform: uppercase;
+  color: rgba(242, 236, 228, .64); background: transparent;
+  border: 0; border-bottom: 1px solid rgba(242, 236, 228, .12); padding: 10px 14px 10px 0;
+  text-align: left;
+}
+.vp-doc td {
+  border: 0; padding: 12px 14px 12px 0; font-size: .94rem;
+  color: rgba(242, 236, 228, .74);
+}
+
+/* Admonitions - likewise undesigned; built from the coral callout the Install
+   artboard uses for "Wi-Fi is 2.4 GHz only." */
+.vp-doc .custom-block {
+  border: 1px solid rgba(242, 236, 228, .12); border-left-width: 2px;
+  border-radius: 0 12px 12px 0; background: rgba(242, 236, 228, .025);
+  padding: 16px 18px; font-size: .94rem;
+}
+.vp-doc .custom-block .custom-block-title {
+  font-family: var(--vp-font-family-mono); font-size: 10.5px; font-weight: 700;
+  letter-spacing: .16em; text-transform: uppercase; margin-bottom: 8px;
+}
+.vp-doc .custom-block.tip     { border-left-color: var(--se-gold); }
+.vp-doc .custom-block.tip .custom-block-title { color: var(--se-gold); }
+.vp-doc .custom-block.info    { border-left-color: rgba(242, 236, 228, .35); }
+/* Burnt orange, not amber: with the accent now gold, an amber warning would be
+   the same colour as an ordinary link. */
+.vp-doc .custom-block.warning { border-left-color: #c9752f; }
+.vp-doc .custom-block.warning .custom-block-title { color: #e09a5a; }
+.vp-doc .custom-block.danger  { border-left-color: #c9552f; }
+.vp-doc .custom-block.danger .custom-block-title { color: #e07a5a; }
+.vp-doc .custom-block a { color: var(--se-gold); }
+
+/* Code */
+.vp-doc div[class*='language-'] { border-radius: 12px; border: 1px solid rgba(242, 236, 228, .08); }
+.vp-doc :not(pre) > code {
+  font-size: .86em; padding: 3px 6px; border-radius: 5px;
+  background: rgba(242, 236, 228, .07); color: #f2ece4;
+}
+
+/* Prev/next pager and footer, as bordered cards. */
+.VPDocFooter .pager-link {
+  border-radius: 12px; border: 1px solid rgba(242, 236, 228, .1);
+  background: rgba(242, 236, 228, .025);
+}
+.VPDocFooter .pager-link:hover { border-color: rgba(242, 236, 228, .24); background: rgba(242, 236, 228, .045); }
+.VPFooter { background: var(--vp-c-bg-alt); border-top: 1px solid rgba(242, 236, 228, .07); }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,8 @@
-import './custom.css'
 import DefaultTheme from 'vitepress/theme'
+// AFTER the default theme on purpose: these are overrides, and :root vs .dark
+// is a specificity tie that source order decides. Imported first, every token
+// below would lose to VitePress's own palette.
+import './custom.css'
 import type { Theme } from 'vitepress'
 import InstallPanel from './InstallPanel.vue'
 import HomeHero from './HomeHero.vue'

--- a/docs/MULTI_SCREEN_SUPPORT.md
+++ b/docs/MULTI_SCREEN_SUPPORT.md
@@ -9,7 +9,7 @@
 
 ## 1. Goal
 
-Support multiple hardware variants (today: **4″ JC4880P433C**, **7″ JC1060P470C**; tomorrow:
+Support multiple hardware variants (today: **4″ JC4880P443C**, **7″ JC1060P470C**; tomorrow:
 more) from **one codebase**, with:
 
 - one set of source/logic shared by all boards,
@@ -45,7 +45,7 @@ Nothing is variant-aware — this is greenfield.
 
 | | **4″ (current)** | **7″ (new)** |
 |---|---|---|
-| Board | GUITION JC4880P433C | GUITION JC1060P470C |
+| Board | GUITION JC4880P443C | GUITION JC1060P470C |
 | SoC | ESP32-P4 + C6 | ESP32-P4 + C6 |
 | Panel driver | **ST7701** (MIPI DSI) | **JD9165** (MIPI DSI) |
 | Resolution (landscape) | **800 × 480** | **1024 × 600** |

--- a/docs/guide/hardware.md
+++ b/docs/guide/hardware.md
@@ -6,7 +6,7 @@ for you.
 
 |  | 4-inch (stable) | 7-inch (beta) |
 |---|---|---|
-| Board | GUITION JC4880P433C | GUITION JC1060P470C |
+| Board | GUITION JC4880P443C | GUITION JC1060P470C |
 | Display | 800×480, ST7701 | 1024×600, JD9165 |
 | Touch | GT911 capacitive | GT911 capacitive |
 | Processor | ESP32-P4, 400 MHz dual-core | ESP32-P4, 400 MHz dual-core |

--- a/include/config.h
+++ b/include/config.h
@@ -70,7 +70,7 @@
 #endif
 
 #if SCREEN_SIZE == 4
-    // GUITION JC4880P433C — ST7701 MIPI DSI
+    // GUITION JC4880P443C — ST7701 MIPI DSI
     #define DISPLAY_WIDTH       800     // LVGL width (landscape)
     #define DISPLAY_HEIGHT      480     // LVGL height (landscape)
     #define PANEL_WIDTH         480     // Physical panel width (portrait)

--- a/platformio.ini
+++ b/platformio.ini
@@ -120,7 +120,7 @@ build_src_filter = -<*>
 ; adding Unity's include path, so unity.h is installed but never found (CI #192).
 
 ; =============================================================================
-;  4"  —  GUITION JC4880P433C  (ST7701, 800x480)            [ WORKING ]
+;  4"  —  GUITION JC4880P443C  (ST7701, 800x480)            [ WORKING ]
 ; =============================================================================
 [env:esp32_4inch]
 extends     = esp32_base

--- a/web-installer/manifest-4inch.json
+++ b/web-installer/manifest-4inch.json
@@ -1,5 +1,5 @@
 {
-  "name": "SonosESP — 4\" Screen (GUITION JC4880P433C)",
+  "name": "SonosESP — 4\" Screen (GUITION JC4880P443C)",
   "version": "2.0.0",
   "new_install_prompt_erase": true,
   "builds": [


### PR DESCRIPTION
Follow-up to #150. Two independent things, one commit each.

## 1. The 4-inch part number was wrong everywhere

`JC4880P433C` → **`JC4880P443C`**. Wrong in the README, RELEASE, the hardware
guide, the multi-screen doc, the issue and PR templates, the `config.h` and
`platformio.ini` comments, and the name inside `manifest-4inch.json` that the
installer puts in front of people.

Two independent confirmations: the vendored `bb_spi_lcd` library calls the same
panel `JC4880P443`, and it's what the AliExpress listings use. **Searching the
old number does not find the board** — which is the part that actually cost
someone something, since "which one do I buy" is the first question the docs
answer.

Comments and strings only; no firmware behaviour changes.

## 2. Gold accent, the design on every page, a rebuilt installer

**Gold, not coral.** The accent is now the firmware's own values — `AMB_ACCENT
#E0B252`, `AMB_ACCENT_HI #EFC468` — lifted from `include/amber.h`, so the site
and the device are one brand instead of two. The release is called Amber and the
wordmark was already gold; the coral site was the odd one out.

Coral survives in exactly one place, as `--se-bloom-a/b` behind the hero: that
gradient is atmosphere rather than meaning, and a single-hue version reads flat.
The `warning` callout moves to burnt orange, since an amber warning would now be
the same colour as an ordinary link.

**Every page, not just the home page.** The handoff's Install and Features
artboards share one docs shell — and that shell is what VitePress already gives
you. So rather than hand-build two pages and leave the other eight mismatched,
this maps VitePress's own tokens onto the design. Every page gets it, including
the ones the handoff never drew, plus the 404 and the search modal. Tables and
admonitions had no spec at all, so they're built from the design's existing
grammar.

**Rebuilt installer**, to the artboard: numbered steps, board cards carrying the
part number and the exact `.bin` they write, hairline spec row. It also reads the
manifest and lists what it will flash — `0x2000` bootloader, `0x8000` partitions,
`0xe000` boot_app0, `0x10000` firmware. Parsed from the same file esp-web-tools
consumes, so it can't drift, and `0xe000` is the omission `deploy-pages.yml`
guards against because leaving it out gives you a board that won't boot.

**Prices**, checked Sept 2026: ~$32 for the 4-inch, ~$37 for the 7-inch, so the
page says "about $30–40 shipped" rather than the $20–30 that was assumed. The buy
link is a *search* by part number, not a listing URL — listings go dead, searches
don't — and it follows the 4″/7″ toggle.

## Three bugs found and fixed on the way

- **The docs were rendering in VitePress's stock dark, not the design's.**
  `custom.css` was imported before the default theme, and `:root` vs `.dark` is a
  specificity tie that source order decides — so every token lost to VitePress's
  own palette. Caught by grepping the built stylesheet for each `--vp-c-bg`
  declaration in order. Fixed twice over: the import now loads last, and tokens
  are declared on `:root, .dark`.
- **The nav wordmark rendered twice on every docs page.** I had put a component
  in the `nav-bar-title-before` slot — but that slot sits *inside* VitePress's own
  `<a class="title">`, which made it both an invalid anchor-in-anchor and a second
  thing capable of rendering the title. Reading `VPNavBarTitle.vue` showed the
  right answer: `siteTitle` is rendered with `v-html`, so it takes markup
  directly. The wordmark is now one line of config — no component, no `Layout`
  override, and only one renderer that can produce it.
- **The 4-inch resolution.** I first wrote `480×800`, matching how the AliExpress
  listing describes the panel; `hardware.md` and `InstallPanel` both say
  `800×480` (portrait-native, driven landscape). It follows our own docs.

## Testing

VitePress builds clean, all 13 pages render. Firmware untouched apart from one
comment — no `src/` changes.
