### PR TITLE
fix: stop URL-decoding favourite URIs before AddURIToQueue (#168)

### DIFF
--- a/src/screens/ui_settings_screens.cpp
+++ b/src/screens/ui_settings_screens.cpp
@@ -760,7 +760,22 @@ static int browsePopulate(lv_obj_t* list, int startIndex) {
             String id = String(data->id);
 
             String uri = sonos.extractXML(itemXML, "res");
-            uri = sonos.decodeHTML(uri);
+            // decodeHTMLEntities(), NOT sonos.decodeHTML(). The DIDL arrives double-
+            // escaped, so the <res> still carries &amp; after browseContent()'s pass
+            // and needs ONE more entity decode - but decodeHTML() also URL-decodes
+            // %3A -> ':', %2F -> '/', %26 -> '&' and so on, and a Sonos object id is
+            // percent-encoded BY DESIGN. Every favourite this speaker stores reads
+            //
+            //     x-rincon-cpcontainer:1006206clibraryplaylist%3Ap.8Wx63KEuV5X2rb?sid=204&flags=8300&sn=4
+            //
+            // and the id inside its r:resMD is the same "%3A" form. Rewriting the URI
+            // to "libraryplaylist:p.8Wx..." made URI and metadata name two different
+            // objects, and the player answered AddURIToQueue with HTTP 500 / UPnP 800
+            // for every Apple Music playlist. Measured against a Sonos Move
+            // (96.1-79270): same metadata, ':' -> 500/800, '%3A' -> 200, 171 tracks.
+            // Radio favourites carry the same corruption ("radio%3Ara..." -> "radio:ra...")
+            // and only kept working because SetAVTransportURI tolerates it.
+            uri = decodeHTMLEntities(uri);
 
             if (data->isContainer) {
                 if (id.startsWith("SQ:") && id.indexOf("/") < 0) {
@@ -778,7 +793,9 @@ static int browsePopulate(lv_obj_t* list, int startIndex) {
                 if (uri.length() == 0) {
                     String resMD = sonos.extractXML(itemXML, "r:resMD");
                     if (resMD.length() > 0) {
-                        resMD = sonos.decodeHTML(resMD);
+                        // Same rule as the URI above: this resMD yields a container
+                        // id and a <res> URI, both percent-encoded. Entities only.
+                        resMD = decodeHTMLEntities(resMD);
 
                         if (resMD.indexOf("<upnp:class>object.container</upnp:class>") >= 0) {
                             int idStart = resMD.indexOf("id=\"") + 4;
@@ -829,7 +846,9 @@ static int browsePopulate(lv_obj_t* list, int startIndex) {
                     // escaped form; playURI() runs encodeXML(), so it wants the decoded
                     // one. Passing the same string to both would double-escape here.
                     String resMD = sonos.extractXML(itemXML, "r:resMD");
-                    String meta  = resMD.length() ? sonos.decodeHTML(resMD) : itemXML;
+                    // Entities only - the item id in here ("100c706cradio%3Ara...") is
+                    // percent-encoded like every other Sonos object id.
+                    String meta  = resMD.length() ? decodeHTMLEntities(resMD) : itemXML;
                     Serial.printf("[BROWSE] Playing URI: %s%s\n", uri.c_str(),
                                   resMD.length() ? "  (with favourite metadata)" : "");
                     sonos.playURI(uri.c_str(), meta.c_str());


### PR DESCRIPTION
## Description

Sonos object ids are percent-encoded by design. `browsePopulate()` passed the `<res>` URI, the `r:resMD` and the metadata through `sonos.decodeHTML()`, whose URL-decode table turns `%3A` into `:`. The speaker then received a URI that no longer matched its own object id and rejected `AddURIToQueue` with HTTP 500 / UPnP 800, so Apple Music favourites never played.

Three call sites now use `decodeHTMLEntities()` (XML entities only). `decodeHTML()` is unchanged and stays in use for display titles, where URL-decoding is correct.

Radio favourites carry the same corruption (`radio%3Ara…` → `radio:ra…`) and only kept working because `SetAVTransportURI` tolerates it, where `AddURIToQueue` does not.

## Related Issue

Fixes #168

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- `browsePopulate()`: `<res>` URI decoded with `decodeHTMLEntities()` instead of `sonos.decodeHTML()`
- same for the `r:resMD` used to resolve a container id
- same for the metadata passed to `playURI()`
- a comment at the first site recording why, with the measurement below

## Testing

Measured against a Sonos Roam 2 (96.1-79270) by replaying the same SOAP call from a laptop: with `:` → HTTP 500 / UPnP 800, with `%3A` preserved → 200 and the playlist enqueued.

On the panel, Apple Music favourites loaded from the Favorites screen, with the queue length checked against the track count reported by the Apple Music web player:

| Playlist | Apple Music | Sonos queue |
|---|---|---|
| Discothèque | 17 | 17 |
| Fun | 47 | 47 |
| Réveil | 83 | 83 |
| Dodo | 92 | 92 |

(A 337-track playlist enqueues three times, but that is #169 and unrelated to this change — it reproduces identically without this patch.)

### Hardware Testing
- [x] Tested on GUITION JC4880P443C (ESP32-P4 + ESP32-C6)

### Functionality Testing
- [x] Device discovery works
- [x] Playback control works (play/pause/skip)
- [x] Volume control works
- [x] Album art loads correctly
- [x] No crashes during normal use
- [x] Tested for at least 30 minutes

### Edge Cases
- [x] Source switching — music → Sonos Radio favourite → music. TV not tested, no TV here.
- [ ] Rapid track skipping — not exercised
- [ ] WiFi reconnection — not exercised
- [ ] Memory leak check — not performed

## Memory Impact
- **Before**: RAM 41424 bytes, Flash 2457202 bytes
- **After**: RAM 41424 bytes, Flash 2457094 bytes
- **Change**: RAM unchanged, Flash −108 bytes

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] I have tested my changes on actual hardware
- [ ] I have checked for memory leaks — not performed
- [ ] CRITICAL comments for SDIO/mutex/memory — not applicable, this change touches neither
- [ ] I have verified no SDIO crashes occur with my changes — not specifically exercised beyond the 30 minutes above
