### PR TITLE
docs: the OTA flicker is the flash chip, not the P4

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -169,7 +169,15 @@ Credentials are saved in NVS and survive reboots and firmware updates.
 
 While firmware is written to flash, the processor's cache must be switched off. The display's image lives in external memory reached through that cache, so for those moments the panel is fed invalid data and flickers.
 
-The feature that avoids this (flash "auto-suspend") is [not supported on the ESP32-P4](https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/api-reference/peripherals/spi_flash/spi_flash_optional_feature.html) — Espressif's documentation says support "may be added in the future". It's harmless: let the update finish and the device reboots normally.
+The feature that avoids this is flash ["auto-suspend"](https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/api-reference/peripherals/spi_flash/spi_flash_optional_feature.html), which lets the cache keep running through a write. The ESP32-P4 itself supports it. The flash chip fitted to these panels does not — they ship a Boya BY25Q, and ESP-IDF's own driver for that part records suspend as unavailable. Parts from GigaDevice and a few others do support it, so this comes down to the chip soldered to your board rather than to the firmware or the processor.
+
+Your board reports its own chip in the serial log at boot:
+
+```
+[FLASH] Boya BY25Q 16MB (0x684018) - Auto-suspend: NO
+```
+
+It's harmless: let the update finish and the device reboots normally.
 
 ---
 


### PR DESCRIPTION
The troubleshooting page said flash auto-suspend is not supported on the ESP32-P4. It is. `SOC_SPI_MEM_SUPPORT_AUTO_SUSPEND` is `(1)` for esp32p4 in the IDF we already ship, and back to release/v5.4.

The block is the flash part. These panels ship a Boya BY25Q, and ESP-IDF's driver for it says so at `components/spi_flash/spi_flash_chip_boya.c:41`:

```
// flash-suspend is not supported
```

Compare `spi_flash_chip_gd.c`, which carries a real `SPI_FLASH_CHIP_CAP_SUSPEND` list.

That changes what we tell people: waiting for a platform update will not fix the flicker. The page now says so, and shows the boot log line that names each board's own chip.

Docs only.
